### PR TITLE
Add xdr type search field

### DIFF
--- a/src/actions/xdrViewer.js
+++ b/src/actions/xdrViewer.js
@@ -8,6 +8,14 @@ export function updateXdrInput(input) {
   }
 }
 
+export const UPDATE_XDR_TYPE_FILTER = 'UPDATE_XDR_TYPE_FILTER';
+export function updateXdrTypeFilter(filter) {
+  return {
+    type: UPDATE_XDR_TYPE_FILTER,
+    filter,
+  }
+}
+
 export const UPDATE_XDR_TYPE = 'UPDATE_XDR_TYPE';
 export function updateXdrType(xdrType) {
   return {

--- a/src/components/XdrViewer.js
+++ b/src/components/XdrViewer.js
@@ -2,12 +2,12 @@ import React from 'react';
 import {connect} from 'react-redux';
 import _ from 'lodash';
 import SelectPicker from './FormComponents/SelectPicker';
+import TextPicker from './FormComponents/TextPicker.js';
 import extrapolateFromXdr from '../utilities/extrapolateFromXdr';
 import TreeView from './TreeView';
 import validateBase64 from '../utilities/validateBase64';
-import {updateXdrInput, updateXdrType, fetchLatestTx} from '../actions/xdrViewer';
+import {updateXdrInput, updateXdrTypeFilter, updateXdrType, fetchLatestTx} from '../actions/xdrViewer';
 import NETWORK from '../constants/network';
-import {xdr} from 'stellar-sdk';
 
 function XdrViewer(props) {
   let {dispatch, state, baseURL} = props;
@@ -16,7 +16,7 @@ function XdrViewer(props) {
   let messageClass = validation.result === 'error' ? 'xdrInput__message__alert' : 'xdrInput__message__success';
   let message = <p className={messageClass}>{validation.message}</p>
 
-  let xdrTypeIsValid = _.indexOf(xdrTypes, state.type) >= 0;
+  let xdrTypeIsValid = _.indexOf(state.types, state.type) >= 0;
   let treeView, errorMessage;
   if (state.input === '') {
     errorMessage = <p>Enter a base-64 encoded XDR blob to decode.</p>;
@@ -53,11 +53,17 @@ function XdrViewer(props) {
         </div>
 
         <p className="XdrViewer__label">XDR type:</p>
+        <TextPicker
+          value={state.typeSearch}
+          placeholder="Search"
+          onUpdate={(value) => dispatch(updateXdrTypeFilter(value))}
+          className="XdrViewer__type_search"
+          />
         <SelectPicker
           value={state.type}
-          placeholder="Select XDR type"
+          placeholder={"Select XDR type"}
           onUpdate={(input) => dispatch(updateXdrType(input))}
-          items={xdrTypes}
+          items={state.types}
         />
       </div>
     </div>
@@ -77,8 +83,3 @@ function chooseState(state) {
     baseURL: NETWORK.available[state.network.current].url,
   }
 }
-
-// Array of all the xdr types. Then, the most common ones appear at the top
-// again for convenience
-let xdrTypes = _(xdr).functions().sort().value();
-xdrTypes = ['TransactionEnvelope', 'TransactionResult', 'TransactionMeta', '---'].concat(xdrTypes)

--- a/src/reducers/xdrViewer.js
+++ b/src/reducers/xdrViewer.js
@@ -1,11 +1,14 @@
 import {combineReducers} from 'redux';
-import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE} from '../actions/xdrViewer';
+import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE_FILTER, UPDATE_XDR_TYPE} from '../actions/xdrViewer';
 import {LOAD_STATE} from '../actions/routing';
+import {xdr} from 'stellar-sdk';
 import url from 'url';
 
 const routing = combineReducers({
   input,
   type,
+  types,
+  filter,
 });
 
 export default routing;
@@ -24,6 +27,15 @@ function input(state = '', action) {
   return state;
 }
 
+function filter(state = '', action) {
+  switch (action.type) {
+  case UPDATE_XDR_TYPE_FILTER:
+    return action.filter;
+  }
+
+  return state;
+}
+
 function type(state = 'TransactionEnvelope', action) {
   switch (action.type) {
   case LOAD_STATE:
@@ -33,7 +45,93 @@ function type(state = 'TransactionEnvelope', action) {
     break;
   case UPDATE_XDR_TYPE:
     return action.xdrType;
+  case UPDATE_XDR_TYPE_FILTER:
+    let matches = xdrTypeSearch(action.filter);
+    if (matches.length > 1) {
+      return matches[0];
+    }
+    break;
   }
 
   return state;
+}
+
+function types(state = [], action) {
+  switch (action.type) {
+  case LOAD_STATE:
+    return xdrTypes("");
+  case UPDATE_XDR_TYPE_FILTER:
+    return xdrTypes(action.filter);
+  }
+
+  return state;
+}
+
+let allXdrTypes = _(xdr).functions().sort().value();
+let commonXdrTypes = ['TransactionEnvelope', 'TransactionResult', 'TransactionMeta'];
+
+// All the xdr types.
+// Preceded by either the most common types or those that pass the filter.
+function xdrTypes(filter) {
+  let front = commonXdrTypes;
+  if (filter) {
+    let matches = xdrTypeSearch(filter);
+    front = matches.slice(0, 10);
+  }
+  return front.concat(['---']).concat(allXdrTypes)
+}
+
+function xdrTypeSearch(filter) {
+  if (!filter) {
+    return [];
+  }
+  return fuzzySearch(filter, allXdrTypes);
+}
+
+// fuzzysearch by qrtz/@github
+// https://github.com/qrtz/fuzzySearch/blob/master/lib/fuzzySearch.js
+function fuzzySearch(value, array, caseSensitive) {
+  var pattern = caseSensitive === true ? value : value.toLowerCase(),
+    patternLength = pattern.length;
+  return array.reduce(function(results, current) {
+    if (patternLength > current.length) {
+      return results
+    }
+
+    var lastIndex = -1,
+      start = -1,
+      str = caseSensitive === true ? current : current.toLowerCase();
+
+    for (var i = 0; i < patternLength; i++) {
+      lastIndex = str.indexOf(pattern.charAt(i), lastIndex + 1);
+
+      if (0 > lastIndex) {
+        break;
+      }
+
+      if (0 > start) {
+        start = lastIndex
+      }
+    }
+
+    if (-1 < lastIndex) {
+      results.push({
+        input: current,
+        length: lastIndex + 1 - start,
+        start: start
+      })
+    }
+    return results
+  }, []).sort(function(a, b) {
+    var diff = a.length - b.length;
+    if (0 === diff) {
+      diff = a.start - b.start;
+      if (0 === diff) {
+        return a.input.localeCompare(b.input);
+      }
+    }
+    return diff;
+  }).map(function(item) {
+    return item.input
+  });
 }

--- a/src/reducers/xdrViewer.js
+++ b/src/reducers/xdrViewer.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {combineReducers} from 'redux';
 import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE_FILTER, UPDATE_XDR_TYPE} from '../actions/xdrViewer';
 import {LOAD_STATE} from '../actions/routing';

--- a/src/styles/_XdrViewer.scss
+++ b/src/styles/_XdrViewer.scss
@@ -6,6 +6,10 @@
   border-bottom: 1px solid $s-color-neutral7;
   padding-bottom: 2em;
 }
-  .XdrViewer__label {
-    margin-bottom: 0.2em;
-  }
+.XdrViewer__label {
+  margin-bottom: 0.2em;
+}
+.XdrViewer__type_search {
+  width: 250px;
+  margin-bottom: 0.5em;
+}


### PR DESCRIPTION
Add a field for searching through the numerous XDR types. The top result from the fuzzy search is set as the active type, and the other results (up to 10) are put before the `---` in the type list.

The experience if you don't use the search field is unchanged.

Before typing
![image](https://user-images.githubusercontent.com/705646/39411738-4eac1234-4bde-11e8-9185-b24ac8174fab.png)

After typing
![image](https://user-images.githubusercontent.com/705646/39411739-514546aa-4bde-11e8-8ec9-c5e8c5564997.png)

