### PR TITLE
Add all operation types to Transaction Builder

### DIFF
--- a/src/components/FormComponents/AmountPicker.js
+++ b/src/components/FormComponents/AmountPicker.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import PositiveIntPicker from './PositiveIntPicker';
+import PositiveNumberPicker from './PositiveNumberPicker';
 
-// AmountPicker picks a positive amount. It extends the PositiveIntPicker and
-// adds validation rules IN ADDITION to the ones already present in PositiveIntPicker.
+// AmountPicker picks a positive amount. It extends the PositiveNumberPicker and
+// adds validation rules IN ADDITION to the ones already present in PositiveNumberPicker.
 export default function AmountPicker(props) {
-  return <PositiveIntPicker
+  return <PositiveNumberPicker
     {...props}
     validator={(value) => {
       if (value.charAt(0) === '-') {

--- a/src/components/FormComponents/AmountPicker.js
+++ b/src/components/FormComponents/AmountPicker.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PositiveIntPicker from './PositiveIntPicker';
 
+// AmountPicker picks a positive amount. It extends the PositiveIntPicker and
+// adds validation rules IN ADDITION to the ones already present in PositiveIntPicker.
 export default function AmountPicker(props) {
   return <PositiveIntPicker
     {...props}

--- a/src/components/FormComponents/AssetPicker.js
+++ b/src/components/FormComponents/AssetPicker.js
@@ -33,17 +33,23 @@ export default function AssetPicker(props) {
       />
   }
 
+  let assetButtons = {
+    'native': 'native',
+    'alphanum4': 'Alphanumeric 4',
+    'alphanum12': 'Alphanumeric 12',
+  };
+
+  if (props.disableNative) {
+    delete assetButtons.native;
+  }
+
   return <div>
     <RadioButtonPicker
       value={value.type}
       onUpdate={(typeValue) => onUpdate(_.assign({}, props.value, {
         type: typeValue,
       }))}
-      items={{
-        'native': 'native',
-        'alphanum4': 'Alphanumeric 4',
-        'alphanum12': 'Alphanumeric 12',
-      }}
+      items={assetButtons}
       />
     {codePicker}
     {codePickerError}

--- a/src/components/FormComponents/BooleanPicker.js
+++ b/src/components/FormComponents/BooleanPicker.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import RadioButtonPicker from './RadioButtonPicker';
+
+export default function BooleanPicker(props) {
+  let {value, onUpdate} = props;
+
+  return <RadioButtonPicker
+    value={value}
+    onUpdate={(value) => onUpdate(value)}
+    items={{
+      'true': 'true',
+      'false': 'false',
+    }}
+    />
+}

--- a/src/components/FormComponents/ManualMultiPicker.js
+++ b/src/components/FormComponents/ManualMultiPicker.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import _ from 'lodash';
+import classNames from 'classnames';
+
+// ManualMultiPicker is a compound picker interface that displays multiple
+// instances of a Picker. It is manual in that the user uses to add or reduce
+// the amount of pickers displayed. This picker is useful for instances where
+// the number of items are more precise (like payment paths) or the picker has a
+// compound value (AssetPicker values are objects).
+
+// @param {array} props.value - Array of values. If empty or non array, then it will default to a one element array
+// @param {Picker|function} props.component - A React Picker component function to be repeated
+// @param {object|string} [props.default] - This is the default value for new elements that are added
+// @param {function} props.onUpdate - Picker callback function called when the values change.
+export default function MultiPicker(props) {
+  let {onUpdate, component} = props;
+  let values = props.value;
+  if (!_.isArray(values)) {
+    values = [props.default];
+  }
+
+  let SingleComponent = props.component;
+  return <div className="ManualMultiPicker">
+    {_.map(values, (singleValue, index) => {
+      return <div key={index} className={classNames(
+        'ManualMultiPicker__item',
+        {'ManualMultiPicker__item--last': index === values.length - 1},
+      )}>
+        <div className="ManualMultiPicker__item__infobar">
+          <span><strong>#{index + 1}</strong></span>
+          <button
+            className="s-button ManualMultiPicker__item__remove"
+            onClick={() => onUpdate(removeValueAt(values, index))}>
+            remove
+          </button>
+        </div>
+
+        <SingleComponent
+          onUpdate={(newValue) => onUpdate(updateValueAt(values, index, newValue))}
+          value={singleValue}
+        />
+      </div>
+    })}
+    <div className="ManualMultiPicker__addNew">
+      <button className="s-button" onClick={() => onUpdate(values.concat(props.default))}>
+        Add new
+      </button>
+    </div>
+  </div>
+}
+
+// Removes a item in specific area of index
+function removeValueAt(values, index) {
+  values = [].concat(values);
+  values.splice(index, 1);
+  return values;
+}
+
+// Replaces a value of the array at a specific index
+function updateValueAt(values, index, newValue) {
+  values = values.slice();
+  values[index] = newValue;
+  return values;
+}

--- a/src/components/FormComponents/MultiPicker.js
+++ b/src/components/FormComponents/MultiPicker.js
@@ -1,26 +1,28 @@
 import React from 'react';
 import _ from 'lodash';
 
-// Takes in a prop `value` that gets normalized to have one empty element at the end.
 // MultiPicker is a compound picker interface that ensures there is always
 // enough rows for the user to add more data. MultiPicker accomplishes this
 // by making sure there is only one consecutive empty picker at the end.
 //
 // An empty element is defined as null, undefined, or ''. This means that only
 // string value pickers (like PositiveIntPicker but not AssetPicker) can be
-// used inside the MultiPicker. In the future, support can be added for Pickers
-// with compound values.
-//
-// MultiPicker will also shrink the amount of pickers if there more than one
-// consecutive "empty pickers". This is so that if the user enters in many values
-// and deletes them all, there won't be an excess of extra
+// used inside the MultiPicker. For non string values with no way to empty the
+// value (such as radio buttons that can't be cleared), use ManualMultiPicker.
+
+
+// @param {array} props.value - Array of values. If empty or non array, then it
+//   will default to a one element array. The length of the array will be
+//   normalized to have one empty element at the end.
+// @param {function} props.onUpdate - Picker callback function called when the values change.
 export default function MultiPicker(props) {
   let {onUpdate, component} = props;
-  if (!_.isArray(props.value)) {
-    return <div></div>;
+  let value = props.value;
+  if (!_.isArray(value)) {
+    value = [];
   }
 
-  let normalizedValues = adjustTrailingEmptyElements(props.value);
+  let normalizedValues = adjustTrailingEmptyElements(value);
 
   let SingleComponent = props.component;
   return <div>

--- a/src/components/FormComponents/OperationTypePicker.js
+++ b/src/components/FormComponents/OperationTypePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import {operationsMap} from '../../data/operations.js';
-import RadioButtonPicker from './RadioButtonPicker';
+import SelectPicker from './SelectPicker';
 
 let operationItemMap = {};
 _.each(operationsMap, (op) => {
@@ -11,7 +11,7 @@ _.each(operationsMap, (op) => {
 export default function OperationTypePicker(props) {
   let {value, onUpdate} = props;
 
-  return <RadioButtonPicker
+  return <SelectPicker
     value={value}
     onUpdate={onUpdate}
     items={operationItemMap}

--- a/src/components/FormComponents/PositiveIntPicker.js
+++ b/src/components/FormComponents/PositiveIntPicker.js
@@ -6,9 +6,13 @@ export default function PositiveIntPicker(props) {
     {...props}
     validator={(value) => {
       if (value.charAt(0) === '-') {
-        return 'Expected a positive number.';
+        return 'Expected a positive number or zero.';
       } else if (!value.match(/^[0-9]*$/g)) {
         return 'Expected a whole number.';
+      }
+
+      if (typeof props.validator !== 'undefined') {
+        return props.validator(value);
       }
     }}
   />

--- a/src/components/FormComponents/PositiveNumberPicker.js
+++ b/src/components/FormComponents/PositiveNumberPicker.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import TextPicker from './TextPicker';
+
+export default function PositiveNumberPicker(props) {
+  return <TextPicker
+    {...props}
+    validator={(value) => {
+      if (value.charAt(0) === '-') {
+        return 'Expected a positive number.';
+      } else if (!value.match(/^[0-9]*(\.[0-9]+){0,1}$/g)) {
+        return 'Expected a positive number with a period for the decimal point.';
+      }
+    }}
+  />
+}

--- a/src/components/FormComponents/PositiveNumberPicker.js
+++ b/src/components/FormComponents/PositiveNumberPicker.js
@@ -6,9 +6,13 @@ export default function PositiveNumberPicker(props) {
     {...props}
     validator={(value) => {
       if (value.charAt(0) === '-') {
-        return 'Expected a positive number.';
+        return 'Expected a positive number or zero.';
       } else if (!value.match(/^[0-9]*(\.[0-9]+){0,1}$/g)) {
         return 'Expected a positive number with a period for the decimal point.';
+      }
+
+      if (typeof props.validator !== 'undefined') {
+        return props.validator(value);
       }
     }}
   />

--- a/src/components/FormComponents/RadioButtonPicker.js
+++ b/src/components/FormComponents/RadioButtonPicker.js
@@ -6,12 +6,13 @@ import React from 'react';
 // }
 export default function RadioButtonPicker(props) {
   let {value, onUpdate, items} = props;
+  let group = Math.random(); // Allows for tabbing and prevents radio button collisions
 
   return <div className="s-buttonGroup picker picker--radio">
     {_.map(items, (label, id) => {
       return <label className="s-buttonGroup__wrapper" key={id}>
         <input type="radio" className="s-buttonGroup__radio"
-          name={id}
+          name={group}
           onChange={onUpdate.bind(null, id)}
           value={id}
           checked={value === id} />

--- a/src/components/FormComponents/RadioButtonPicker.js
+++ b/src/components/FormComponents/RadioButtonPicker.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
-// Items is an object whose keys are id's and values are human readable labels
+// @param {object} props.items An object whose keys are the onUpdate values and
+//   object values are labels the user will see.
 // {
-//   'humanReadableLabel': 'Human Readable Label',
+//   'valueToBeStored': 'Human Readable Label',
 // }
 export default function RadioButtonPicker(props) {
   let {value, onUpdate, items} = props;

--- a/src/components/FormComponents/SelectPicker.js
+++ b/src/components/FormComponents/SelectPicker.js
@@ -7,12 +7,12 @@ import React from 'react';
 // }
 export default function SelectPicker(props) {
   let {value, onUpdate, items} = props;
-
   return <select
     className="picker picker--select"
     value={value}
     onChange={(event) => onUpdate(event.target.value)}
     >
+    <option value=""></option>
     {_.map(items, (label, id) => {
       return <option key={id} value={id}>{label}</option>
     })}

--- a/src/components/FormComponents/SelectPicker.js
+++ b/src/components/FormComponents/SelectPicker.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+// @param {object} props.items An object whose keys are the onUpdate values and
+//   object values are labels the user will see.
+// {
+//   'valueToBeStored': 'Human Readable Label',
+// }
+export default function SelectPicker(props) {
+  let {value, onUpdate, items} = props;
+
+  return <select
+    className="picker picker--select"
+    value={value}
+    onChange={(event) => onUpdate(event.target.value)}
+    >
+    {_.map(items, (label, id) => {
+      return <option key={id} value={id}>{label}</option>
+    })}
+  </select>;
+}

--- a/src/components/FormComponents/Unsigned8bitIntPicker.js
+++ b/src/components/FormComponents/Unsigned8bitIntPicker.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PositiveIntPicker from './PositiveIntPicker';
+
+export default function Unsigned8bitIntPicker(props) {
+  return <PositiveIntPicker
+    {...props}
+    validator={(value) => {
+      if (value >= 255) {
+        return 'Expected a number between 0 and 255 (inclusive).';
+      }
+    }}
+  />
+}

--- a/src/components/OperationPanes/AccountMerge.js
+++ b/src/components/OperationPanes/AccountMerge.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
+
+export default function AccountMerge(props) {
+  return [
+    <OptionsTablePair label="Destination" key="destination">
+      <PubKeyPicker
+        value={props.values['destination']}
+        onUpdate={(value) => {props.onUpdate('destination', value)}}
+        />
+    </OptionsTablePair>,
+  ];
+}

--- a/src/components/OperationPanes/AllowTrust.js
+++ b/src/components/OperationPanes/AllowTrust.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
+import TextPicker from '../FormComponents/TextPicker.js';
+import BooleanPicker from '../FormComponents/BooleanPicker.js';
+
+export default function AllowTrust(props) {
+  return [
+    <OptionsTablePair label="Trustor" key="trustor">
+      <PubKeyPicker
+        value={props.values['trustor']}
+        onUpdate={(value) => {props.onUpdate('trustor', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Asset Code" key="assetCode">
+      <TextPicker
+        value={props.values['assetCode']}
+        onUpdate={(value) => {props.onUpdate('assetCode', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Authorize" key="authorize">
+      <BooleanPicker
+        value={props.values['authorize']}
+        onUpdate={(value) => {props.onUpdate('authorize', value)}}
+        />
+    </OptionsTablePair>,
+  ];
+}

--- a/src/components/OperationPanes/ChangeTrust.js
+++ b/src/components/OperationPanes/ChangeTrust.js
@@ -12,11 +12,12 @@ export default function ChangeTrust(props) {
         onUpdate={(value) => {props.onUpdate('asset', value)}}
         />
     </OptionsTablePair>,
-    <OptionsTablePair label="Trust Limit" key="limit">
+    <OptionsTablePair label="Trust Limit" optional="true" key="limit">
       <PositiveIntPicker
         value={props.values['limit']}
-        onUpdate={(value) => {props.onUpdate('destination', value)}}
+        onUpdate={(value) => {props.onUpdate('limit', value)}}
         />
+      <p>If empty, will default to the max int64.</p>
     </OptionsTablePair>,
   ];
 }

--- a/src/components/OperationPanes/ChangeTrust.js
+++ b/src/components/OperationPanes/ChangeTrust.js
@@ -18,7 +18,7 @@ export default function ChangeTrust(props) {
         value={props.values['limit']}
         onUpdate={(value) => {props.onUpdate('limit', value)}}
         />
-      <p>If empty, will default to the max int64.</p>
+      <p className="optionsTable__pair__content__note">If empty, will default to the max int64.</p>
     </OptionsTablePair>,
   ];
 }

--- a/src/components/OperationPanes/ChangeTrust.js
+++ b/src/components/OperationPanes/ChangeTrust.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import AssetPicker from '../FormComponents/AssetPicker.js';
+import PositiveIntPicker from '../FormComponents/PositiveIntPicker.js';
+
+export default function ChangeTrust(props) {
+  return [
+    <OptionsTablePair label="Asset" key="asset">
+      <AssetPicker
+        value={props.values['asset']}
+        onUpdate={(value) => {props.onUpdate('asset', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Trust Limit" key="limit">
+      <PositiveIntPicker
+        value={props.values['limit']}
+        onUpdate={(value) => {props.onUpdate('destination', value)}}
+        />
+    </OptionsTablePair>,
+  ];
+}

--- a/src/components/OperationPanes/ChangeTrust.js
+++ b/src/components/OperationPanes/ChangeTrust.js
@@ -9,6 +9,7 @@ export default function ChangeTrust(props) {
     <OptionsTablePair label="Asset" key="asset">
       <AssetPicker
         value={props.values['asset']}
+        disableNative={true}
         onUpdate={(value) => {props.onUpdate('asset', value)}}
         />
     </OptionsTablePair>,

--- a/src/components/OperationPanes/CreateAccount.js
+++ b/src/components/OperationPanes/CreateAccount.js
@@ -5,24 +5,18 @@ import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
 import AmountPicker from '../FormComponents/AmountPicker.js';
 
 export default function CreateAccount(props) {
-  return <div>
-    <OptionsTablePair label="Destination">
+  return [
+    <OptionsTablePair label="Destination" key="destination">
       <PubKeyPicker
         value={props.values['destination']}
         onUpdate={(value) => {props.onUpdate('destination', value)}}
         />
-    </OptionsTablePair>
-    <OptionsTablePair label="Starting Balance">
+    </OptionsTablePair>,
+    <OptionsTablePair label="Starting Balance" key="startingBalance">
       <AmountPicker
         value={props.values['startingBalance']}
         onUpdate={(value) => {props.onUpdate('startingBalance', value)}}
         />
-    </OptionsTablePair>
-    <OptionsTablePair label="Source Account" optional={true}>
-      <PubKeyPicker
-        value={props.values['sourceAccount']}
-        onUpdate={(value) => {props.onUpdate('sourceAccount', value)}}
-        />
-    </OptionsTablePair>
-  </div>
+    </OptionsTablePair>,
+  ];
 }

--- a/src/components/OperationPanes/GenericOffer.js
+++ b/src/components/OperationPanes/GenericOffer.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
+import PositiveNumberPicker from '../FormComponents/PositiveNumberPicker.js';
+import AmountPicker from '../FormComponents/AmountPicker.js';
+import AssetPicker from '../FormComponents/AssetPicker.js';
+
+export default function GenericOffer(props) {
+  return [
+    <OptionsTablePair label="Selling" key="selling">
+      <AssetPicker
+        value={props.values['selling']}
+        onUpdate={(value) => {props.onUpdate('selling', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Buying" key="buying">
+      <AssetPicker
+        value={props.values['buying']}
+        onUpdate={(value) => {props.onUpdate('buying', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Amount" key="amount">
+      <AmountPicker
+        value={props.values['amount']}
+        onUpdate={(value) => {props.onUpdate('amount', value)}}
+        />
+      <p>An amount of zero will delete the offer.</p>
+    </OptionsTablePair>,
+    <OptionsTablePair label="Price" key="price">
+      <PositiveNumberPicker
+        value={props.values['price']}
+        onUpdate={(value) => {props.onUpdate('price', value)}}
+        />
+    </OptionsTablePair>,
+  ];
+}

--- a/src/components/OperationPanes/GenericOffer.js
+++ b/src/components/OperationPanes/GenericOffer.js
@@ -25,7 +25,7 @@ export default function GenericOffer(props) {
         value={props.values['amount']}
         onUpdate={(value) => {props.onUpdate('amount', value)}}
         />
-      <p>An amount of zero will delete the offer.</p>
+      <p className="optionsTable__pair__content__note">An amount of zero will delete the offer.</p>
     </OptionsTablePair>,
     <OptionsTablePair label="Price" key="price">
       <PositiveNumberPicker

--- a/src/components/OperationPanes/ManageOffer.js
+++ b/src/components/OperationPanes/ManageOffer.js
@@ -13,7 +13,7 @@ export default function ManageOffer(props) {
         value={props.values['offerId']}
         onUpdate={(value) => {props.onUpdate('offerId', value)}}
         />
-      <p>If 0, will create a new offer. Existing offer id numbers can be found using the Offers for Account endpoint.</p>
+      <p className="optionsTable__pair__content__note">If 0, will create a new offer. Existing offer id numbers can be found using the Offers for Account endpoint.</p>
     </OptionsTablePair>
   );
 }

--- a/src/components/OperationPanes/ManageOffer.js
+++ b/src/components/OperationPanes/ManageOffer.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import GenericOffer from './GenericOffer';
+import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
+import PositiveIntPicker from '../FormComponents/PositiveNumberPicker.js';
+export default function ManageOffer(props) {
+  let GenericOfferPickers = GenericOffer(props);
+  return GenericOfferPickers.concat(
+    <OptionsTablePair label="Offer ID" key="offerId">
+      <PositiveIntPicker
+        value={props.values['offerId']}
+        onUpdate={(value) => {props.onUpdate('offerId', value)}}
+        />
+      <p>If 0, will create a new offer. Existing offer id numbers can be found using the Offers for Account endpoint.</p>
+    </OptionsTablePair>
+  );
+}

--- a/src/components/OperationPanes/ManageOffer.js
+++ b/src/components/OperationPanes/ManageOffer.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-
 import OptionsTablePair from '../OptionsTable/Pair';
 import GenericOffer from './GenericOffer';
 import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
-import PositiveIntPicker from '../FormComponents/PositiveNumberPicker.js';
+import PositiveIntPicker from '../FormComponents/PositiveIntPicker.js';
+
 export default function ManageOffer(props) {
   let GenericOfferPickers = GenericOffer(props);
   return GenericOfferPickers.concat(

--- a/src/components/OperationPanes/PathPayment.js
+++ b/src/components/OperationPanes/PathPayment.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import AssetPicker from '../FormComponents/AssetPicker.js';
+import AmountPicker from '../FormComponents/AmountPicker.js';
+import PubKeyPicker from '../FormComponents/PubKeyPicker.js';
+import ManualMultiPicker from '../FormComponents/ManualMultiPicker.js';
+
+export default function PathPayment(props) {
+  return [
+    <OptionsTablePair label="Sending Asset" key="sendAsset">
+      <AssetPicker
+        value={props.values['sendAsset']}
+        onUpdate={(value) => {props.onUpdate('sendAsset', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Maximum send amount" key="sendMax">
+      <AmountPicker
+        value={props.values['sendMax']}
+        onUpdate={(value) => {props.onUpdate('sendMax', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Destination" key="destination">
+      <PubKeyPicker
+        value={props.values['destination']}
+        onUpdate={(value) => {props.onUpdate('destination', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Destination Asset" key="destAsset">
+      <AssetPicker
+        value={props.values['destAsset']}
+        onUpdate={(value) => {props.onUpdate('destAsset', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Destination Amount" key="destAmount">
+      <AmountPicker
+        value={props.values['destAmount']}
+        onUpdate={(value) => {props.onUpdate('destAmount', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Asset Path" key="path">
+      <ManualMultiPicker
+        component={AssetPicker}
+        value={props.values['path']}
+        default={{}}
+        onUpdate={(value) => {props.onUpdate('path', value)}}
+        />
+    </OptionsTablePair>,
+
+  ];
+}

--- a/src/components/OperationPanes/Payment.js
+++ b/src/components/OperationPanes/Payment.js
@@ -6,30 +6,24 @@ import AmountPicker from '../FormComponents/AmountPicker.js';
 import AssetPicker from '../FormComponents/AssetPicker.js';
 
 export default function Payment(props) {
-  return <div>
-    <OptionsTablePair label="Destination">
+  return [
+    <OptionsTablePair label="Destination" key="destination">
       <PubKeyPicker
         value={props.values['destination']}
         onUpdate={(value) => {props.onUpdate('destination', value)}}
         />
-    </OptionsTablePair>
-    <OptionsTablePair label="Asset">
+    </OptionsTablePair>,
+    <OptionsTablePair label="Asset" key="asset">
       <AssetPicker
         value={props.values['asset']}
         onUpdate={(value) => {props.onUpdate('asset', value)}}
         />
-    </OptionsTablePair>
-    <OptionsTablePair label="Amount">
+    </OptionsTablePair>,
+    <OptionsTablePair label="Amount" key="amount">
       <AmountPicker
         value={props.values['amount']}
         onUpdate={(value) => {props.onUpdate('amount', value)}}
         />
-    </OptionsTablePair>
-    <OptionsTablePair label="Source Account" optional={true}>
-      <PubKeyPicker
-        value={props.values['sourceAccount']}
-        onUpdate={(value) => {props.onUpdate('sourceAccount', value)}}
-        />
-    </OptionsTablePair>
-  </div>
+    </OptionsTablePair>,
+  ];
 }

--- a/src/components/OperationPanes/SetOptions.js
+++ b/src/components/OperationPanes/SetOptions.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import OptionsTablePair from '../OptionsTable/Pair';
+import PubKeyPicker from '../FormComponents/PubKeyPicker';
+import PositiveIntPicker from '../FormComponents/PositiveIntPicker';
+import TextPicker from '../FormComponents/TextPicker';
+import Unsigned8bitIntPicker from '../FormComponents/Unsigned8bitIntPicker';
+
+export default function SetOptions(props) {
+  return [
+    <OptionsTablePair label="Inflation Destination" optional={true} key="inflationDest">
+      <PubKeyPicker
+        value={props.values['inflationDest']}
+        onUpdate={(value) => {props.onUpdate('inflationDest', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Clear Flags" optional={true} key="clearFlags">
+      <PositiveIntPicker
+        value={props.values['clearFlags']}
+        onUpdate={(value) => {props.onUpdate('clearFlags', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Set Flags" optional={true} key="setFlags">
+      <PositiveIntPicker
+        value={props.values['setFlags']}
+        onUpdate={(value) => {props.onUpdate('setFlags', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Master Weight" optional={true} key="masterWeight">
+      <Unsigned8bitIntPicker
+        value={props.values['masterWeight']}
+        onUpdate={(value) => {props.onUpdate('masterWeight', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Low Threshold" optional={true} key="lowThreshold">
+      <Unsigned8bitIntPicker
+        value={props.values['lowThreshold']}
+        onUpdate={(value) => {props.onUpdate('lowThreshold', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Medium Threshold" optional={true} key="medThreshold">
+      <Unsigned8bitIntPicker
+        value={props.values['medThreshold']}
+        onUpdate={(value) => {props.onUpdate('medThreshold', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="High Threshold" optional={true} key="highThreshold">
+      <Unsigned8bitIntPicker
+        value={props.values['highThreshold']}
+        onUpdate={(value) => {props.onUpdate('highThreshold', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Signer Public Key" optional={true} key="signerAddress">
+      <PubKeyPicker
+        value={props.values['signerAddress']}
+        onUpdate={(value) => {props.onUpdate('signerAddress', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Signer Weight" optional={true} key="signerWeight">
+      <Unsigned8bitIntPicker
+        value={props.values['signerWeight']}
+        onUpdate={(value) => {props.onUpdate('signerWeight', value)}}
+        />
+    </OptionsTablePair>,
+    <OptionsTablePair label="Home Domain" optional={true} key="homeDomain">
+      <TextPicker
+        value={props.values['homeDomain']}
+        onUpdate={(value) => {props.onUpdate('homeDomain', value)}}
+        />
+    </OptionsTablePair>,
+  ];
+}

--- a/src/components/OperationsBuilder.js
+++ b/src/components/OperationsBuilder.js
@@ -29,17 +29,24 @@ class OperationsBuilder extends React.Component {
 let operation = (ops, index, dispatch) => {
   let op = ops[index];
   let opConfig = getOperation(op.name);
-  let operationPane;
-  let separator;
+  let operationPane, sourceAccountRow, separator;
+  let dispatchUpdateOpAtts = (key, value) => {
+    dispatch(updateOperationAttributes(op.id, {
+      [key]: value
+    }))
+  };
   if (typeof opConfig !== 'undefined') {
     operationPane = opConfig.operationPane({
-      onUpdate: (key, value) => {
-        dispatch(updateOperationAttributes(op.id, {
-          [key]: value
-        }))
-      },
+      onUpdate: dispatchUpdateOpAtts,
       values: op.attributes
     });
+
+    sourceAccountRow = <OptionsTablePair label="Source Account" optional={true} key="sourceAccount">
+      <PubKeyPicker
+        value={op.attributes['sourceAccount']}
+        onUpdate={(value) => dispatchUpdateOpAtts('sourceAccount', value)}
+        />
+    </OptionsTablePair>;
 
     separator = <hr className="optionsTable__separator" />;
   }
@@ -68,7 +75,9 @@ let operation = (ops, index, dispatch) => {
           dispatch(updateOperationType(op.id, value))
         }} />
       </OptionsTablePair>
+      {separator}
       {operationPane}
+      {sourceAccountRow}
     </div>
   </div>;
 }

--- a/src/components/TxBuilderPanes/TxAttributes.js
+++ b/src/components/TxBuilderPanes/TxAttributes.js
@@ -19,6 +19,7 @@ export default function TxAttributes(props) {
         value={props.values['sequence']}
         onUpdate={(value) => {props.onUpdate('sequence', value)}}
         />
+      <p className="optionsTable__pair__content__note">The transaction sequence number is usually one higher than current account sequence number.</p>
     </OptionsTablePair>
     <OptionsTablePair label="Transaction Fee" optional={true}>
       <StroopsPicker

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -10,6 +10,7 @@ import {
 } from 'stellar-sdk';
 import {PubKeyPicker} from './FormComponents/PubKeyPicker';
 import {EasySelect} from './EasySelect';
+import Libify from '../utilities/Libify';
 
 export default class TxBuilderResult extends React.Component {
   render() {
@@ -81,41 +82,21 @@ function buildTransaction(attributes, operations) {
 
     if (attributes.memoType !== 'MEMO_NONE') {
       try {
-        transaction = transaction.addMemo(jsLibifyMemo({
+        transaction = transaction.addMemo(Libify.Memo({
           type: attributes.memoType,
           content: attributes.memoContent,
         }));
       } catch(e) {
+        console.log(e);
         result.errors.push(`Memo: ${e.message}`);
       }
     }
 
     _.each(operations, (op, index) => {
-      if (op.name === '') {
-        result.errors.push(`Operation #${index + 1}: operation type not selected`);
-        return;
-      }
-
       try {
-        let atts = op.attributes;
-        let opOpts = {};
-
-        opOpts.destination = atts.destination;
-        opOpts.asset = jsLibifyAsset(atts.asset);
-
-        // TODO: refactor this to somehow automatically jsLibify everything
-        if (op.name === 'payment') {
-          opOpts.amount = atts.amount;
-        } else if (op.name === 'createAccount') {
-          opOpts.startingBalance = atts.startingBalance;
-        }
-
-        if (typeof atts.source !== 'undefined' && atts.source !== '') {
-          opOpts.source = atts.source;
-        }
-
-        transaction = transaction.addOperation(Operation[op.name](opOpts))
+        transaction = transaction.addOperation(Libify.Operation(op.name, op.attributes));
       } catch(e) {
+        console.error(e);
         result.errors.push(`Operation #${index + 1}: ${e.message}`);
       }
     })
@@ -123,6 +104,7 @@ function buildTransaction(attributes, operations) {
     transaction = transaction.build();
     result.xdr = transaction.toEnvelope().toXDR('base64');
   } catch(e) {
+    console.log(e);
     result.errors.push(e.message);
   }
 
@@ -133,29 +115,4 @@ function formatErrorList(errors) {
   return _.reduce(errors, (result, error) => {
     return `${result}- ${error} \n`;
   }, '');
-}
-
-function jsLibifyAsset(opts) {
-  if (typeof opts === 'undefined') {
-    return Asset.native();
-  }
-
-  if (opts.type === '' || opts.type === 'native') {
-    return Asset.native();
-  }
-
-  return new Asset(opts.code, opts.issuer);
-}
-
-function jsLibifyMemo(opts) {
-  switch(opts.type) {
-  case 'MEMO_TEXT':
-    return Memo.text(opts.content);
-  case 'MEMO_ID':
-    return Memo.id(opts.content);
-  case 'MEMO_HASH':
-    return Memo.hash(opts.content);
-  case 'MEMO_RETURN':
-    return Memo.returnHash(opts.content);
-  }
 }

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -87,7 +87,7 @@ function buildTransaction(attributes, operations) {
           content: attributes.memoContent,
         }));
       } catch(e) {
-        console.log(e);
+        console.error(e);
         result.errors.push(`Memo: ${e.message}`);
       }
     }
@@ -104,7 +104,7 @@ function buildTransaction(attributes, operations) {
     transaction = transaction.build();
     result.xdr = transaction.toEnvelope().toXDR('base64');
   } catch(e) {
-    console.log(e);
+    console.error(e);
     result.errors.push(e.message);
   }
 

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -34,6 +34,11 @@ export const operationsMap = [
     label: 'Allow Trust',
     operationPane: require('../components/OperationPanes/AllowTrust'),
   },
+  {
+    name: 'accountMerge',
+    label: 'Account Merge',
+    operationPane: require('../components/OperationPanes/AccountMerge'),
+  },
   // TODO: Other complex operations
   // {
   //   name: 'pathPayment',

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -24,6 +24,11 @@ export const operationsMap = [
     label: 'Payment',
     operationPane: require('../components/OperationPanes/Payment'),
   },
+  {
+    name: 'changeTrust',
+    label: 'Change Trust',
+    operationPane: require('../components/OperationPanes/ChangeTrust'),
+  },
   // TODO: Other complex operations
   // {
   //   name: 'pathPayment',

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -29,6 +29,11 @@ export const operationsMap = [
     label: 'Change Trust',
     operationPane: require('../components/OperationPanes/ChangeTrust'),
   },
+  {
+    name: 'allowTrust',
+    label: 'Allow Trust',
+    operationPane: require('../components/OperationPanes/AllowTrust'),
+  },
   // TODO: Other complex operations
   // {
   //   name: 'pathPayment',

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -49,6 +49,11 @@ export const operationsMap = [
     label: 'Create Passive Offer',
     operationPane: require('../components/OperationPanes/GenericOffer'),
   },
+  {
+    name: 'inflation',
+    label: 'Inflation',
+    operationPane: () => [], // empty operation pane
+  },
   // TODO: Other complex operations
   // {
   //   name: 'pathPayment',

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -39,6 +39,16 @@ export const operationsMap = [
     label: 'Account Merge',
     operationPane: require('../components/OperationPanes/AccountMerge'),
   },
+  {
+    name: 'manageOffer',
+    label: 'Manage Offer',
+    operationPane: require('../components/OperationPanes/ManageOffer'),
+  },
+  {
+    name: 'createPassiveOffer',
+    label: 'Create Passive Offer',
+    operationPane: require('../components/OperationPanes/GenericOffer'),
+  },
   // TODO: Other complex operations
   // {
   //   name: 'pathPayment',

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -25,6 +25,11 @@ export const operationsMap = [
     operationPane: require('../components/OperationPanes/Payment'),
   },
   {
+    name: 'pathPayment',
+    label: 'Path Payment',
+    operationPane: require('../components/OperationPanes/PathPayment'),
+  },
+  {
     name: 'changeTrust',
     label: 'Change Trust',
     operationPane: require('../components/OperationPanes/ChangeTrust'),
@@ -63,100 +68,9 @@ export const operationsMap = [
   //   },
   // },
   // {
-  //   name: 'manageOffer',
-  //   label: 'Manage Offer',
-  //   params: {
-  //     'buying': {
-  //       label: 'Buying Asset',
-  //       pickerType: 'Asset',
-  //     },
-  //     'selling': {
-  //       label: 'Selling Asset',
-  //       pickerType: 'Asset',
-  //     },
-  //     'amount': {
-  //       label: 'Amount',
-  //       pickerType: 'Amount',
-  //     },
-  //     'price': {
-  //       label: 'Price',
-  //       pickerType: 'Amount',
-  //     },
-  //     'offerId': {
-  //       label: 'Offer ID',
-  //       pickerType: 'Offer',
-  //       optional: true,
-  //     }
-  //   },
-  // },
-  // {
-  //   name: 'createPassiveOffer',
-  //   label: 'Create Passive Offer',
-  //   params: {
-  //     'buying': {
-  //       label: 'Buying Asset',
-  //       pickerType: 'Asset',
-  //     },
-  //     'selling': {
-  //       label: 'Selling Asset',
-  //       pickerType: 'Asset',
-  //     },
-  //     'amount': {
-  //       label: 'Amount',
-  //       pickerType: 'Amount',
-  //     },
-  //     'price': {
-  //       label: 'Price',
-  //       pickerType: 'Amount',
-  //     },
-  //   },
-  // },
-  // {
   //   name: 'setOptions',
   //   label: 'Set Options',
   //   params: {
-  //   },
-  // },
-  // {
-  //   name: 'changeTrust',
-  //   label: 'Change Trust',
-  //   params: {
-  //     'asset': {
-  //       label: 'Asset',
-  //       pickerType: 'Asset',
-  //     },
-  //     'amount': {
-  //       label: 'Trust Amount',
-  //       pickerType: 'Amount',
-  //     },
-  //   },
-  // },
-  // {
-  //   name: 'allowTrust',
-  //   label: 'Allow Trust',
-  //   params: {
-  //     'destination': {
-  //       label: 'Trustor',
-  //       pickerType: 'PubKey',
-  //     },
-  //     'asset': {
-  //       label: 'Asset',
-  //       pickerType: 'Asset',
-  //     },
-  //   },
-  // },
-  // {
-  //   name: 'accountMerge',
-  //   label: 'Account Merge',
-  //   params: {
-  //
-  //   },
-  // },
-  // {
-  //   name: 'inflation',
-  //   label: 'Inflation',
-  //   params: {
-  //
   //   },
   // },
 ]

--- a/src/data/operations.js
+++ b/src/data/operations.js
@@ -30,6 +30,11 @@ export const operationsMap = [
     operationPane: require('../components/OperationPanes/PathPayment'),
   },
   {
+    name: 'setOptions',
+    label: 'Set Options',
+    operationPane: require('../components/OperationPanes/SetOptions'),
+  },
+  {
     name: 'changeTrust',
     label: 'Change Trust',
     operationPane: require('../components/OperationPanes/ChangeTrust'),

--- a/src/styles/_ManualMultiPicker.scss
+++ b/src/styles/_ManualMultiPicker.scss
@@ -1,0 +1,29 @@
+.ManualMultiPicker {
+}
+  .ManualMultiPicker__item {
+    position: relative;
+    padding: 0 0.75em 0.75em 0.75em;
+    border-top: 1px solid $s-color-neutral7;
+    border-left: 1px solid $s-color-neutral7;
+    border-right: 1px solid $s-color-neutral7;
+  }
+  .ManualMultiPicker__item:first-child {
+    border-radius: $s-var-radius $s-var-radius 0 0;
+  }
+    .ManualMultiPicker__item--last {
+      border-bottom: 1px solid $s-color-neutral7;
+      border-radius: 0 0 $s-var-radius $s-var-radius;
+    }
+    .ManualMultiPicker__item__infobar {
+      @include S-flex-row;
+      padding: 0.5em 0;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .ManualMultiPicker__item__remove {
+      font-size: $s-scale-5;
+    }
+  .ManualMultiPicker__addNew {
+    margin-top: 0.75em;
+    font-size: $s-scale-5;
+  }

--- a/src/styles/_optionsTable.scss
+++ b/src/styles/_optionsTable.scss
@@ -41,6 +41,7 @@
     padding: 0.75em 1em;
   }
     .optionsTable__pair__content__note {
+      font-size: $s-scale-5;
       margin: 0.75em 0 0 0;
       color: $s-color-neutral3;
     }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -33,5 +33,6 @@
 @import 'simpleTable';
 
 @import 'picker';
+  @import 'ManualMultiPicker';
 
 // Unorganized stuffs below:

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -110,6 +110,14 @@ Libify.Operation.allowTrust = function(opts) {
   })
 }
 
+Libify.Operation.accountMerge = function(opts) {
+  assertNotEmpty(opts.destination, 'Allow Trust operation requires destination');
+  return Sdk.Operation.accountMerge({
+    destination: opts.destination,
+    source: opts.sourceAccount,
+  })
+}
+
 
 
 export default Libify;

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -147,4 +147,10 @@ Libify.Operation.createPassiveOffer = function(opts) {
   })
 }
 
+Libify.Operation.inflation = function(opts) {
+  return Sdk.Operation.inflation({
+    source: opts.sourceAccount,
+  })
+}
+
 export default Libify;

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -20,6 +20,18 @@ let assertNotEmpty = function(value, message) {
   }
 }
 
+// Converts a value into a boolean. String values are converted to their respective
+// boolean values since html forms can only output string values.
+let isLooseTruthy = function(value) {
+  if (value == 'true') {
+    return true;
+  }
+  if (value == 'false') {
+    return false;
+  }
+  return value == true;
+}
+
 let Libify = {};
 
 Libify.Asset = function(opts) {
@@ -85,5 +97,19 @@ Libify.Operation.changeTrust = function(opts) {
     source: opts.sourceAccount,
   })
 }
+
+Libify.Operation.allowTrust = function(opts) {
+  assertNotEmpty(opts.trustor, 'Allow Trust operation requires trustor');
+  assertNotEmpty(opts.assetCode, 'Allow Trust operation requires asset code');
+  assertNotEmpty(opts.authorize, 'Allow Trust operation requires authorization setting');
+  return Sdk.Operation.allowTrust({
+    trustor: opts.trustor,
+    assetCode: opts.assetCode,
+    authorize: isLooseTruthy(opts.authorize),
+    source: opts.sourceAccount,
+  })
+}
+
+
 
 export default Libify;

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -89,6 +89,34 @@ Libify.Operation.payment = function(opts) {
   })
 }
 
+Libify.Operation.pathPayment = function(opts) {
+  assertNotEmpty(opts.sendAsset, 'Path Payment operation requires sending asset');
+  assertNotEmpty(opts.sendMax, 'Path Payment operation requires max send');
+  assertNotEmpty(opts.destination, 'Payment operation requires destination');
+  assertNotEmpty(opts.destAsset, 'Path Payment operation requires destination asset');
+  assertNotEmpty(opts.destAmount, 'Path Payment operation requires the destination amount');
+  if (!_.isArray(opts.path) || opts.path.length < 1) {
+    throw new Error('Path Payment operation requires one or more path hops');
+  }
+
+  let libifiedPath = _.map(opts.path, (hopAsset) => {
+    if (_.isUndefined(hopAsset.type)) {
+      throw new Error('All assets in path must be filled out');
+    }
+    return Libify.Asset(hopAsset);
+  })
+
+  return Sdk.Operation.pathPayment({
+    sendAsset: Libify.Asset(opts.sendAsset),
+    sendMax: opts.sendMax,
+    destination: opts.destination,
+    destAsset: Libify.Asset(opts.destAsset),
+    destAmount: opts.destAmount,
+    path: libifiedPath,
+    source: opts.sourceAccount,
+  })
+}
+
 Libify.Operation.changeTrust = function(opts) {
   assertNotEmpty(opts.asset, 'Change Trust operation requires asset');
   return Sdk.Operation.changeTrust({

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -118,6 +118,33 @@ Libify.Operation.accountMerge = function(opts) {
   })
 }
 
+Libify.Operation.manageOffer = function(opts) {
+  assertNotEmpty(opts.selling, 'Manage Offer operation requires selling asset');
+  assertNotEmpty(opts.buying, 'Manage Offer operation requires buying asset');
+  assertNotEmpty(opts.amount, 'Manage Offer operation requires amount');
+  assertNotEmpty(opts.price, 'Manage Offer operation requires price');
+  return Sdk.Operation.manageOffer({
+    selling: Libify.Asset(opts.selling),
+    buying: Libify.Asset(opts.buying),
+    amount: opts.amount,
+    price: opts.price,
+    offerId: opts.offerId,
+    source: opts.sourceAccount,
+  })
+}
 
+Libify.Operation.createPassiveOffer = function(opts) {
+  assertNotEmpty(opts.selling, 'Create Passive Offer operation requires selling asset');
+  assertNotEmpty(opts.buying, 'Create Passive Offer operation requires buying asset');
+  assertNotEmpty(opts.amount, 'Create Passive Offer operation requires amount');
+  assertNotEmpty(opts.price, 'Create Passive Offer operation requires price');
+  return Sdk.Operation.manageOffer({
+    selling: Libify.Asset(opts.selling),
+    buying: Libify.Asset(opts.buying),
+    amount: opts.amount,
+    price: opts.price,
+    source: opts.sourceAccount,
+  })
+}
 
 export default Libify;

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -1,0 +1,89 @@
+// Libify is a utility that converts a wide variety of inputs into their stricter
+// representations in Stellar libraries such as js-stellar-base and js-stellar-sdk.
+//
+// The Libify api aims to look similar to that of js-stellar-base and sdk. It
+// will output better error messages in cases where helpful (instead of just
+// undefined error messages).
+//
+// Libify could also be used to generate source code from input.
+
+import Sdk from 'stellar-sdk';
+import _ from 'lodash';
+
+// Helpers
+let isEmpty = function(value) {
+  return _.isUndefined(value) || value === '' || value === null;
+}
+let assertNotEmpty = function(value, message) {
+  if (isEmpty(value)) {
+    throw new Error(message);
+  }
+}
+
+let Libify = {};
+
+Libify.Asset = function(opts) {
+  if (isEmpty(opts) || opts.type === 'native') {
+    return Sdk.Asset.native();
+  }
+
+  assertNotEmpty(opts.code, 'Asset requires asset code');
+  return new Sdk.Asset(opts.code, opts.issuer);
+}
+
+Libify.Memo = function(opts) {
+  switch(opts.type) {
+  case 'MEMO_TEXT':
+    return Sdk.Memo.text(opts.content);
+  case 'MEMO_ID':
+    return Sdk.Memo.id(opts.content);
+  case 'MEMO_HASH':
+    return Sdk.Memo.hash(opts.content);
+  case 'MEMO_RETURN':
+    return Sdk.Memo.returnHash(opts.content);
+  }
+}
+
+// Takes in a type and a pile of options and attempts to turn it into a valid
+// js-stellar-base operation. If not, it will throw an error.
+Libify.Operation = function(type, opts) {
+  assertNotEmpty(type, 'Operation type is required');
+  let opFunction = Libify.Operation[type];
+  if (typeof opFunction === 'undefined' || _.has(Libify.Operation, 'opFunction')) {
+    throw new Error('Unknown operation type: ' + type);
+  }
+  return opFunction(opts);
+}
+
+Libify.Operation.createAccount = function(opts) {
+  assertNotEmpty(opts.destination, 'Create Account operation requires destination');
+  assertNotEmpty(opts.startingBalance, 'Create Account operation requires starting balance');
+  return Sdk.Operation.createAccount({
+    destination: opts.destination,
+    startingBalance: opts.startingBalance,
+    source: opts.sourceAccount,
+  })
+}
+
+Libify.Operation.payment = function(opts) {
+  assertNotEmpty(opts.destination, 'Payment operation requires destination');
+  assertNotEmpty(opts.asset, 'Payment operation requires asset');
+  assertNotEmpty(opts.amount, 'Payment operation requires amount');
+  return Sdk.Operation.payment({
+    destination: opts.destination,
+    asset: Libify.Asset(opts.asset),
+    amount: opts.amount,
+    source: opts.sourceAccount,
+  })
+}
+
+Libify.Operation.changeTrust = function(opts) {
+  assertNotEmpty(opts.asset, 'Change Trust operation requires asset');
+  return Sdk.Operation.changeTrust({
+    asset: Libify.Asset(opts.asset),
+    limit: opts.limit,
+    source: opts.sourceAccount,
+  })
+}
+
+export default Libify;


### PR DESCRIPTION
This PR implements all the operation types in the Transaction Builder. It also adds a note feature so that small help messages can be placed under pickers to assist the user.

![image](https://cloud.githubusercontent.com/assets/5728307/12603370/e3a0ced6-c466-11e5-9b56-65d9a88d924e.png)
