### PR TITLE
Remove "All Accounts" endpoint

### DIFF
--- a/src/data/endpoints.js
+++ b/src/data/endpoints.js
@@ -16,15 +16,6 @@ export const endpointsMap = {
   'accounts': {
     'label': 'Accounts',
     'endpoints': {
-      'all': {
-        'label': 'All Accounts',
-        'helpUrl': 'https://www.stellar.org/developers/horizon/reference/accounts-all.html',
-        'method': 'GET',
-        'path': {
-          template: '/accounts{?cursor,limit,order}',
-        },
-        'setupComponent': require('../components/SetupPanes/All'),
-      },
       'single': {
         'label': 'Single Account',
         'helpUrl': 'https://www.stellar.org/developers/horizon/reference/accounts-single.html',

--- a/src/utilities/horizonUrlParser.js
+++ b/src/utilities/horizonUrlParser.js
@@ -20,7 +20,6 @@ let routeTable = {
   '/ledgers/:ledger/effects': {r: 'effects', e: 'for_ledger'},
 
   // account actions
-  '/accounts': {r: 'accounts', e: 'all'},
   '/accounts/:account_id': {r: 'accounts', e: 'single'},
   '/accounts/:account_id/transactions': {r: 'transactions', e: 'for_account'},
   '/accounts/:account_id/operations': {r: 'operations', e: 'for_account'},


### PR DESCRIPTION
This endpoint has been removed in an upcoming horizon release, and is already removed on testnet.