### PR TITLE
Added BIP path text field to transaction signer

### DIFF
--- a/src/actions/transactionSigner.js
+++ b/src/actions/transactionSigner.js
@@ -26,13 +26,19 @@ export function setSecrets(secrets) {
   };
 }
 
+export const SET_BIP_PATH = 'SET_BIP_PATH';
+export function setBIPPath(bipPath) {
+  return {
+    type: SET_BIP_PATH,
+    bipPath,
+  };
+}
+
 export const LEDGER_WALLET_SIGN_START = 'LEDGER_WALLET_SIGN_START';
 export const LEDGER_WALLET_SIGN_SUCCESS = 'LEDGER_WALLET_SIGN_SUCCESS';
 export const LEDGER_WALLET_SIGN_ERROR = 'LEDGER_WALLET_SIGN_ERROR';
 
-const DEFAULT_BIP = "44'/148'/0'";
-
-export function signWithLedger(txXDR) {
+export function signWithLedger(txXDR, bipPath) {
   return dispatch => {
     dispatch({ type: LEDGER_WALLET_SIGN_START });
 
@@ -56,8 +62,8 @@ export function signWithLedger(txXDR) {
 
     let onConnect = () => {
       BP.all([
-        ledgerApi.getPublicKey_async(DEFAULT_BIP),
-        ledgerApi.signTx_async(DEFAULT_BIP, transaction),
+        ledgerApi.getPublicKey_async(bipPath),
+        ledgerApi.signTx_async(bipPath, transaction),
       ]).then(results => {
         let {publicKey} = results[0];
         let {signature} = results[1];

--- a/src/components/FormComponents/BipPathPicker.js
+++ b/src/components/FormComponents/BipPathPicker.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import TextPicker from './TextPicker';
+
+export default function BipPathPicker(props) {
+  return <TextPicker
+    {...props}
+    placeholder={props.placeholder || "BIP path in format: 44'/148'/0'"}
+    validator={(value) => {
+      let regexp = /44'\/148'\/(\d+)'/;
+      let match = regexp.exec(value);
+      if (!(match && match[1].length > 0)) {
+        return "Invalid BIP path. Please provide it in format 44'/148'/x'. We call 44'/148'/0' the primary account";
+      }
+    }}
+    className={props.className}
+  />
+}

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -134,15 +134,13 @@ class TransactionSigner extends React.Component {
                     onUpdate={(value) => dispatch(setSecrets(value))}
                   />
                 </OptionsTablePair>
-                <OptionsTablePair label="BIP Path">
+                <OptionsTablePair label="Ledger Wallet">
                   <BipPathPicker
                     value={bipPath}
                     onUpdate={(value) => dispatch(setBIPPath(value))}
                   />
-                </OptionsTablePair>
-                <OptionsTablePair label="Ledger Wallet">
                   <button  
-                    className="s-button" 
+                    className="s-button TxSignerKeys__signBipPath"
                     onClick={() => {dispatch(signWithLedger(xdr, bipPath))}}
                   >Sign with BIP Path</button>
                   {ledgerwalletMessage}

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -6,12 +6,14 @@ import {
   importFromXdr,
   clearTransaction,
   setSecrets,
+  setBIPPath,
   signWithLedger,
 } from '../actions/transactionSigner';
 import {EasySelect} from './EasySelect';
 import OptionsTablePair from './OptionsTable/Pair';
 import SecretKeyPicker from './FormComponents/SecretKeyPicker';
 import MultiPicker from './FormComponents/MultiPicker';
+import BipPathPicker from './FormComponents/BipPathPicker';
 import {txPostLink, xdrViewer} from '../utilities/linkBuilder';
 import HelpMark from './HelpMark';
 import clickToSelect from '../utilities/clickToSelect';
@@ -25,7 +27,7 @@ import {signTransaction} from '../utilities/Libify';
 class TransactionSigner extends React.Component {
   render() {
     let {dispatch, networkObj} = this.props;
-    let {xdr, signers, ledgerwalletStatus} = this.props.state;
+    let {xdr, signers, bipPath, ledgerwalletStatus} = this.props.state;
     let content;
 
     if (validateTxXdr(xdr).result !== 'success') {
@@ -132,11 +134,17 @@ class TransactionSigner extends React.Component {
                     onUpdate={(value) => dispatch(setSecrets(value))}
                   />
                 </OptionsTablePair>
+                <OptionsTablePair label="BIP Path">
+                  <BipPathPicker
+                    value={bipPath}
+                    onUpdate={(value) => dispatch(setBIPPath(value))}
+                  />
+                </OptionsTablePair>
                 <OptionsTablePair label="Ledger Wallet">
                   <button  
                     className="s-button" 
-                    onClick={() => {dispatch(signWithLedger(xdr))}}
-                  >Sign with Default BIP Path</button>
+                    onClick={() => {dispatch(signWithLedger(xdr, bipPath))}}
+                  >Sign with BIP Path</button>
                   {ledgerwalletMessage}
                 </OptionsTablePair>
               </div>

--- a/src/reducers/transactionSigner.js
+++ b/src/reducers/transactionSigner.js
@@ -3,6 +3,7 @@ import {
   IMPORT_FROM_XDR,
   CLEAR_TRANSACTION,
   SET_SECRETS,
+  SET_BIP_PATH,
   LEDGER_WALLET_SIGN_START,
   LEDGER_WALLET_SIGN_ERROR,
   LEDGER_WALLET_SIGN_SUCCESS,
@@ -15,6 +16,7 @@ import SLUG from '../constants/slug';
 const transactionSigner = combineReducers({
   xdr,
   signers,
+  bipPath,
   ledgerwalletStatus,
 })
 
@@ -46,6 +48,18 @@ function signers(state = [], action) {
     return []
   case SET_SECRETS:
     return action.secrets
+  }
+  return state;
+}
+
+function bipPath(state = [], action) {
+  switch (action.type) {
+  case LOAD_STATE:
+  case IMPORT_FROM_XDR:
+  case CLEAR_TRANSACTION:
+    return "44'/148'/0'"
+  case SET_BIP_PATH:
+    return action.bipPath
   }
   return state;
 }

--- a/src/styles/_TxSignerKeys.scss
+++ b/src/styles/_TxSignerKeys.scss
@@ -1,5 +1,8 @@
+.TxSignerKeys__title {
+  font-size: $s-scale-3;
+  margin-bottom: 0.5em;
+}
 
-  .TxSignerKeys__title {
-    font-size: $s-scale-3;
-    margin-bottom: 0.5em;
-  }
+.TxSignerKeys__signBipPath {
+  margin-top: 0.5em;
+}


### PR DESCRIPTION
Adds support for any SEP-0005 path #193 by providing additional text field. Pre-filled with default value (44'/148'/0'). This field also has basic format validation. See attachment

![stellar_laboratory](https://user-images.githubusercontent.com/36910/36308209-ab51017a-1330-11e8-8b65-a04e276dc468.png)
