### PR TITLE
fix unescaping code to match all instances of &amp; and not just the first

### DIFF
--- a/src/utilities/prism-jsonLinkHighlighter.js
+++ b/src/utilities/prism-jsonLinkHighlighter.js
@@ -44,7 +44,7 @@ function annotatePropertyToken(propertyToken) {
     return;
   }
 
-  let safeUnescapedValueText = valueToken.innerHTML.replace('&amp;','&');
+  let safeUnescapedValueText = valueToken.innerHTML.replace(/\&amp;/g, '&');
   let href = urlGenerator(unQuote(safeUnescapedValueText));
   if (typeof href === 'undefined') {
     return;


### PR DESCRIPTION
This fixes a bug where we weren't unescaping enough. Not a security issue.