### PR TITLE
Fix Effect paging, specifically Effects for Transaction

### DIFF
--- a/src/data/endpoints.js
+++ b/src/data/endpoints.js
@@ -85,7 +85,7 @@ export const endpointsMap = {
         'helpUrl': 'https://www.stellar.org/developers/horizon/reference/effects-for-transaction.html',
         'method': 'GET',
         'path': {
-          template: '/transactions/{transaction}/effects',
+          template: '/transactions/{transaction}/effects{?cursor,limit,order}',
         },
         'setupComponent': require('../components/SetupPanes/ForTransaction'),
       }


### PR DESCRIPTION
As noted in #318 :

> When you see effect for selected transaction (e.g. https://goo.gl/47WXEq ) and click on _links:next:href, it brings you on the same page (page with empty effect is expected). When accessing the JSON directly, it works fine.

The reason for this error is that cursor/limit/order were not appended to the endpoint.

With this change, those params will now be added as intended.

Closes #318 