### PR TITLE
Support Ledger app version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sass-loader": "^3.2.3",
     "solar-css": "git+https://github.com/stellar/solar#master",
     "solar-stellarorg": "git+https://github.com/stellar/solar-stellarorg#master",
-    "stellar-ledger-api": "2.0.2",
+    "stellar-ledger-api": "2.0.5",
     "stellar-sdk": "^0.7.3",
     "uri-templates": "^0.1.9",
     "urijs": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sass-loader": "^3.2.3",
     "solar-css": "git+https://github.com/stellar/solar#master",
     "solar-stellarorg": "git+https://github.com/stellar/solar-stellarorg#master",
-    "stellar-ledger-api": "1.1.3",
+    "stellar-ledger-api": "2.0.2",
     "stellar-sdk": "^0.7.3",
     "uri-templates": "^0.1.9",
     "urijs": "^1.16.0",


### PR DESCRIPTION
In version 2 of the Stellar Ledger app the hash-signing function has been removed so all operations are handled by the signTx function. Version 2 of the js library is backward compatible with version 1 of the Ledger app, but version 1 of the js library is not forward compatible with version 2 the app.