### PR TITLE
fix transaction sequence number bug caused by using JS Number

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sass-loader": "^3.0.0",
     "solar-css": "git+https://github.com/stellar/solar#master",
     "solar-stellarorg": "git+https://github.com/stellar/solar-stellarorg#master",
-    "stellar-sdk": "^0.3.2",
+    "stellar-sdk": "^0.4.0",
     "uri-templates": "^0.1.9",
     "webpack": "^1.12.2"
   }

--- a/src/components/FormComponents/MultiPicker.js
+++ b/src/components/FormComponents/MultiPicker.js
@@ -65,10 +65,9 @@ function adjustTrailingEmptyElements(values) {
   return values;
 }
 
-// Updates a value of the array at a specific inde
+// Updates a value of the array at a specific index
 function updateValueAt(values, index, newValue) {
   values = values.slice();
-  debugger;
   values[index] = newValue;
   return values;
 }

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {Account, TransactionBuilder, Operation, Asset, Memo} from 'stellar-sdk';
+import {
+  Account,
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Memo,
+  UnsignedHyper,
+} from 'stellar-sdk';
 import {PubKeyPicker} from './FormComponents/PubKeyPicker';
 import {EasySelect} from './EasySelect';
 
@@ -63,7 +70,7 @@ function buildTransaction(attributes, operations) {
   };
 
   try {
-    var account = new Account(attributes.sourceAccount, attributes.sequence - 1);
+    var account = new Account(attributes.sourceAccount, UnsignedHyper.fromString(attributes.sequence).subtract(1).toString());
 
     let opts = {};
     if (attributes.fee !== '') {


### PR DESCRIPTION
New accounts on the testnet are now created with a starting sequence number greater the native JavaScript Number max number. A new account I created on testnet had the sequence of 9048748768362496 where as the javascript max functional `Number.MAX_SAFE_INTEGER` is 9007199254740991 which is LESS than the sequence number of new accounts.

There was a bug in the laboratory and in js-stellar-base that relied on the insufficient `Number` native value in JavaScript.