### PR TITLE
Improvements to help users new to the laboratory and Stellar

### DIFF
--- a/src/actions/transactionBuilder.js
+++ b/src/actions/transactionBuilder.js
@@ -13,13 +13,10 @@ export function updateAttributes(newAttributes) {
 // Operations
 export const ADD_OPERATION = 'ADD_OPERATION';
 export let addOperation = (() => {
-  let counter = 0;
-
   return () => {
-    counter++;
     return {
       type: ADD_OPERATION,
-      opId: counter
+      opId: Date.now(),
     };
   }
 })();

--- a/src/components/EasySelect.js
+++ b/src/components/EasySelect.js
@@ -1,19 +1,14 @@
 import React from 'react';
+import clickToSelect from '../utilities/clickToSelect';
 
 // Clicking an EasySelect element will select the contents
 export let EasySelect = React.createClass({
-  selectContents: function(event) {
-    var range = document.createRange();
-    range.selectNodeContents(event.target);
-    window.getSelection().removeAllRanges();
-    window.getSelection().addRange(range);
-  },
   render: function() {
     let className = 'EasySelect';
     if (this.props.plain) {
       className += ' EasySelect__plain'
     }
 
-    return <span className={className} onClick={this.selectContents}>{this.props.children}</span>;
+    return <span className={className} onClick={clickToSelect}>{this.props.children}</span>;
   }
 });

--- a/src/components/EndpointExplorer.js
+++ b/src/components/EndpointExplorer.js
@@ -34,6 +34,11 @@ class EndpointExplorer extends React.Component {
 
     return <div className="so-back">
       <div className="so-chunk">
+        <div className="pageIntro">
+          <p>
+            This tool can be used to run queries against the <a href="https://www.stellar.org/developers/reference/" target="_blank">REST API endpoints</a> on the
+            Horizon server. Horizon is the client facing library for the Stellar ecosystem.</p>
+        </div>
         <div className="EndpointExplorer">
           <div className="EndpointExplorer__picker">
             <EndpointPicker

--- a/src/components/EndpointPicker.js
+++ b/src/components/EndpointPicker.js
@@ -55,7 +55,7 @@ function ButtonGroupButton(props) {
   let {selected, label, onChange, id} = props;
   let classes = classNames(
     's-button',
-    's-button__light',
+    's-button--light',
     {"is-active": selected},
   )
 

--- a/src/components/FormComponents/RadioButtonPicker.js
+++ b/src/components/FormComponents/RadioButtonPicker.js
@@ -17,7 +17,7 @@ export default function RadioButtonPicker(props) {
           onChange={onUpdate.bind(null, id)}
           value={id}
           checked={value === id} />
-        <span className="s-button s-button__light">{label}</span>
+        <span className="s-button s-button--light">{label}</span>
       </label>
     })}
   </div>;

--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -12,7 +12,7 @@ function LaboratoryChrome(props) {
     return <a
       href={'#' + slug}
       className={classNames(
-        'buttonList__item s-button s-button__min',
+        'buttonList__item s-button s-button--min',
         {'is-active': props.routing.location === slug})}
       key={slug}>
       {name}

--- a/src/components/NetworkPicker.js
+++ b/src/components/NetworkPicker.js
@@ -35,7 +35,7 @@ const NetworkToggle = (props) => {
       onChange={onToggle}
       checked={selected}
       value={name} />
-    <span className="s-button s-button__light NetworkPicker__button">{name}</span>
+    <span className="s-button s-button--light NetworkPicker__button">{name}</span>
   </label>
 }
 

--- a/src/components/TransactionBuilder.js
+++ b/src/components/TransactionBuilder.js
@@ -24,6 +24,11 @@ class TransactionBuilder extends React.Component {
     return <div className="TransactionBuilder">
       <div className="so-back">
         <div className="so-chunk">
+          <div className="pageIntro">
+            <p>
+              The transaction builder lets you build a new Stellar transaction no existing signatures.
+            </p>
+          </div>
           <TxBuilderAttributes
             attributes={attributes}
             onUpdate={onAttributeUpdate.bind(this, dispatch)} />

--- a/src/components/TransactionBuilder.js
+++ b/src/components/TransactionBuilder.js
@@ -25,8 +25,9 @@ class TransactionBuilder extends React.Component {
       <div className="so-back">
         <div className="so-chunk">
           <div className="pageIntro">
+            <p>The transaction builder lets you build a new Stellar transaction.</p>
             <p>
-              The transaction builder lets you build a new Stellar transaction no existing signatures.
+              This transaction will start out with no signatures. To make it into the ledger, this transaction will then need to be signed and submitted to the network.
             </p>
           </div>
           <TxBuilderAttributes

--- a/src/components/TransactionBuilder.js
+++ b/src/components/TransactionBuilder.js
@@ -28,9 +28,11 @@ class TransactionBuilder extends React.Component {
             attributes={attributes}
             onUpdate={onAttributeUpdate.bind(this, dispatch)} />
           <OperationsBuilder />
-          <button className="TransactionOperations__add s-button" onClick={() => dispatch(addOperation())}>
-            Add Operation
-          </button>
+          <div className="TransactionOperations__add">
+            <button className="TransactionOperations__add__button s-button" onClick={() => dispatch(addOperation())}>
+              + Add Operation
+            </button>
+          </div>
         </div>
       </div>
       <div className="so-back TransactionBuilder__result">

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -60,6 +60,11 @@ class TransactionSigner extends React.Component {
         postLink = <a {...postLinkProps}>Submit this transaction to the network</a>;
       }
 
+      let resultTitle;
+      if (result.success) {
+        resultTitle = <h3 className="TxSignerResult__title">Transaction signed!</h3>
+      }
+
       content = <div>
         <div className="so-back">
           <div className="so-chunk">
@@ -97,6 +102,7 @@ class TransactionSigner extends React.Component {
         </div>
         <div className="so-back TxSignerResult TransactionSigner__result">
           <div className="so-chunk">
+            {resultTitle}
             <p className="TxSignerResult__summary">{result.message}</p>
             {codeResult}
             {postLink}
@@ -144,14 +150,22 @@ function signTx(xdr, signers, useNetworkFunc) {
     }
   }
 
+
   let newTx = new Transaction(xdr);
   let existingSigs = newTx.signatures.length;
   _.each(validSigners, (signer) => {
     newTx.sign(Keypair.fromSeed(signer));
   })
 
+  if (existingSigs + validSigners.length === 0) {
+    return {
+      message: 'Enter a secret key to sign message'
+    }
+  }
+
   return {
     xdr: newTx.toEnvelope().toXDR('base64'),
+    success: true,
     message: `${validSigners.length} signature(s) added; ${existingSigs + validSigners.length} signature(s) total`,
     totalSignatures: validSigners.length,
   };

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -49,15 +49,7 @@ class TransactionSigner extends React.Component {
           <pre className="TxSignerResult__xdr so-code so-code__wrap"><code>{result.xdr}</code></pre>
         </EasySelect>;
 
-        let postLinkProps = {
-          className: 's-button TxSignerResult__submit',
-        };
-        if (result.totalSignatures === 0) {
-          postLinkProps.className += ' is-disabled';
-        } else {
-          postLinkProps.href = txPostLink(result.xdr);
-        }
-        postLink = <a {...postLinkProps}>Submit this transaction to the network</a>;
+        postLink = <a className="s-button TxSignerResult__submit" href={txPostLink(result.xdr)}>Submit this transaction to the network</a>;
       }
 
       let resultTitle;
@@ -137,7 +129,7 @@ function isValidSecret(key) {
 function signTx(xdr, signers, useNetworkFunc) {
   Network[useNetworkFunc]();
 
-  let validSigners = [];
+  let validSecretKeys = [];
   for (let i = 0; i < signers.length; i++) {
     let signer = signers[i];
     if (signer !== null && !_.isUndefined(signer) && signer !== '') {
@@ -146,18 +138,18 @@ function signTx(xdr, signers, useNetworkFunc) {
           message: 'Valid secret keys are required to sign transaction'
         }
       }
-      validSigners.push(signer);
+      validSecretKeys.push(signer);
     }
   }
 
 
   let newTx = new Transaction(xdr);
   let existingSigs = newTx.signatures.length;
-  _.each(validSigners, (signer) => {
+  _.each(validSecretKeys, (signer) => {
     newTx.sign(Keypair.fromSeed(signer));
   })
 
-  if (existingSigs + validSigners.length === 0) {
+  if (validSecretKeys.length === 0) {
     return {
       message: 'Enter a secret key to sign message'
     }
@@ -166,7 +158,6 @@ function signTx(xdr, signers, useNetworkFunc) {
   return {
     xdr: newTx.toEnvelope().toXDR('base64'),
     success: true,
-    message: `${validSigners.length} signature(s) added; ${existingSigs + validSigners.length} signature(s) total`,
-    totalSignatures: validSigners.length,
+    message: `${validSecretKeys.length} signature(s) added; ${existingSigs + validSecretKeys.length} signature(s) total`,
   };
 }

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -13,6 +13,7 @@ import SecretKeyPicker from './FormComponents/SecretKeyPicker';
 import MultiPicker from './FormComponents/MultiPicker';
 import {txPostLink} from '../utilities/linkBuilder';
 import HelpMark from './HelpMark';
+import clickToSelect from '../utilities/clickToSelect';
 
 class TransactionSigner extends React.Component {
   render() {
@@ -42,19 +43,13 @@ class TransactionSigner extends React.Component {
         'Number of existing signatures': transaction.signatures.length,
       };
 
-      let codeResult, postLink;
+      let codeResult, postLink, resultTitle, postInstructions;
 
       if (!_.isUndefined(result.xdr)) {
-        codeResult = <EasySelect plain={true}>
-          <pre className="TxSignerResult__xdr so-code so-code__wrap"><code>{result.xdr}</code></pre>
-        </EasySelect>;
-
-        postLink = <a className="s-button TxSignerResult__submit" href={txPostLink(result.xdr)}>Submit this transaction to the network</a>;
-      }
-
-      let resultTitle;
-      if (result.success) {
-        resultTitle = <h3 className="TxSignerResult__title">Transaction signed!</h3>
+        codeResult = <pre className="TxSignerResult__xdr so-code so-code__wrap" onClick={clickToSelect}><code>{result.xdr}</code></pre>;
+        postLink = <a className="s-button TxSignerResult__submit" href={txPostLink(result.xdr)}>Submit this transaction using the Post Transaction endpoint</a>;
+        resultTitle = <h3 className="TxSignerResult__title">Transaction signed!</h3>;
+        postInstructions = <p className="TxSignerResult__instructions">Now that this transaction is signed, you can submit it to the network. Horizon provides an endpoint called Post Transaction that will relay your transaction to the network and inform you of the result.</p>
       }
 
       content = <div>
@@ -97,12 +92,26 @@ class TransactionSigner extends React.Component {
             {resultTitle}
             <p className="TxSignerResult__summary">{result.message}</p>
             {codeResult}
+            {postInstructions}
             {postLink}
           </div>
         </div>
       </div>
     }
     return <div className="TransactionSigner">
+      <div className="so-back">
+        <div className="so-chunk">
+          <div className="pageIntro">
+            <p>
+              The transaction signer lets you add signatures to a Stellar transaction. Signatures are used in the network to prove that the account is authorized to perform the operations in the transaction.
+            </p>
+            <p>
+              For simple transactions, you only need one signature from the correct account. Some advanced signatures may require more than one signature if there are multiple source accounts or signing keys.
+            </p>
+            <p><a href="https://www.stellar.org/developers/learn/concepts/multi-sig.html" target="_blank">Read more about signatures on the developer's site.</a></p>
+          </div>
+        </div>
+      </div>
       {content}
     </div>
   }
@@ -157,7 +166,6 @@ function signTx(xdr, signers, useNetworkFunc) {
 
   return {
     xdr: newTx.toEnvelope().toXDR('base64'),
-    success: true,
     message: `${validSecretKeys.length} signature(s) added; ${existingSigs + validSecretKeys.length} signature(s) total`,
   };
 }

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -19,6 +19,7 @@ export default function TxBuilderAttributes(props) {
           value={attributes['sourceAccount']}
           onUpdate={(value) => {onUpdate('sourceAccount', value)}}
           />
+        <p className="optionsTable__pair__content__note">If you don't have an account yet, you can create a test network account using the <a href="https://www.stellar.org/developers/#friendbot" target="_blank">quick start tutorial</a>.</p>
       </OptionsTablePair>
       <OptionsTablePair label={<span>Transaction Sequence Number <HelpMark href="https://www.stellar.org/developers/learn/concepts/transactions.html#sequence-number" /></span>}>
         <SequencePicker

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -30,7 +30,7 @@ export default class TxBuilderResult extends React.Component {
       validationErrors.push('Memo content is required if memo type is selected');
     }
 
-    let finalResult, errorTitleText, successTitleText, signingLink;
+    let finalResult, errorTitleText, successTitleText, signingInstructions, signingLink;
     if (validationErrors.length > 0) {
       errorTitleText = 'Form validation errors:';
       finalResult = formatErrorList(validationErrors);
@@ -43,8 +43,15 @@ export default class TxBuilderResult extends React.Component {
       } else {
         successTitleText = `Success! Transaction Envelope XDR:`;
         finalResult = transactionBuild.xdr;
+        signingInstructions = <p className="TransactionBuilderResult__instructions">
+          In order for the transaction to make it into the ledger, a transaction must be successfully
+          signed and submitted to the network. The laboratory provides
+          the <a href="#txsigner">Transaction Signer</a> to for signing a
+          transaction, and the <a href="#explorer?resource=transactions&endpoint=create">Post Transaction endpoint</a> for
+          submitting one to the network.
+        </p>;
         signingLink = <a className="s-button TransactionBuilderResult__sign"
-          href={txSignerLink(transactionBuild.xdr)}>Sign this transaction</a>
+          href={txSignerLink(transactionBuild.xdr)}>Sign this transaction in the Transaction Signer</a>
       }
     }
 
@@ -57,6 +64,7 @@ export default class TxBuilderResult extends React.Component {
       <EasySelect plain={true}><pre className="TransactionXDR so-code TransactionBuilderResult__code">
         <code>{finalResult}</code>
       </pre></EasySelect>
+      {signingInstructions}
       {signingLink}
     </div>
   }

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -30,26 +30,30 @@ export default class TxBuilderResult extends React.Component {
       validationErrors.push('Memo content is required if memo type is selected');
     }
 
-    let finalResult, errorTitle, signingLink;
+    let finalResult, errorTitleText, successTitleText, signingLink;
     if (validationErrors.length > 0) {
-      errorTitle = 'Form validation errors:';
+      errorTitleText = 'Form validation errors:';
       finalResult = formatErrorList(validationErrors);
     } else {
       let transactionBuild = buildTransaction(attributes, operations);
 
       if (transactionBuild.errors.length > 0) {
-        errorTitle = `Transaction building errors:`;
+        errorTitleText = `Transaction building errors:`;
         finalResult = formatErrorList(transactionBuild.errors);
       } else {
-        errorTitle = `Transaction Envelope XDR:`;
+        successTitleText = `Success! Transaction Envelope XDR:`;
         finalResult = transactionBuild.xdr;
         signingLink = <a className="s-button TransactionBuilderResult__sign"
           href={txSignerLink(transactionBuild.xdr)}>Sign this transaction</a>
       }
     }
 
-    return <div className="TxBuilderResult">
-      <h3>{errorTitle}</h3>
+    let errorTitle = errorTitleText ? <h3 className="TransactionBuilderResult__error">{errorTitleText}</h3> : null
+    let successTitle = successTitleText ? <h3 className="TransactionBuilderResult__success">{successTitleText}</h3> : null
+
+    return <div className="TransactionBuilderResult">
+      {successTitle}
+      {errorTitle}
       <EasySelect plain={true}><pre className="TransactionXDR so-code TransactionBuilderResult__code">
         <code>{finalResult}</code>
       </pre></EasySelect>

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -12,6 +12,7 @@ import {PubKeyPicker} from './FormComponents/PubKeyPicker';
 import {EasySelect} from './EasySelect';
 import Libify from '../utilities/Libify';
 import {txSignerLink} from '../utilities/linkBuilder';
+import clickToSelect from '../utilities/clickToSelect';
 
 export default class TxBuilderResult extends React.Component {
   render() {
@@ -61,9 +62,9 @@ export default class TxBuilderResult extends React.Component {
     return <div className="TransactionBuilderResult">
       {successTitle}
       {errorTitle}
-      <EasySelect plain={true}><pre className="TransactionXDR so-code TransactionBuilderResult__code">
+      <pre className="TransactionXDR so-code TransactionBuilderResult__code" onClick={clickToSelect}>
         <code>{finalResult}</code>
-      </pre></EasySelect>
+      </pre>
       {signingInstructions}
       {signingLink}
     </div>

--- a/src/styles/_EndpointExplorer.scss
+++ b/src/styles/_EndpointExplorer.scss
@@ -1,5 +1,5 @@
 .EndpointExplorer {
-  padding-top: 2em;
+  margin-top: 2em;
 }
 .EndpointExplorer__picker {
   margin-bottom: 2em;

--- a/src/styles/_TransactionBuilder.scss
+++ b/src/styles/_TransactionBuilder.scss
@@ -68,6 +68,7 @@
   margin-top: 0.5em;
   margin-bottom: 1.5em;
   background: $s-color-neutral9;
+  cursor: pointer;
   word-wrap: break-word;
 }
 .TransactionBuilderResult__success {

--- a/src/styles/_TransactionBuilder.scss
+++ b/src/styles/_TransactionBuilder.scss
@@ -27,8 +27,12 @@
   @include S-flexItem-share;
 }
 
+.TransactionOpMeta {
+  width: 108px;
+  text-align: center;
+}
 .TransactionOpMeta__order {
-  padding: 1.5em 1em 0.5em 1em;
+  padding: 1.5em 0 0.5em 0;
 }
   .TransactionOpMeta__order__input {
     height: 72px;
@@ -44,11 +48,18 @@
 
 .TransactionOperations__add {
   width: 100%;
+  padding-left: 108px;
+  margin-bottom: 1.5em;
+}
+.TransactionOperations__add__button {
+  width: 100%;
   font-size: $s-scale-3;
   padding-top: 0.5em;
   padding-bottom: 0.5em;
   text-align: center;
-  margin-bottom: 1.5em;
+  color: $s-color-neutral2;
+  background: $s-color-neutral8;
+  border-color: $s-color-neutral6;
 }
 
 .TransactionBuilderResult__code {

--- a/src/styles/_TransactionBuilder.scss
+++ b/src/styles/_TransactionBuilder.scss
@@ -10,6 +10,9 @@
 
   background: $s-color-neutral8;
 }
+  .TransactionBuilder__result :last-child {
+    margin-bottom: 0;
+  }
 
 .TransactionAttributes {
   margin-bottom: 1.5em;

--- a/src/styles/_TransactionBuilder.scss
+++ b/src/styles/_TransactionBuilder.scss
@@ -1,5 +1,4 @@
 .TransactionBuilder {
-  padding-top: 2em;
   padding-bottom: 4em;
 }
 
@@ -64,12 +63,13 @@
 
 .TransactionBuilderResult__code {
   margin-top: 0.5em;
+  margin-bottom: 1.5em;
   background: $s-color-neutral9;
   word-wrap: break-word;
 }
-.TransactionBuilderResult__sign {
-  margin-top: 1em;
-}
 .TransactionBuilderResult__success {
   color: $s-color-success;
+}
+.TransactionBuilderResult__instructions {
+  margin-bottom: 1em;
 }

--- a/src/styles/_TransactionBuilder.scss
+++ b/src/styles/_TransactionBuilder.scss
@@ -70,3 +70,6 @@
 .TransactionBuilderResult__sign {
   margin-top: 1em;
 }
+.TransactionBuilderResult__success {
+  color: $s-color-success;
+}

--- a/src/styles/_TransactionSigner.scss
+++ b/src/styles/_TransactionSigner.scss
@@ -1,5 +1,4 @@
 .TransactionSigner {
-  padding-top: 2em;
 }
   .TransactionSigner__import {
 

--- a/src/styles/_TransactionSigner.scss
+++ b/src/styles/_TransactionSigner.scss
@@ -13,3 +13,6 @@
   .TransactionSigner__result {
     margin-bottom: 2em;
   }
+  .TransactionSigner__result :last-child {
+    margin-bottom: 0;
+  }

--- a/src/styles/_TxSignerResult.scss
+++ b/src/styles/_TxSignerResult.scss
@@ -6,6 +6,9 @@
 
   background: $s-color-neutral8;
 }
+  .TxSignerResult__title {
+    color: $s-color-success;
+  }
   .TxSignerResult__xdr {
     background: $s-color-neutral9;
   }

--- a/src/styles/_TxSignerResult.scss
+++ b/src/styles/_TxSignerResult.scss
@@ -10,5 +10,7 @@
     color: $s-color-success;
   }
   .TxSignerResult__xdr {
+    cursor: pointer;
+    margin-bottom: 1.5em;
     background: $s-color-neutral9;
   }

--- a/src/styles/_pageIntro.scss
+++ b/src/styles/_pageIntro.scss
@@ -1,0 +1,11 @@
+.pageIntro {
+  margin-top: 2em;
+  margin-bottom: 2em;
+  padding: 1em;
+
+  background: $s-color-neutral8;
+  border-radius: $s-var-radius;
+}
+  .pageIntro :last-child {
+    margin-bottom: 0;
+  }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -29,9 +29,10 @@
 @import 'EasySelect';
 @import 'HelpMark';
 
-// General css modules
+// General css modules not tied to a React component. Should be lowercase
 @import 'optionsTable';
 @import 'simpleTable';
+@import 'pageIntro';
 
 @import 'picker';
   @import 'ManualMultiPicker';

--- a/src/utilities/clickToSelect.js
+++ b/src/utilities/clickToSelect.js
@@ -1,0 +1,10 @@
+// DOM helper. When an element has clickToSelect and a users clicks on the element,
+// then the whole element will be selected/highlighted.
+
+// usage: <Element onClick={clickToSelect} />
+export default function clickToSelect(event) {
+  var range = document.createRange();
+  range.selectNodeContents(event.target);
+  window.getSelection().removeAllRanges();
+  window.getSelection().addRange(range);
+};

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -32,7 +32,8 @@ export function serializeStore(slug, state) {
         txbuilderResult.operations = state.transactionBuilder.operations;
       }
 
-      if (txbuilderResult.attributes.memoType === 'MEMO_NONE') {
+      if (_.has(txbuilderResult, 'attributes.memoType') &&
+          txbuilderResult.attributes.memoType === 'MEMO_NONE') {
         delete txbuilderResult.attributes.memoType;
       }
 

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -31,6 +31,15 @@ export function serializeStore(slug, state) {
       if (state.transactionBuilder.operations.length > 1 || !firstOpEmpty) {
         txbuilderResult.operations = state.transactionBuilder.operations;
       }
+
+      if (txbuilderResult.attributes.memoType === 'MEMO_NONE') {
+        delete txbuilderResult.attributes.memoType;
+      }
+
+      if (_.size(txbuilderResult.attributes) === 0) {
+        delete txbuilderResult.attributes;
+      }
+
       if (_.size(txbuilderResult) === 0) {
         return {};
       }


### PR DESCRIPTION
There were quite a big features in this PR. Thank you to the people who provided feedback on the laboratory and @mozzadrella for collecting this feedback. There will be more changes and this is not the only one to address usability.

### Page specific introduction text
Each page now has it's own introduction text

![image](https://cloud.githubusercontent.com/assets/5728307/13369983/a67e7f4a-dcb1-11e5-8fca-0d4f2b2b654f.png)

![image](https://cloud.githubusercontent.com/assets/5728307/13410277/bc550500-deeb-11e5-91c2-da4e1ced5904.png)

![image](https://cloud.githubusercontent.com/assets/5728307/13369929/0bd9afbe-dcb1-11e5-8068-91339a9c2cdc.png)


### Add operation button de-emphazied
Multi operation transactions are an intermediate-advanced feature. By de-emphasizing it, less people will be confused

![image](https://cloud.githubusercontent.com/assets/5728307/13369963/581f3010-dcb1-11e5-847a-ffaf69e4f306.png)

### Help text in transaction builder (note the green success titles)
![image](https://cloud.githubusercontent.com/assets/5728307/13369968/746d1afc-dcb1-11e5-95b6-75b0e2ec3d26.png)

### Help text in transaction signer
![image](https://cloud.githubusercontent.com/assets/5728307/13369974/8b1b9396-dcb1-11e5-9584-f4abb80ef9c7.png)

### Small things
- improved spacing aesthetics
- improved url management and importing from url