### PR TITLE
Fix incorrect txsigner persistence

### DIFF
--- a/src/components/TransactionImporter.js
+++ b/src/components/TransactionImporter.js
@@ -25,7 +25,6 @@ export default class TransactionImporter extends React.Component {
   }
   render() {
     let validation, message, submitEnabled, messageClass;
-
     validation = validateTxXdr(this.state.input);
     messageClass = validation.result === 'error' ? 'xdrInput__message__alert' : 'xdrInput__message__success';
     message = <p className={messageClass}>{validation.message}</p>

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -15,15 +15,16 @@ import {txPostLink, xdrViewer} from '../utilities/linkBuilder';
 import HelpMark from './HelpMark';
 import clickToSelect from '../utilities/clickToSelect';
 import extrapolateFromXdr from '../utilities/extrapolateFromXdr';
+import validateTxXdr from '../utilities/validateTxXdr';
 import TreeView from './TreeView';
 
 class TransactionSigner extends React.Component {
   render() {
     let {dispatch} = this.props;
-    let {tx, signers} = this.props.state;
+    let {xdr, signers} = this.props.state;
     let content;
 
-    if (!tx.loaded) {
+    if (validateTxXdr(xdr).result !== 'success') {
       content = <div className="so-back">
         <div className="so-chunk">
           <div className="TxSignerImport TransactionSigner__import">
@@ -33,11 +34,11 @@ class TransactionSigner extends React.Component {
         </div>
       </div>
     } else {
-      let result = signTx(tx.xdr, signers, this.props.useNetworkFunc);
-      let transaction = new Transaction(tx.xdr);
+      let result = signTx(xdr, signers, this.props.useNetworkFunc);
+      let transaction = new Transaction(xdr);
 
       let infoTable = {
-        'Transaction Envelope XDR': <EasySelect plain={true}><pre className="so-code so-code__wrap"><code>{tx.xdr}</code></pre></EasySelect>,
+        'Transaction Envelope XDR': <EasySelect plain={true}><pre className="so-code so-code__wrap"><code>{xdr}</code></pre></EasySelect>,
         'Source account': transaction.source,
         'Sequence number': transaction.sequence,
         'Transaction Fee (stroops)': transaction.fee,

--- a/src/reducers/transactionSigner.js
+++ b/src/reducers/transactionSigner.js
@@ -52,6 +52,7 @@ function tx(state = {
 
 function signers(state = [], action) {
   switch (action.type) {
+  case IMPORT_FROM_XDR:
   case CLEAR_TRANSACTION:
     return []
   case SET_SECRETS:

--- a/src/reducers/transactionSigner.js
+++ b/src/reducers/transactionSigner.js
@@ -22,18 +22,20 @@ function tx(state = {
 }, action) {
   switch (action.type) {
   case LOAD_STATE:
-    if (action.slug === SLUG.TXSIGNER && action.payload.xdr &&
-        validateTxXdr(action.payload.xdr).result === 'success') {
-      return {
-        xdr: action.payload.xdr,
-        loaded: true,
+    if (action.slug === SLUG.TXSIGNER && action.payload.xdr) {
+      if (validateTxXdr(action.payload.xdr).result === 'success') {
+        return {
+          xdr: action.payload.xdr,
+          loaded: true,
+        }
       }
+      // If invalid xdr in the url, then we go back to step zero
+      return {
+        xdr: '',
+        loaded: false,
+      };
     }
-    // If invalid xdr in the url, then we go back to step zero
-    return {
-      xdr: '',
-      loaded: false,
-    };
+    return state;
   case IMPORT_FROM_XDR:
     return {
       xdr: action.xdr,

--- a/src/reducers/transactionSigner.js
+++ b/src/reducers/transactionSigner.js
@@ -5,47 +5,32 @@ import {
   SET_SECRETS,
 } from '../actions/transactionSigner';
 import {LOAD_STATE} from '../actions/routing';
-import validateTxXdr from '../utilities/validateTxXdr';
 import _ from 'lodash';
+import validateTxXdr from '../utilities/validateTxXdr';
 import SLUG from '../constants/slug';
 
 const transactionSigner = combineReducers({
-  tx,
+  xdr,
   signers,
 })
 
 export default transactionSigner;
 
-function tx(state = {
-  xdr: '',
-  loaded: false,
-}, action) {
+function xdr(state = '', action) {
   switch (action.type) {
   case LOAD_STATE:
     if (action.slug === SLUG.TXSIGNER && action.payload.xdr) {
       if (validateTxXdr(action.payload.xdr).result === 'success') {
-        return {
-          xdr: action.payload.xdr,
-          loaded: true,
-        }
+        return action.payload.xdr;
       }
       // If invalid xdr in the url, then we go back to step zero
-      return {
-        xdr: '',
-        loaded: false,
-      };
+      return '';
     }
     return state;
   case IMPORT_FROM_XDR:
-    return {
-      xdr: action.xdr,
-      loaded: true,
-    }
+    return action.xdr;
   case CLEAR_TRANSACTION:
-    return {
-      xdr: '',
-      loaded: false,
-    }
+    return '';
   }
   return state;
 }

--- a/src/utilities/storeSerializer.js
+++ b/src/utilities/storeSerializer.js
@@ -52,8 +52,8 @@ export function serializeStore(slug, state) {
       // We only want to serialize the imported xdr and not the saved secret key
       // to prevent sensitive data being stored in browser history.
       let txsignerResult = {};
-      if (state.transactionSigner.tx.xdr.length > 0) {
-        txsignerResult.xdr = state.transactionSigner.tx.xdr;
+      if (state.transactionSigner.xdr.length > 0) {
+        txsignerResult.xdr = state.transactionSigner.xdr;
       }
       return txsignerResult;
     case 'xdr-viewer':


### PR DESCRIPTION
Previously, the txsigner state would:
1. clear the txsigner state due to any LOAD_STATE triggered by changing the url (directly or via a link)
2. remain the secret key input that didn't get cleared

---

Also includes a refactoring to simplify the redux reducer (net negative lines of code; woot!)