### PR TITLE
Current network in url query params

### DIFF
--- a/src/components/EndpointExplorer.js
+++ b/src/components/EndpointExplorer.js
@@ -6,6 +6,7 @@ import {EndpointPicker} from './EndpointPicker';
 import {EndpointSetup} from './EndpointSetup';
 import {EndpointResult} from './EndpointResult';
 import {getEndpoint} from '../data/endpoints';
+import NETWORK from '../constants/network';
 import UriTemplates from 'uri-templates';
 import querystring from 'querystring';
 
@@ -67,7 +68,7 @@ export default connect(chooseState)(EndpointExplorer)
 function chooseState(state) {
   return {
     state: state.endpointExplorer,
-    baseURL: state.network.available[state.network.current].url,
+    baseURL: NETWORK.available[state.network.current].url,
   };
 }
 

--- a/src/components/NetworkPicker.js
+++ b/src/components/NetworkPicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import {chooseNetwork} from "../actions/network";
+import NETWORK from '../constants/network';
 
 class NetworkPicker extends React.Component {
   render() {
@@ -43,8 +44,8 @@ export default connect(chooseState)(NetworkPicker);
 
 function chooseState(state) {
   return {
-    availableNames: Object.keys(state.network.available),
+    availableNames: Object.keys(NETWORK.available),
     currentName:    state.network.current,
-    currentURL:     state.network.available[state.network.current].url,
+    currentURL:     NETWORK.available[state.network.current].url,
   };
 }

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -18,6 +18,7 @@ import scrollOnAnchorOpen from '../utilities/scrollOnAnchorOpen';
 import extrapolateFromXdr from '../utilities/extrapolateFromXdr';
 import validateTxXdr from '../utilities/validateTxXdr';
 import TreeView from './TreeView';
+import NETWORK from '../constants/network';
 
 class TransactionSigner extends React.Component {
   render() {
@@ -148,7 +149,7 @@ export default connect(chooseState)(TransactionSigner);
 function chooseState(state) {
   return {
     state: state.transactionSigner,
-    useNetworkFunc: state.network.available[state.network.current].useNetworkFunc,
+    useNetworkFunc: NETWORK.available[state.network.current].useNetworkFunc,
   }
 }
 

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -22,7 +22,7 @@ import NETWORK from '../constants/network';
 
 class TransactionSigner extends React.Component {
   render() {
-    let {dispatch} = this.props;
+    let {dispatch, networkObj} = this.props;
     let {xdr, signers} = this.props.state;
     let content;
 
@@ -36,7 +36,7 @@ class TransactionSigner extends React.Component {
         </div>
       </div>
     } else {
-      let result = signTx(xdr, signers, this.props.useNetworkFunc);
+      let result = signTx(xdr, signers, networkObj);
       let transaction = new Transaction(xdr);
 
       let infoTable = {
@@ -149,7 +149,7 @@ export default connect(chooseState)(TransactionSigner);
 function chooseState(state) {
   return {
     state: state.transactionSigner,
-    useNetworkFunc: NETWORK.available[state.network.current].useNetworkFunc,
+    networkObj: NETWORK.available[state.network.current].networkObj,
   }
 }
 
@@ -162,8 +162,8 @@ function isValidSecret(key) {
   return true;
 }
 
-function signTx(xdr, signers, useNetworkFunc) {
-  Network[useNetworkFunc]();
+function signTx(xdr, signers, networkObj) {
+  Network.use(networkObj);
 
   let validSecretKeys = [];
   for (let i = 0; i < signers.length; i++) {

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -7,6 +7,7 @@ import StroopsPicker from './FormComponents/StroopsPicker';
 import MemoPicker from './FormComponents/MemoPicker';
 import {connect} from 'react-redux';
 import {Keypair} from 'stellar-sdk';
+import NETWORK from '../constants/network';
 import {fetchSequence} from '../actions/transactionBuilder';
 
 export default function TxBuilderAttributes(props) {

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -53,7 +53,7 @@ class sequenceFetcherClass extends React.Component {
   render() {
     let {attributes, sequenceFetcherError} = this.props.state;
     let dispatch = this.props.dispatch;
-    let network = this.props.network;
+    let currentNetwork = this.props.currentNetwork;
     if (!Keypair.isValidPublicKey(attributes.sourceAccount)) {
       return null;
     }
@@ -71,7 +71,7 @@ class sequenceFetcherClass extends React.Component {
       <a
         className="s-button"
         onClick={() => dispatch(
-          fetchSequence(attributes.sourceAccount, network.available[network.current].url)
+          fetchSequence(attributes.sourceAccount, NETWORK.available[currentNetwork].url)
         )}
         >Fetch next sequence number for account starting with "{truncatedAccountId}"</a>
       <br />
@@ -84,6 +84,6 @@ let SequenceFetcher = connect(chooseState)(sequenceFetcherClass);
 function chooseState(state) {
   return {
     state: state.transactionBuilder,
-    network: state.network,
+    currentNetwork: state.network.current,
   }
 }

--- a/src/constants/network.js
+++ b/src/constants/network.js
@@ -1,0 +1,14 @@
+const NETWORK = {
+  available: {
+    test: {
+      url: 'https://horizon-testnet.stellar.org',
+      useNetworkFunc: 'useTestNetwork',
+    },
+    public: {
+      url: 'https://horizon.stellar.org',
+      useNetworkFunc: 'usePublicNetwork',
+    }
+  },
+  defaultName: 'test',
+};
+export default NETWORK;

--- a/src/constants/network.js
+++ b/src/constants/network.js
@@ -1,12 +1,14 @@
+import {Network, Networks} from 'stellar-sdk';
+
 const NETWORK = {
   available: {
     test: {
       url: 'https://horizon-testnet.stellar.org',
-      useNetworkFunc: 'useTestNetwork',
+      networkObj: new Network(Networks.TESTNET),
     },
     public: {
       url: 'https://horizon.stellar.org',
-      useNetworkFunc: 'usePublicNetwork',
+      networkObj: new Network(Networks.PUBLIC),
     }
   },
   defaultName: 'test',

--- a/src/reducers/network.js
+++ b/src/reducers/network.js
@@ -10,7 +10,7 @@ export default network;
 function current(state=NETWORK.defaultName, action) {
   switch(action.type) {
     case LOAD_STATE:
-      if (NETWORK.available[action.payload.network]) {
+      if (action.payload.network && NETWORK.available[action.payload.network]) {
         return action.payload.network;
       }
       return state;

--- a/src/reducers/network.js
+++ b/src/reducers/network.js
@@ -1,5 +1,6 @@
 import {combineReducers} from "redux";
 import {CHOOSE_NETWORK, SET_NETWORKS} from "../actions/network";
+import {LOAD_STATE} from '../actions/routing';
 
 const defaultNetworks = {
   test: {
@@ -12,7 +13,7 @@ const defaultNetworks = {
   }
 }
 
-const defaultNetworkName = 'test';
+export const defaultNetworkName = 'test';
 const defaultUseNetworkFunc = 'useTestNetwork';
 
 const network = combineReducers({ current, available });
@@ -21,6 +22,11 @@ export default network;
 
 function current(state=defaultNetworkName, action) {
   switch(action.type) {
+    case LOAD_STATE:
+      if (defaultNetworks[action.payload.network]) {
+        return action.payload.network;
+      }
+      return state;
     case CHOOSE_NETWORK:
       return action.name;
     default:

--- a/src/reducers/network.js
+++ b/src/reducers/network.js
@@ -1,29 +1,16 @@
 import {combineReducers} from "redux";
-import {CHOOSE_NETWORK, SET_NETWORKS} from "../actions/network";
+import {CHOOSE_NETWORK} from "../actions/network";
+import NETWORK from '../constants/network';
 import {LOAD_STATE} from '../actions/routing';
 
-const defaultNetworks = {
-  test: {
-    url: 'https://horizon-testnet.stellar.org',
-    useNetworkFunc: 'useTestNetwork',
-  },
-  public: {
-    url: 'https://horizon.stellar.org',
-    useNetworkFunc: 'usePublicNetwork',
-  }
-}
-
-export const defaultNetworkName = 'test';
-const defaultUseNetworkFunc = 'useTestNetwork';
-
-const network = combineReducers({ current, available });
+const network = combineReducers({ current });
 
 export default network;
 
-function current(state=defaultNetworkName, action) {
+function current(state=NETWORK.defaultName, action) {
   switch(action.type) {
     case LOAD_STATE:
-      if (defaultNetworks[action.payload.network]) {
+      if (NETWORK.available[action.payload.network]) {
         return action.payload.network;
       }
       return state;
@@ -31,14 +18,5 @@ function current(state=defaultNetworkName, action) {
       return action.name;
     default:
       return state;
-  }
-}
-
-function available(state=defaultNetworks, action) {
-  switch(action.type) {
-  case SET_NETWORKS:
-    return action.networks;
-  default:
-    return state;
   }
 }

--- a/src/utilities/linkBuilder.js
+++ b/src/utilities/linkBuilder.js
@@ -12,9 +12,7 @@ import horizonUrlParser from './horizonUrlParser';
 export function txSignerLink(xdr) {
   let query = serializeStore(SLUG.TXSIGNER, {
     transactionSigner: {
-      tx: {
-        xdr: xdr,
-      },
+      xdr: xdr,
     },
   });
   return hashBuilder(SLUG.TXSIGNER, query);

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -6,6 +6,9 @@ import NETWORK from '../constants/network';
 // The store serializer converts the state relevant to a specific page into an object.
 // This object is then used to build the routing url.
 
+// IMPORTANT: The state that gets passed here may be an incomplete one.
+// Incomplete ones are useful because it lets us build URLs without needing the
+// whole state tree (such as in ../utilities/linkBuilder.js).
 export function serializeStore(slug, state) {
   return _.assign({},
     serializePageSpecificStore(slug, state),
@@ -14,7 +17,8 @@ export function serializeStore(slug, state) {
 }
 
 function serializeNetworkStore(state) {
-  if (state.network.current !== NETWORK.defaultName) {
+  // Only return something if we were passed the current network
+  if (_.has(state, 'network.current')) {
     return {
       network: state.network.current,
     }
@@ -129,7 +133,10 @@ function deserializePageSpecificQueryObj(slug, queryObj) {
 }
 
 function deserializeNetworkQueryObj(queryObj) {
-  return {
-    network: queryObj.network === undefined ? NETWORK.defaultName : queryObj.network,
+  if (queryObj.network) {
+    return {
+      network: queryObj.network,
+    }
   }
+  return {};
 }

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -1,13 +1,28 @@
 import {dehydrate, rehydrate} from './hydration';
 import _ from 'lodash';
 import SLUG from '../constants/slug';
+import {defaultNetworkName} from '../reducers/network';
 
-// The store serializer is used to convert the store of a specific page into a
-// object of strings to be used in the url hash param.
-// It takes in a page slug and will return the string for that specific store.
+// The store serializer converts the state relevant to a specific page into an object.
+// This object is then used to build the routing url.
 
-// The deserialization step happens in each of the reducers
 export function serializeStore(slug, state) {
+  return _.assign({},
+    serializePageSpecificStore(slug, state),
+    serializeNetworkStore(state),
+  );
+}
+
+function serializeNetworkStore(state) {
+  if (state.network.current !== defaultNetworkName) {
+    return {
+      network: state.network.current,
+    }
+  }
+  return {};
+}
+
+function serializePageSpecificStore(slug, state) {
   switch (slug) {
     case SLUG.EXPLORER:
       let endpointsResult = {};
@@ -84,8 +99,14 @@ function assignNonEmpty(targetObj, inputObj) {
 }
 
 // This deserializes the query object into a simple object. This resulting simple
-// object is then passed to the reducers that apple the object to their store.
+// object is then passed to the reducers that apply the object to their store.
 export function deserializeQueryObj(slug, queryObj) {
+  return _.assign({},
+    deserializePageSpecificQueryObj(slug, queryObj),
+    deserializeNetworkQueryObj(queryObj),
+  );
+}
+function deserializePageSpecificQueryObj(slug, queryObj) {
   switch (slug) {
     case SLUG.EXPLORER:
       let endpointsResult = Object.assign({}, queryObj);
@@ -104,5 +125,11 @@ export function deserializeQueryObj(slug, queryObj) {
       return queryObj;
     default:
       return {};
+  }
+}
+
+function deserializeNetworkQueryObj(queryObj) {
+  return {
+    network: queryObj.network === undefined ? defaultNetworkName : queryObj.network,
   }
 }

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -1,7 +1,7 @@
 import {dehydrate, rehydrate} from './hydration';
 import _ from 'lodash';
 import SLUG from '../constants/slug';
-import {defaultNetworkName} from '../reducers/network';
+import NETWORK from '../constants/network';
 
 // The store serializer converts the state relevant to a specific page into an object.
 // This object is then used to build the routing url.
@@ -14,7 +14,7 @@ export function serializeStore(slug, state) {
 }
 
 function serializeNetworkStore(state) {
-  if (state.network.current !== defaultNetworkName) {
+  if (state.network.current !== NETWORK.defaultName) {
     return {
       network: state.network.current,
     }
@@ -130,6 +130,6 @@ function deserializePageSpecificQueryObj(slug, queryObj) {
 
 function deserializeNetworkQueryObj(queryObj) {
   return {
-    network: queryObj.network === undefined ? defaultNetworkName : queryObj.network,
+    network: queryObj.network === undefined ? NETWORK.defaultName : queryObj.network,
   }
 }


### PR DESCRIPTION
**TL;DR;**: Network parameter will always be in the url. Doing otherwise would be a ton more code for a minor aesthetic improvement.

-----

Most of my notes here are more for my own thoughts and understanding of how I got to this solution.

I have cleanly separated each commit so that is easy to review each step of the way.

## Commit 1: Feature
Added the serialization and deserialization of network into the url.

## Commit 2: Refactoring

When first writing the laboratory, we were not sure what was best to put in the reducer. After a bit more experience, it is more clear that we shouldn't be storing static data in the reducer since it clutters up the reducers and can be done in a cleaner way (by having a constants file).

The presence of a potentially dynamic available networks can mess up how we serialize and deserialize the network part of the state. I do not foresee having an option in the laboratory to add new horizon servers any time soon and this is a good tradeoff to make for safety.

## Commit 3: Realizing that things can't be "pretty"
I originally wanted the URL to not have network to have the lack of network refer to the default network which is test. Unfortunately for my desires, this does not easily work.

The original method would mean that whenever we build urls, we would need to have information about the current network (and thus the whole state).

Having the whole state to build URLs is annoying because we build them in stateless places. For example, we build a URL to link from the transaction builder to the signer. Adding my original vision would mean that every link now needs knowledge of the current network.

## Final notes
I actually like how this turned out and I think it's actually better to explicitly have the network in the url. Things fell together pretty well :)