### PR TITLE
Simple routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ npm install
 npm install
 ./node_modules/.bin/gulp build
 ```
+
+## Internal documentation
+The [docs.md](./docs.md) file contains code documentation on the laboratory. The docs.md is only relevant for developing the laboratory.

--- a/docs.md
+++ b/docs.md
@@ -1,23 +1,40 @@
 This file contains information about the laboratory itself and design choices inside.
 
-## Simple Router
+# Simple Router
 The laboratory uses a simple routing system with no outside dependencies. The simple router is stateless. Components do not need to know about the router since everything is handled.
 
-### Dataflow: Two possible events
-#### Outbound changes: Changes from updated redux store
+## Dataflow: Two possible events
+### Outbound changes: Changes from updated redux store
 When the redux state changes, we can then serialize it and save it in the url. This is handled by a middleware called `routerMiddleware`.
 
 This is reactive and won't change the redux store.
 
-#### Inbound changes: Changes from url hash updates
+#### Triggers
+1. An action happened (LOAD_STATE actions are ignored).
+
+### Inbound changes: Changes from url hash updates
 The a component uses the `routerListener` to provide access to dispatching actions. It will perform a diff to see if an the store needs to be updated. If so, it will dispatch an event.
 
 If save data is not specified, the redux store should not be cleared.
 
-### User navigation via clicks on plain hash links
+#### Two results:
+1. Load the state from the query string and navigate
+2. Only navigate. Don't load state
+
+#### Triggers
+1. Page initially loads: Result 1
+2. Hash change with query present: Result 1
+3. Hash change with empty query: Result 2
+
+## User navigation via clicks on plain hash links
 User navigation should always occur through hash links. This is so that users can open links in new tabs as well as right clicking to copy the link.
 
 Although these events are user initiated, these are considered "inbound" changes since it is changing the hash which is outside of redux.
 
-### Routing actions and reducer
+## Routing actions and reducer
 The only code creating actions for routing.js should be the routerListener.
+
+## Store Serializer
+The store serializer serializes and deserializes specific parts of a branch in the reducer.
+
+It is optional in that if a feature was implemented in just the reducer, it can work without needing a store serializer implemented. Without the store serializer implemented, the url hash state params will be empty.

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,23 @@
+This file contains information about the laboratory itself and design choices inside.
+
+## Simple Router
+The laboratory uses a simple routing system with no outside dependencies. The simple router is stateless. Components do not need to know about the router since everything is handled.
+
+### Dataflow: Two possible events
+#### Outbound changes: Changes from updated redux store
+When the redux state changes, we can then serialize it and save it in the url. This is handled by a middleware called `routerMiddleware`.
+
+This is reactive and won't change the redux store.
+
+#### Inbound changes: Changes from url hash updates
+The a component uses the `routerListener` to provide access to dispatching actions. It will perform a diff to see if an the store needs to be updated. If so, it will dispatch an event.
+
+If save data is not specified, the redux store should not be cleared.
+
+### User navigation via clicks on plain hash links
+User navigation should always occur through hash links. This is so that users can open links in new tabs as well as right clicking to copy the link.
+
+Although these events are user initiated, these are considered "inbound" changes since it is changing the hash which is outside of redux.
+
+### Routing actions and reducer
+The only code creating actions for routing.js should be the routerListener.

--- a/src/actions/routing.js
+++ b/src/actions/routing.js
@@ -5,3 +5,12 @@ export function updateLocation(location) {
     location
   }
 }
+
+export const LOAD_STATE = "LOAD_STATE";
+export function loadState(slug, payload) {
+  return {
+    type: LOAD_STATE,
+    slug,
+    payload
+  }
+}

--- a/src/actions/routing.js
+++ b/src/actions/routing.js
@@ -1,8 +1,8 @@
 export const UPDATE_LOCATION = "UPDATE_LOCATION";
-export function updateLocation(location) {
+export function updateLocation(slug) {
   return {
     type: UPDATE_LOCATION,
-    location
+    slug
   }
 }
 

--- a/src/actions/routing.js
+++ b/src/actions/routing.js
@@ -1,0 +1,7 @@
+export const UPDATE_LOCATION = "UPDATE_LOCATION";
+export function updateLocation(location) {
+  return {
+    type: UPDATE_LOCATION,
+    location
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,8 @@ import thunk from 'redux-thunk';
 import {Provider} from 'react-redux';
 
 import rootReducer from './reducers/root';
-import logging from "./middleware/logging";
+import logging from './middleware/logging';
+import {routerMiddleware} from './utilities/simpleRouter';
 import LaboratoryChrome from './components/LaboratoryChrome';
 
 
@@ -17,6 +18,7 @@ document.write('<div id="app"></div>');
 
 let createStoreWithMiddleware = applyMiddleware(
   thunk,
+  routerMiddleware,
   logging
 )(createStore);
 

--- a/src/components/FormComponents/MemoPicker.js
+++ b/src/components/FormComponents/MemoPicker.js
@@ -6,25 +6,26 @@ import PickerError from './PickerError';
 import {UnsignedHyper} from 'stellar-sdk';
 
 export default function MemoPicker(props) {
-  let {value, onUpdate} = props;
+  let {onUpdate} = props;
   let contentPicker;
-  let normalizedValue = (value.type === '') ? 'MEMO_NONE' : value.type;
+  let normalizedValue = _.assign({}, props.value);
+  normalizedValue.type = (props.value.type === '') ? 'MEMO_NONE' : props.value.type;
 
-  if (normalizedValue !== 'MEMO_NONE') {
+  if (normalizedValue.type !== 'MEMO_NONE') {
     contentPicker = <TextPicker
-      value={value.content}
-      onUpdate={(contentValue) => onUpdate(_.assign({}, props.value, {
+      value={normalizedValue.content}
+      onUpdate={(contentValue) => onUpdate(_.assign({}, normalizedValue, {
         content: contentValue,
       }))}
-      placeholder={memoPlaceholder(normalizedValue)}
-      validator={contentValidator.bind(null, value)} // Use entire Memo value and not just the content value
+      placeholder={memoPlaceholder(normalizedValue.type)}
+      validator={contentValidator.bind(null, normalizedValue)} // Use entire Memo value and not just the content value
     />;
   }
 
   return <div>
     <RadioButtonPicker
-      value={normalizedValue}
-      onUpdate={(typeValue) => onUpdate(_.assign({}, props.value, {
+      value={normalizedValue.type}
+      onUpdate={(typeValue) => onUpdate(_.assign({}, normalizedValue, {
         type: typeValue,
       }))}
       items={{

--- a/src/components/FormComponents/MemoPicker.js
+++ b/src/components/FormComponents/MemoPicker.js
@@ -8,21 +8,22 @@ import {UnsignedHyper} from 'stellar-sdk';
 export default function MemoPicker(props) {
   let {value, onUpdate} = props;
   let contentPicker;
+  let normalizedValue = (value.type === '') ? 'MEMO_NONE' : value.type;
 
-  if (value.type !== 'MEMO_NONE') {
+  if (normalizedValue !== 'MEMO_NONE') {
     contentPicker = <TextPicker
       value={value.content}
       onUpdate={(contentValue) => onUpdate(_.assign({}, props.value, {
         content: contentValue,
       }))}
-      placeholder={memoPlaceholder(value.type)}
+      placeholder={memoPlaceholder(normalizedValue)}
       validator={contentValidator.bind(null, value)} // Use entire Memo value and not just the content value
     />;
   }
 
   return <div>
     <RadioButtonPicker
-      value={value.type}
+      value={normalizedValue}
       onUpdate={(typeValue) => onUpdate(_.assign({}, props.value, {
         type: typeValue,
       }))}

--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -5,6 +5,7 @@ import NetworkPicker from './NetworkPicker';
 import EndpointExplorer from './EndpointExplorer';
 import TransactionBuilder from './TransactionBuilder';
 import TransactionSigner from './TransactionSigner';
+import {RouterListener} from '../utilities/simpleRouter';
 
 let LaboratoryChrome = React.createClass({
   getInitialState: function() {
@@ -68,6 +69,7 @@ let LaboratoryChrome = React.createClass({
       </div>
 
       {activeTab}
+      <RouterListener />
     </div>;
   }
 });

--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -7,74 +7,72 @@ import TransactionBuilder from './TransactionBuilder';
 import TransactionSigner from './TransactionSigner';
 import {RouterListener} from '../utilities/simpleRouter';
 
-let LaboratoryChrome = React.createClass({
-  getInitialState: function() {
-    return {
-      tab: 'EndpointExplorer'
-    };
-  },
-  setTab: function(tab) {
-    this.setState({tab})
-  },
-  render: function() {
-    let activeTab;
-    switch (this.state.tab) {
-      case 'EndpointExplorer':
-        activeTab = <EndpointExplorer />;
-        break;
-      case 'TransactionBuilder':
-        activeTab = <TransactionBuilder />;
-        break;
-      case 'TransactionSigner':
-        activeTab = <TransactionSigner />;
-        break;
-      default:
-        throw new Error(`Invalid tab: ${this.state.tab}`);
-    }
-
-    let defaultClasses = 'buttonList__item s-button s-button__min';
-
-    let tabItem = (name, key) => {
-      return <a
-        onClick={() => {this.setTab(key)}}
-        className={classNames(
-          'buttonList__item s-button s-button__min',
-          {'is-active': this.state.tab === key})}
-        key={key}>
-        {name}
-      </a>
-    }
-
-    return <div>
-      <div className="so-back">
-        <div className="so-chunk">
-          <div className="so-siteHeader LaboratoryChrome__header">
-            <span className="so-logo">
-              <a href="https://www.stellar.org/" className="so-logo__main">Stellar</a>
-              <span className="so-logo__separator"> </span>
-              <a href="https://www.stellar.org/laboratory/" className="so-logo__subSite">laboratory</a>
-            </span>
-            <NetworkPicker />
-          </div>
-        </div>
-      </div>
-      <div className="so-back LaboratoryChrome__siteNavBack">
-        <div className="so-chunk">
-          <nav className="s-buttonList">
-            {tabItem('Endpoint Explorer', 'EndpointExplorer')}
-            {tabItem('Transaction Builder', 'TransactionBuilder')}
-            {tabItem('Transaction Signer', 'TransactionSigner')}
-          </nav>
-        </div>
-      </div>
-
-      {activeTab}
-      <RouterListener />
-    </div>;
+function LaboratoryChrome(props) {
+  let tabItem = (name, slug) => {
+    return <a
+      href={'#' + slug}
+      className={classNames(
+        'buttonList__item s-button s-button__min',
+        {'is-active': props.routing.location === slug})}
+      key={slug}>
+      {name}
+    </a>
   }
-});
+
+  return <div>
+    <div className="so-back">
+      <div className="so-chunk">
+        <div className="so-siteHeader LaboratoryChrome__header">
+          <span className="so-logo">
+            <a href="https://www.stellar.org/" className="so-logo__main">Stellar</a>
+            <span className="so-logo__separator"> </span>
+            <a href="https://www.stellar.org/laboratory/" className="so-logo__subSite">laboratory</a>
+          </span>
+          <NetworkPicker />
+        </div>
+      </div>
+    </div>
+    <div className="so-back LaboratoryChrome__siteNavBack">
+      <div className="so-chunk">
+        <nav className="s-buttonList">
+          {tabItem('Endpoint Explorer', 'endpoints')}
+          {tabItem('Transaction Builder', 'txbuilder')}
+          {tabItem('Transaction Signer', 'txsigner')}
+        </nav>
+      </div>
+    </div>
+
+    {getContent(props.routing.location)}
+    <RouterListener />
+  </div>;
+}
+
+function getContent(slug) {
+  switch (slug) {
+    case '':
+      return <SimplePage><p>To begin, select a tool from above.</p></SimplePage>
+    case 'endpoints':
+      return <EndpointExplorer />;
+    case 'txbuilder':
+      return <TransactionBuilder />;
+    case 'txsigner':
+      return <TransactionSigner />;
+    default:
+      return <SimplePage><p>Page "{slug}" not found</p></SimplePage>
+  }
+}
+
+function SimplePage(props) {
+  return <div className="so-back SimplePage__back">
+    <div className="so-chunk">
+      {props.children}
+    </div>
+  </div>
+}
 
 export default connect(chooseState)(LaboratoryChrome);
 function chooseState(state) {
-  return {}
+  return {
+    routing: state.routing
+  }
 }

--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -35,7 +35,7 @@ function LaboratoryChrome(props) {
     <div className="so-back LaboratoryChrome__siteNavBack">
       <div className="so-chunk">
         <nav className="s-buttonList">
-          {tabItem('Endpoint Explorer', 'endpoints')}
+          {tabItem('Endpoint Explorer', 'explorer')}
           {tabItem('Transaction Builder', 'txbuilder')}
           {tabItem('Transaction Signer', 'txsigner')}
         </nav>
@@ -51,7 +51,7 @@ function getContent(slug) {
   switch (slug) {
     case '':
       return <SimplePage><p>To begin, select a tool from above.</p></SimplePage>
-    case 'endpoints':
+    case 'explorer':
       return <EndpointExplorer />;
     case 'txbuilder':
       return <TransactionBuilder />;

--- a/src/components/OperationsBuilder.js
+++ b/src/components/OperationsBuilder.js
@@ -62,7 +62,7 @@ let operation = (ops, index, dispatch) => {
     <div className="TransactionOp__meta TransactionOpMeta">
       <div className="TransactionOpMeta__order">
         <BlurNumberInput
-          value={index + 1}
+          value={Number(index) + 1}
           onUpdate={(value) => dispatch(reorderOperation(op.id, value))}
           maxLength="2"
           className="TransactionOpMeta__order__input" />

--- a/src/components/TransactionImporter.js
+++ b/src/components/TransactionImporter.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Transaction} from 'stellar-sdk';
 import classNames from 'classnames';
 import _ from 'lodash';
+import validateTxXdr from '../utilities/validateTxXdr';
 
 // TransactionImporter will call the onImport passed to it's props when the user
 // presses the import button and the input is valid
@@ -19,14 +19,14 @@ export default class TransactionImporter extends React.Component {
     })
   }
   triggerImport() {
-    if (validateXdr(this.state.input).result === 'success') {
+    if (validateTxXdr(this.state.input).result === 'success') {
       this.props.onImport(this.state.input);
     }
   }
   render() {
     let validation, message, submitEnabled;
 
-    validation = validateXdr(this.state.input);
+    validation = validateTxXdr(this.state.input);
     if (validation.result === 'error') {
       message = <p className="TransactionImporter__message__alert">{validation.message}</p>
     } else if (validation.result === 'success') {
@@ -56,31 +56,3 @@ export default class TransactionImporter extends React.Component {
 TransactionImporter.propTypes = {
   'onImport': React.PropTypes.func.isRequired,
 };
-
-function validateXdr(input) {
-  input = _.trim(input);
-
-  if (input === '') {
-    return {
-      result: 'empty',
-    };
-  }
-  if (input.match(/^[-A-Za-z0-9+\/=]*$/) === null) {
-    return {
-      result: 'error',
-      message: 'The input is not valid base64 (a-zA-Z0-9+/=).'
-    };
-  }
-  try {
-    new Transaction(input);
-    return {
-      result: 'success',
-      message: 'Valid Transaction Envelope XDR',
-    }
-  } catch (e) {
-    return {
-      result: 'error',
-      message: 'Unable to parse input XDR into Transaction Envelope',
-    };
-  }
-}

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -24,7 +24,8 @@ export default class TxBuilderResult extends React.Component {
     if (attributes.sequence === '') {
       validationErrors.push('Sequence number is a required field');
     }
-    if (attributes.memoType !== 'MEMO_NONE' && attributes.memoContent === '') {
+    let memoIsNone = attributes.memoType === 'MEMO_NONE' || attributes.memoType === '';
+    if (!memoIsNone && attributes.memoContent === '') {
       validationErrors.push('Memo content is required if memo type is selected');
     }
 

--- a/src/reducers/endpointExplorer.js
+++ b/src/reducers/endpointExplorer.js
@@ -6,6 +6,7 @@ import {
   FINISH_REQUEST,
   UPDATE_VALUE,
 } from "../actions/endpointExplorer";
+import {LOAD_STATE} from '../actions/routing';
 import {getEndpoint, getTemplate} from '../data/endpoints';
 
 const endpointExplorer = combineReducers({
@@ -23,20 +24,28 @@ export default endpointExplorer
 
 function currentResource(state="", action) {
   switch (action.type) {
+    case LOAD_STATE:
+      if (action.slug === 'endpoints' && action.payload.resource) {
+        return action.payload.resource;
+      }
+      break;
     case CHOOSE_ENDPOINT:
       return action.resource;
-    default:
-      return state;
   }
+  return state;
 }
 
 function currentEndpoint(state="", action) {
   switch (action.type) {
+  case LOAD_STATE:
+    if (action.slug === 'endpoints' && action.payload.endpoint) {
+      return action.payload.endpoint;
+    }
+    break;
   case CHOOSE_ENDPOINT:
     return action.endpoint;
-  default:
-    return state;
   }
+  return state;
 }
 
 function identity(initial) {
@@ -54,15 +63,19 @@ function pendingRequestTemplate(state="", action) {
 
 function pendingRequestValues(state={}, action) {
   switch (action.type) {
+  case LOAD_STATE:
+  if (action.slug === 'endpoints' && action.payload.values) {
+    return action.payload.values;
+  }
+  break;
   case UPDATE_VALUE:
     return Object.assign({}, state, {
       [action.param]: action.value
     });
   case CHOOSE_ENDPOINT:
     return {};
-  default:
-    return state;
   }
+  return state;
 }
 
 function currentRequest(state={isLoading: false}, action) {

--- a/src/reducers/endpointExplorer.js
+++ b/src/reducers/endpointExplorer.js
@@ -25,7 +25,7 @@ export default endpointExplorer
 function currentResource(state="", action) {
   switch (action.type) {
     case LOAD_STATE:
-      if (action.slug === 'endpoints' && action.payload.resource) {
+      if (action.slug === 'explorer' && action.payload.resource) {
         return action.payload.resource;
       }
       break;
@@ -38,7 +38,7 @@ function currentResource(state="", action) {
 function currentEndpoint(state="", action) {
   switch (action.type) {
   case LOAD_STATE:
-    if (action.slug === 'endpoints' && action.payload.endpoint) {
+    if (action.slug === 'explorer' && action.payload.endpoint) {
       return action.payload.endpoint;
     }
     break;
@@ -64,7 +64,7 @@ function pendingRequestTemplate(state="", action) {
 function pendingRequestValues(state={}, action) {
   switch (action.type) {
   case LOAD_STATE:
-  if (action.slug === 'endpoints' && action.payload.values) {
+  if (action.slug === 'explorer' && action.payload.values) {
     return action.payload.values;
   }
   break;

--- a/src/reducers/root.js
+++ b/src/reducers/root.js
@@ -3,12 +3,14 @@ import endpointExplorer from './endpointExplorer';
 import transactionBuilder from './transactionBuilder';
 import transactionSigner from './transactionSigner';
 import network from './network';
+import routing from './routing';
 
 const rootReducer = combineReducers({
   endpointExplorer,
   transactionBuilder,
   transactionSigner,
   network,
+  routing,
 });
 
 export default rootReducer;

--- a/src/reducers/routing.js
+++ b/src/reducers/routing.js
@@ -1,0 +1,20 @@
+import {combineReducers} from 'redux';
+import {UPDATE_LOCATION} from '../actions/routing';
+import url from 'url';
+
+const routing = combineReducers({
+  location,
+});
+
+export default routing;
+
+function location(state, action) {
+  if (typeof state === 'undefined') {
+    // During first load, we want to reduce FOUC by bootstrapping here
+    return url.parse(window.location.hash.substr(1)).pathname || '';
+  }
+  if (action.type === UPDATE_LOCATION) {
+    return action.location;
+  }
+  return state;
+}

--- a/src/reducers/routing.js
+++ b/src/reducers/routing.js
@@ -8,11 +8,7 @@ const routing = combineReducers({
 
 export default routing;
 
-function location(state, action) {
-  if (typeof state === 'undefined') {
-    // During first load, we want to reduce FOUC by bootstrapping here
-    return url.parse(window.location.hash.substr(1)).pathname || '';
-  }
+function location(state = '', action) {
   if (action.type === UPDATE_LOCATION) {
     return action.location;
   }

--- a/src/reducers/routing.js
+++ b/src/reducers/routing.js
@@ -1,5 +1,5 @@
 import {combineReducers} from 'redux';
-import {UPDATE_LOCATION} from '../actions/routing';
+import {UPDATE_LOCATION, LOAD_STATE} from '../actions/routing';
 import url from 'url';
 
 const routing = combineReducers({
@@ -9,8 +9,10 @@ const routing = combineReducers({
 export default routing;
 
 function location(state = '', action) {
-  if (action.type === UPDATE_LOCATION) {
-    return action.location;
+  switch(action.type) {
+  case UPDATE_LOCATION:
+  case LOAD_STATE:
+    return action.slug;
   }
   return state;
 }

--- a/src/reducers/routing.js
+++ b/src/reducers/routing.js
@@ -12,6 +12,9 @@ function location(state = '', action) {
   switch(action.type) {
   case UPDATE_LOCATION:
   case LOAD_STATE:
+    if (action.slug === null) {
+      return '';
+    }
     return action.slug;
   }
   return state;

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -5,6 +5,7 @@ import {
   FETCH_SEQUENCE_SUCCESS,
   FETCH_SEQUENCE_FAIL,
 } from '../actions/transactionBuilder';
+import {LOAD_STATE} from '../actions/routing';
 import _ from 'lodash';
 
 const defaultOperations = [{
@@ -19,6 +20,11 @@ function operations(state, action) {
 
   let targetOpIndex, newOps;
   switch (action.type) {
+  case LOAD_STATE:
+  if (action.slug === 'txbuilder' && action.payload.operations) {
+    return action.payload.operations;
+  }
+  break;
   case 'ADD_OPERATION':
     return Array.prototype.concat(state, {
       id: action.opId,
@@ -79,6 +85,11 @@ function attributes(state, action) {
   }
 
   switch(action.type) {
+  case LOAD_STATE:
+  if (action.slug === 'txbuilder' && action.payload.attributes) {
+    return action.payload.attributes;
+  }
+  break;
   case UPDATE_ATTRIBUTES:
     return Object.assign({}, state, action.newAttributes);
   case FETCH_SEQUENCE_SUCCESS:

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -21,8 +21,11 @@ function operations(state, action) {
   let targetOpIndex, newOps;
   switch (action.type) {
   case LOAD_STATE:
-    if (action.slug === 'txbuilder' && action.payload.operations) {
-      return action.payload.operations;
+    if (action.slug === 'txbuilder') {
+      if (action.payload.operations) {
+        return action.payload.operations;
+      }
+      return defaultOperations;
     }
     break;
   case 'ADD_OPERATION':
@@ -85,8 +88,8 @@ function attributes(state, action) {
 
   switch(action.type) {
   case LOAD_STATE:
-    if (action.slug === 'txbuilder' && action.payload.attributes) {
-      return action.payload.attributes;
+    if (action.payload.attributes) {
+      return _.assign({}, defaultAttributes, action.payload.attributes);
     }
     break;
   case UPDATE_ATTRIBUTES:

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -75,7 +75,7 @@ const defaultAttributes = {
   sourceAccount: '',
   sequence: '',
   fee: '',
-  memoType: 'MEMO_NONE',
+  memoType: '',
   memoContent: '',
 };
 function attributes(state, action) {

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -21,10 +21,10 @@ function operations(state, action) {
   let targetOpIndex, newOps;
   switch (action.type) {
   case LOAD_STATE:
-  if (action.slug === 'txbuilder' && action.payload.operations) {
-    return action.payload.operations;
-  }
-  break;
+    if (action.slug === 'txbuilder' && action.payload.operations) {
+      return action.payload.operations;
+    }
+    break;
   case 'ADD_OPERATION':
     return Array.prototype.concat(state, {
       id: action.opId,
@@ -44,9 +44,8 @@ function operations(state, action) {
     return updateOperation(state, action.opId, {
       attributes: _.assign({}, getAttributes(state, action.opId), action.newAttributes),
     });
-  default:
-    return state;
   }
+  return state;
 }
 function getAttributes(state, opId) {
   return _.find(state, { id: opId }).attributes;
@@ -86,17 +85,16 @@ function attributes(state, action) {
 
   switch(action.type) {
   case LOAD_STATE:
-  if (action.slug === 'txbuilder' && action.payload.attributes) {
-    return action.payload.attributes;
-  }
-  break;
+    if (action.slug === 'txbuilder' && action.payload.attributes) {
+      return action.payload.attributes;
+    }
+    break;
   case UPDATE_ATTRIBUTES:
     return Object.assign({}, state, action.newAttributes);
   case FETCH_SEQUENCE_SUCCESS:
     return Object.assign({}, state, { sequence: action.sequence });
-  default:
-    return state;
   }
+  return state;
 }
 
 function sequenceFetcherError(state = '', action) {

--- a/src/reducers/transactionSigner.js
+++ b/src/reducers/transactionSigner.js
@@ -4,6 +4,8 @@ import {
   CLEAR_TRANSACTION,
   SET_SECRETS,
 } from '../actions/transactionSigner';
+import {LOAD_STATE} from '../actions/routing';
+import validateTxXdr from '../utilities/validateTxXdr';
 import _ from 'lodash';
 
 const transactionSigner = combineReducers({
@@ -18,6 +20,19 @@ function tx(state = {
   loaded: false,
 }, action) {
   switch (action.type) {
+  case LOAD_STATE:
+    if (action.slug === 'txsigner' && action.payload.xdr &&
+        validateTxXdr(action.payload.xdr).result === 'success') {
+      return {
+        xdr: action.payload.xdr,
+        loaded: true,
+      }
+    }
+    // If invalid xdr in the url, then we go back to step zero
+    return {
+      xdr: '',
+      loaded: false,
+    };
   case IMPORT_FROM_XDR:
     return {
       xdr: action.xdr,

--- a/src/styles/_SimplePage.scss
+++ b/src/styles/_SimplePage.scss
@@ -1,0 +1,4 @@
+.SimplePage__back {
+  padding-top: 2em;
+  padding-bottom: 2em;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -13,7 +13,7 @@
   @import 'EndpointSetup';
   @import 'EndpointResult';
 
-
+@import 'SimplePage';
 
 @import 'TransactionBuilder';
 

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -64,6 +64,7 @@ Libify.Asset = function(opts) {
 
 Libify.Memo = function(opts) {
   switch(opts.type) {
+  case '':
   case 'MEMO_TEXT':
     return Sdk.Memo.text(opts.content);
   case 'MEMO_ID':

--- a/src/utilities/hydration.js
+++ b/src/utilities/hydration.js
@@ -1,0 +1,7 @@
+export const hydrate = function(obj) {
+  return new Buffer(obj, 'base64').toString();
+}
+
+export const dehydrate = function(obj) {
+  return new Buffer(JSON.stringify(obj)).toString('base64');
+}

--- a/src/utilities/hydration.js
+++ b/src/utilities/hydration.js
@@ -1,5 +1,11 @@
-export const hydrate = function(obj) {
-  return new Buffer(obj, 'base64').toString();
+export const rehydrate = function(obj) {
+  try {
+    return JSON.parse(new Buffer(obj, 'base64').toString());
+  } catch (e) {
+    alert('Unable to parse values passed in url query parameters');
+    console.error(e);
+    return {}
+  }
 }
 
 export const dehydrate = function(obj) {

--- a/src/utilities/simpleRouter.js
+++ b/src/utilities/simpleRouter.js
@@ -2,18 +2,25 @@ import {connect} from 'react-redux';
 import React from 'react';
 import url from 'url';
 import querystring from 'querystring';
-import {updateLocation, loadState} from '../actions/routing';
+import {updateLocation, loadState, LOAD_STATE} from '../actions/routing';
 import {serializeStore, deserializeQueryObj} from './storeSerializer';
 
 export const routerMiddleware = store => next => action => {
   let result = next(action);
   let state = store.getState();
 
+  if (action.type === LOAD_STATE) {
+    return result;
+  }
+
   let newUrlObj = parseUrlHash(window.location.hash);
   newUrlObj.query = serializeStore(state.routing.location, state);
   delete newUrlObj.search;
 
-  window.location.hash = '#' + url.format(newUrlObj);
+  // NOTE: We only replace state here since these are only for general state
+  // changes. By using history.replaceState, the routerListener won't pick up
+  // on these changes.
+  history.replaceState(null, null, '#' + url.format(newUrlObj));
   return result;
 }
 

--- a/src/utilities/simpleRouter.js
+++ b/src/utilities/simpleRouter.js
@@ -2,9 +2,10 @@ import {connect} from 'react-redux';
 import React from 'react';
 import url from 'url';
 import querystring from 'querystring';
-import {updateLocation, loadState, LOAD_STATE} from '../actions/routing';
+import {updateLocation, loadState, LOAD_STATE, UPDATE_LOCATION} from '../actions/routing';
 import {serializeStore, deserializeQueryObj} from './storeSerializer';
 
+// One way data flow for routerMiddleware: redux -> url
 export const routerMiddleware = store => next => action => {
   let result = next(action);
   let state = store.getState();
@@ -24,6 +25,7 @@ export const routerMiddleware = store => next => action => {
   return result;
 }
 
+// One way data flow for RouterListener: url change -> redux
 class RouterHashListener extends React.Component {
     componentWillMount() {
     window.addEventListener('hashchange', this.hashChangeHandler.bind(this), false);
@@ -32,10 +34,15 @@ class RouterHashListener extends React.Component {
     // Just doing our duty of cleanup though it's really not necessary
     window.removeEventListener('hashchange', this.hashChangeHandler.bind(this), false);
   }
+  componentDidMount() {
+    this.changeProcessor(parseUrlHash(window.location.hash), {})
+  }
   hashChangeHandler(e) {
-    let oldUrl = parseUrlHash(e.oldURL);
-    let newUrl = parseUrlHash(e.newURL);
-
+    this.changeProcessor(parseUrlHash(e.newURL), parseUrlHash(e.oldURL))
+  }
+  // @param {UrlObj|object} newUrl - URL object (of the hash) from node `url`
+  // @param {UrlObj|object} oldUrl - URL object (of the hash) from node `url`. Can be empty object
+  changeProcessor(newUrl, oldUrl) {
     if (oldUrl.pathname !== newUrl.pathname) {
       this.props.dispatch(updateLocation(newUrl.pathname));
     }

--- a/src/utilities/simpleRouter.js
+++ b/src/utilities/simpleRouter.js
@@ -1,0 +1,40 @@
+import {connect} from 'react-redux';
+import React from 'react';
+import url from 'url';
+import {updateLocation} from '../actions/routing';
+
+export const routerMiddleware = store => next => action => {
+  return next(action);
+}
+
+class RouterHashListener extends React.Component {
+    componentWillMount() {
+    window.addEventListener('hashchange', this.hashChangeHandler.bind(this), false);
+  }
+  componentWillUnmount() {
+    // Just doing our duty of cleanup though it's really not necessary
+    window.removeEventListener('hashchange', this.hashChangeHandler.bind(this), false);
+  }
+  hashChangeHandler(e) {
+    let oldUrlHash = url.parse(e.oldURL).hash || '';
+    let newUrlHash = url.parse(e.newURL).hash || '';
+
+    // The "real" url is inside the hash;
+    let oldUrl = url.parse(oldUrlHash.substr(1));
+    let newUrl = url.parse(newUrlHash.substr(1));
+
+    if (oldUrl.pathname !== newUrl.pathname) {
+      this.props.dispatch(updateLocation(newUrl.pathname));
+    }
+  }
+  render() {
+    return null;
+  }
+}
+
+export let RouterListener = connect(chooseState, dispatch => ({ dispatch }))((RouterHashListener));
+function chooseState(state) {
+  return {
+    routing: state.routing
+  };
+}

--- a/src/utilities/simpleRouter.js
+++ b/src/utilities/simpleRouter.js
@@ -43,7 +43,9 @@ class RouterHashListener extends React.Component {
   // @param {UrlObj|object} newUrl - URL object (of the hash) from node `url`
   // @param {UrlObj|object} oldUrl - URL object (of the hash) from node `url`. Can be empty object
   changeProcessor(newUrl, oldUrl) {
-    if (oldUrl.pathname !== newUrl.pathname) {
+    let pathnameChanged = oldUrl.pathname !== newUrl.pathname;
+    let queryChanged = oldUrl.query !== newUrl.query;
+    if (pathnameChanged || queryChanged) {
       this.props.dispatch(updateLocation(newUrl.pathname));
     }
 

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -7,7 +7,7 @@ import {dehydrate, rehydrate} from './hydration';
 // The deserialization step happens in each of the reducers
 export function serializeStore(slug, state) {
   switch (slug) {
-    case 'endpoints':
+    case 'explorer':
       let endpointsResult = {};
       if (state.endpointExplorer.currentResource) {
         endpointsResult.resource = state.endpointExplorer.currentResource;

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -1,9 +1,11 @@
-import {dehydrate} from './hydration';
+import {dehydrate, rehydrate} from './hydration';
 
 // The store serializer is used to convert the store of a specific page into a
 // object of strings to be used in the url hash param.
-// It takes in a page slug and will return the string for that specific store
-export default function storeSerializer(slug, state) {
+// It takes in a page slug and will return the string for that specific store.
+
+// The deserialization step happens in each of the reducers
+export function serializeStore(slug, state) {
   switch (slug) {
     case 'endpoints':
       let endpointsResult = {};
@@ -12,7 +14,9 @@ export default function storeSerializer(slug, state) {
       }
       if (state.endpointExplorer.currentEndpoint) {
         endpointsResult.endpoint = state.endpointExplorer.currentEndpoint;
-        endpointsResult.params = dehydrate(state.endpointExplorer)
+      }
+      if (_.size(state.endpointExplorer.pendingRequest.values) > 0) {
+        endpointsResult.values = dehydrate(state.endpointExplorer.pendingRequest.values)
       }
       return endpointsResult;
     case 'txbuilder':
@@ -27,6 +31,29 @@ export default function storeSerializer(slug, state) {
         txsignerResult.xdr = state.transactionSigner.tx.xdr;
       }
       return txsignerResult;
+    default:
+      return {};
+  }
+}
+
+// This deserializes the query object into a simple object. This resulting simple
+// object is then passed to the reducers that apple the object to their store.
+export function deserializeQueryObj(slug, queryObj) {
+  switch (slug) {
+    case 'endpoints':
+      let endpointsResult = Object.assign({}, queryObj);
+      if (endpointsResult.values) {
+        endpointsResult.values = rehydrate(endpointsResult.values);
+      }
+      return endpointsResult;
+    case 'txbuilder':
+      let txbuilderResult = Object.assign({}, queryObj);
+      if (txbuilderResult.params) {
+        txbuilderResult.params = rehydrate(txbuilderResult.params);
+      }
+      return txbuilderResult;
+    case 'txsigner':
+      return queryObj;
     default:
       return {};
   }

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -40,18 +40,17 @@ export function serializeStore(slug, state) {
 // object is then passed to the reducers that apple the object to their store.
 export function deserializeQueryObj(slug, queryObj) {
   switch (slug) {
-    case 'endpoints':
+    case 'explorer':
       let endpointsResult = Object.assign({}, queryObj);
       if (endpointsResult.values) {
         endpointsResult.values = rehydrate(endpointsResult.values);
       }
       return endpointsResult;
     case 'txbuilder':
-      let txbuilderResult = Object.assign({}, queryObj);
-      if (txbuilderResult.params) {
-        txbuilderResult.params = rehydrate(txbuilderResult.params);
+      if (queryObj.params) {
+        return rehydrate(queryObj.params);
       }
-      return txbuilderResult;
+      return {};
     case 'txsigner':
       return queryObj;
     default:

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -1,0 +1,33 @@
+import {dehydrate} from './hydration';
+
+// The store serializer is used to convert the store of a specific page into a
+// object of strings to be used in the url hash param.
+// It takes in a page slug and will return the string for that specific store
+export default function storeSerializer(slug, state) {
+  switch (slug) {
+    case 'endpoints':
+      let endpointsResult = {};
+      if (state.endpointExplorer.currentResource) {
+        endpointsResult.resource = state.endpointExplorer.currentResource;
+      }
+      if (state.endpointExplorer.currentEndpoint) {
+        endpointsResult.endpoint = state.endpointExplorer.currentEndpoint;
+        endpointsResult.params = dehydrate(state.endpointExplorer)
+      }
+      return endpointsResult;
+    case 'txbuilder':
+      return {
+        params: dehydrate(state.transactionBuilder),
+      };
+    case 'txsigner':
+      // We only want to serialize the imported xdr and not the saved secret key
+      // to prevent sensitive data being stored in browser history.
+      let txsignerResult = {};
+      if (state.transactionSigner.tx.xdr.length > 0) {
+        txsignerResult.xdr = state.transactionSigner.tx.xdr;
+      }
+      return txsignerResult;
+    default:
+      return {};
+  }
+}

--- a/src/utilities/validateTxXdr.js
+++ b/src/utilities/validateTxXdr.js
@@ -1,0 +1,29 @@
+import {Transaction} from 'stellar-sdk';
+
+export default function validateTxXdr(input) {
+  input = _.trim(input);
+
+  if (input === '') {
+    return {
+      result: 'empty',
+    };
+  }
+  if (input.match(/^[-A-Za-z0-9+\/=]*$/) === null) {
+    return {
+      result: 'error',
+      message: 'The input is not valid base64 (a-zA-Z0-9+/=).'
+    };
+  }
+  try {
+    new Transaction(input);
+    return {
+      result: 'success',
+      message: 'Valid Transaction Envelope XDR',
+    }
+  } catch (e) {
+    return {
+      result: 'error',
+      message: 'Unable to parse input XDR into Transaction Envelope',
+    };
+  }
+}


### PR DESCRIPTION
This implements routing in the laboratory with light optimizations to reduce the url length.

This doesn't use react-router. Instead, it uses a small router written for just the Laboratory with a simple data flow. Components do not know about a router at all and the only routing information is stored in a one item reducer. I'm overall pretty happy with the way this turned out.

## docs.md
I created a file called `docs.md` to put in documentation about the laboratory code itself.