### PR TITLE
link the header "laboratory" to the laboratory home page

### DIFF
--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -28,7 +28,7 @@ function LaboratoryChrome(props) {
           <span className="so-logo">
             <a href="https://www.stellar.org/" className="so-logo__main">Stellar</a>
             <span className="so-logo__separator"> </span>
-            <a href="https://www.stellar.org/laboratory/" className="so-logo__subSite">laboratory</a>
+            <a href="#" className="so-logo__subSite">laboratory</a>
           </span>
           <NetworkPicker />
         </div>


### PR DESCRIPTION
So that people running it locally won't accidentally get to the stellar.org
hosted laboratory

I'm talking about this thing:
![image](https://cloud.githubusercontent.com/assets/5728307/13446639/f42ab2b6-dfc9-11e5-857c-42759ff56504.png)


----

Feel free to merge
