### PR TITLE
Add XDR Viewer link for transaction fee_meta_xdr field

### DIFF
--- a/src/utilities/linkHighlighterRules.js
+++ b/src/utilities/linkHighlighterRules.js
@@ -19,6 +19,9 @@ let linkHighlighterRules = {
   'result_meta_xdr': (value) => {
     return xdrViewer(value, 'TransactionMeta');
   },
+  'fee_meta_xdr': (value) => {
+    return xdrViewer(value, 'OperationMeta');
+  },
   'id': accountIdGenerator,
   'public_key': accountIdGenerator,
   'account_id': accountIdGenerator,


### PR DESCRIPTION
This links transaction `fee_meta_xdr` field to the XDR Viewer with the correct XDR type selected.