### PR TITLE
UTF-8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sass-loader": "^3.0.0",
     "solar-css": "git+https://github.com/stellar/solar#master",
     "solar-stellarorg": "git+https://github.com/stellar/solar-stellarorg#master",
-    "stellar-base": "0.5.5",
+    "stellar-base": "0.5.6",
     "uri-templates": "^0.1.9",
     "webpack": "^1.12.2"
   }


### PR DESCRIPTION
Updates stellar-base to `0.5.6` which contains UTF-8 support in memo_text.