### PR TITLE
Use custom horizon/network

### DIFF
--- a/src/actions/network.js
+++ b/src/actions/network.js
@@ -1,15 +1,46 @@
-export const CHOOSE_NETWORK = "CHOOSE_NETWORK";
-export function chooseNetwork(name) {
-  return {
-    type: CHOOSE_NETWORK,
-    name
-  }
-}
+import NETWORK from '../constants/network';
 
 export const SET_NETWORKS = "SET_NETWORKS";
 export function setNetworks(networks) {
   return {
     type: SET_NETWORKS,
     networks
+  }
+}
+
+export const SHOW_MODAL = "SHOW_MODAL";
+export const HIDE_MODAL = "HIDE_MODAL";
+export function setModalVisibility(visible) {
+  return {
+    type: visible ? SHOW_MODAL : HIDE_MODAL
+  }
+}
+
+export const UPDATE_MODAL = "UPDATE_MODAL";
+export function updateModal(key, value) {
+  return {
+    type: UPDATE_MODAL,
+    key,
+    value
+  }
+}
+
+export const SET_PARAMS = "SET_PARAMS";
+export function chooseNetwork(name) {
+  return {
+    type: SET_PARAMS,
+    params: {
+      name,
+      horizonURL: NETWORK.available[name].horizonURL,
+      networkPassphrase: NETWORK.available[name].networkPassphrase,
+    }
+  }
+}
+
+export function setCustomParams(params) {
+  params.name = 'custom';
+  return {
+    type: SET_PARAMS,
+    params
   }
 }

--- a/src/components/EndpointExplorer.js
+++ b/src/components/EndpointExplorer.js
@@ -68,7 +68,7 @@ export default connect(chooseState)(EndpointExplorer)
 function chooseState(state) {
   return {
     state: state.endpointExplorer,
-    baseURL: NETWORK.available[state.network.current].url,
+    baseURL: state.network.current.horizonURL,
   };
 }
 

--- a/src/components/NetworkPicker.js
+++ b/src/components/NetworkPicker.js
@@ -1,28 +1,68 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {chooseNetwork} from "../actions/network";
+import {chooseNetwork, setModalVisibility, updateModal, setCustomParams} from "../actions/network";
 import NETWORK from '../constants/network';
+import TextPicker from './FormComponents/TextPicker.js';
 
 class NetworkPicker extends React.Component {
   render() {
     let {dispatch} = this.props;
-    let {currentName, currentURL, availableNames} = this.props;
+    let {current, modal} = this.props;
 
-    let items = availableNames.map(n => {
+    let items = Object.keys(NETWORK.available).map(n => {
       return <NetworkToggle
         name={n}
         key={n}
-        selected={currentName === n}
+        selected={current.name === n}
         onToggle={() => dispatch(chooseNetwork(n))}
         />
     })
 
     return <div className="NetworkPicker">
+      {modal.visible ?
+        <div className="overlay">
+          <div className="modal">
+            <div className="right"><a href="#" className="close" onClick={() => { dispatch(setModalVisibility(false)); return false; } }>&times;</a></div>
+            <div>
+              <p>Horizon URL:</p>
+              <TextPicker
+                value={modal.values.horizonURL}
+                validator={isValidHorizonURL}
+                onUpdate={(value) => dispatch(updateModal('horizonURL', value))}
+                />
+              <p>Network Passphrase:</p>
+              <TextPicker
+                value={modal.values.networkPassphrase}
+                onUpdate={(value) => dispatch(updateModal('networkPassphrase', value))}
+                />
+              <button className="s-button"
+                disabled={false}
+                onClick={() => dispatch(setCustomParams(modal.values))}
+                >Use network</button>
+            </div>
+          </div>
+        </div> : null
+      }
       <form className="s-buttonGroup NetworkPicker__buttonGroup">
         {items}
+        <NetworkToggle
+          name="custom"
+          key="custom"
+          selected={current.name === "custom"}
+          onToggle={() => dispatch(setModalVisibility(true))}
+          />
       </form>
-      <span className="NetworkPicker__url">{currentURL}</span>
+      <span className="NetworkPicker__url">{current.horizonURL}</span>
     </div>
+  }
+}
+
+const isValidHorizonURL = (u) => {
+  try {
+    new URL(u);
+    return true;
+  } catch (e) {
+    return "Value is not a valid URL";
   }
 }
 
@@ -44,8 +84,7 @@ export default connect(chooseState)(NetworkPicker);
 
 function chooseState(state) {
   return {
-    availableNames: Object.keys(NETWORK.available),
-    currentName:    state.network.current,
-    currentURL:     NETWORK.available[state.network.current].url,
+    current: state.network.current,
+    modal:   state.network.modal,
   };
 }

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -26,9 +26,11 @@ import {signTransaction} from '../utilities/Libify';
 
 class TransactionSigner extends React.Component {
   render() {
-    let {dispatch, networkObj} = this.props;
+    let {dispatch, networkPassphrase} = this.props;
     let {xdr, signers, bipPath, ledgerwalletStatus} = this.props.state;
     let content;
+
+    let networkObj = new Network(networkPassphrase)
 
     if (validateTxXdr(xdr).result !== 'success') {
       content = <div className="so-back">
@@ -45,6 +47,7 @@ class TransactionSigner extends React.Component {
       let transaction = new Transaction(xdr);
 
       let infoTable = {
+        'Signing for': <pre className="so-code so-code__wrap"><code>{networkPassphrase}</code></pre>,
         'Transaction Envelope XDR': <EasySelect plain={true}><pre className="so-code so-code__wrap"><code>{xdr}</code></pre></EasySelect>,
         'Transaction Hash': <EasySelect plain={true}><pre className="so-code so-code__wrap"><code>{transaction.hash().toString('hex')}</code></pre></EasySelect>,
         'Source account': transaction.source,
@@ -186,7 +189,7 @@ export default connect(chooseState)(TransactionSigner);
 function chooseState(state) {
   return {
     state: state.transactionSigner,
-    networkObj: NETWORK.available[state.network.current].networkObj,
+    networkPassphrase: state.network.current.networkPassphrase,
   }
 }
 

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -65,7 +65,7 @@ class sequenceFetcherClass extends React.Component {
   render() {
     let {attributes, sequenceFetcherError} = this.props.state;
     let dispatch = this.props.dispatch;
-    let currentNetwork = this.props.currentNetwork;
+    let horizonURL = this.props.horizonURL;
     if (!StrKey.isValidEd25519PublicKey(attributes.sourceAccount)) {
       return null;
     }
@@ -83,10 +83,11 @@ class sequenceFetcherClass extends React.Component {
       <a
         className="s-button"
         onClick={() => dispatch(
-          fetchSequence(attributes.sourceAccount, NETWORK.available[currentNetwork].url)
+          fetchSequence(attributes.sourceAccount, horizonURL)
         )}
         >Fetch next sequence number for account starting with "{truncatedAccountId}"</a>
       <br />
+      <small>Fetching from: <code>{horizonURL}</code></small><br />
       {sequenceErrorMessage}
     </p>
   }
@@ -96,6 +97,6 @@ let SequenceFetcher = connect(chooseState)(sequenceFetcherClass);
 function chooseState(state) {
   return {
     state: state.transactionBuilder,
-    currentNetwork: state.network.current,
+    horizonURL: state.network.current.horizonURL,
   }
 }

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
+import {Network} from 'stellar-sdk';
 import {PubKeyPicker} from './FormComponents/PubKeyPicker';
 import {EasySelect} from './EasySelect';
 import Libify from '../utilities/Libify';
@@ -30,7 +31,7 @@ export default class TxBuilderResult extends React.Component {
       errorTitleText = 'Form validation errors:';
       finalResult = formatErrorList(validationErrors);
     } else {
-      let transactionBuild = Libify.buildTransaction(attributes, operations, this.props.networkObj);
+      let transactionBuild = Libify.buildTransaction(attributes, operations, new Network(this.props.networkPassphrase));
 
       if (transactionBuild.errors.length > 0) {
         errorTitleText = `Transaction building errors:`;
@@ -38,6 +39,8 @@ export default class TxBuilderResult extends React.Component {
       } else {
         successTitleText = `Success! Transaction Envelope XDR:`;
         finalResult = <div>
+          Network Passphrase:<br />
+          {this.props.networkPassphrase}<br />
           Hash:<br />
           {transactionBuild.hash}<br />
           XDR:<br />
@@ -79,7 +82,7 @@ export default connect(chooseState)(TxBuilderResult);
 function chooseState(state) {
   return {
     state: state.transactionBuilder,
-    networkObj: NETWORK.available[state.network.current].networkObj,
+    networkPassphrase: state.network.current.networkPassphrase,
   }
 }
 

--- a/src/components/XdrViewer.js
+++ b/src/components/XdrViewer.js
@@ -74,7 +74,7 @@ export default connect(chooseState)(XdrViewer);
 function chooseState(state) {
   return {
     state: state.xdrViewer,
-    baseURL: NETWORK.available[state.network.current].url,
+    baseURL: state.network.current.horizonURL,
   }
 }
 

--- a/src/constants/network.js
+++ b/src/constants/network.js
@@ -3,12 +3,12 @@ import {Network, Networks} from 'stellar-sdk';
 const NETWORK = {
   available: {
     test: {
-      url: 'https://horizon-testnet.stellar.org',
-      networkObj: new Network(Networks.TESTNET),
+      horizonURL: 'https://horizon-testnet.stellar.org',
+      networkPassphrase: Networks.TESTNET
     },
     public: {
-      url: 'https://horizon.stellar.org',
-      networkObj: new Network(Networks.PUBLIC),
+      horizonURL: 'https://horizon.stellar.org',
+      networkPassphrase: Networks.PUBLIC
     }
   },
   defaultName: 'test',

--- a/src/reducers/network.js
+++ b/src/reducers/network.js
@@ -1,22 +1,56 @@
 import {combineReducers} from "redux";
-import {CHOOSE_NETWORK} from "../actions/network";
+import {CHOOSE_NETWORK, SET_PARAMS, SHOW_MODAL, HIDE_MODAL, UPDATE_MODAL} from "../actions/network";
 import NETWORK from '../constants/network';
 import {LOAD_STATE} from '../actions/routing';
 
-const network = combineReducers({ current });
+let defaultNetwork = {
+  name: NETWORK.defaultName,
+  horizonURL: NETWORK.available[NETWORK.defaultName].horizonURL,
+  networkPassphrase: NETWORK.available[NETWORK.defaultName].networkPassphrase
+};
 
-export default network;
-
-function current(state=NETWORK.defaultName, action) {
+let current = (state=defaultNetwork, action) => {
   switch(action.type) {
     case LOAD_STATE:
+      if (action.queryObj.network == "custom") {
+        return {
+          name: action.queryObj.network,
+          horizonURL: action.queryObj.horizonURL,
+          networkPassphrase: action.queryObj.networkPassphrase
+        }
+      }
+
       if (action.queryObj.network && NETWORK.available[action.queryObj.network]) {
-        return action.queryObj.network;
+        return Object.assign({name: action.queryObj.network}, NETWORK.available[action.queryObj.network]);
       }
       return state;
-    case CHOOSE_NETWORK:
-      return action.name;
+    case SET_PARAMS:
+      return action.params;
     default:
       return state;
   }
 }
+
+function modal(state={visible: false, values: {}}, action) {
+  switch(action.type) {
+    case SHOW_MODAL:
+      return Object.assign({}, state, {visible: true});
+    case HIDE_MODAL:
+      return Object.assign({}, state, {visible: false});
+    case SET_PARAMS:
+      return {visible: false, values: Object.assign({}, action.params)};
+    case UPDATE_MODAL:
+      let values = state.values;
+      values[action.key] = action.value
+      return {visible: true, values};
+    default:
+      return state;
+  }
+}
+
+const network = combineReducers({
+  current,
+  modal
+});
+
+export default network;

--- a/src/styles/_NetworkPicker.scss
+++ b/src/styles/_NetworkPicker.scss
@@ -17,3 +17,74 @@
   font-size: $s-scale-5;
   color: $s-color-neutral3;
 }
+
+.NetworkPicker .overlay {
+  position: fixed;
+  z-index: 100;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  -webkit-animation: fadein 0.4s;
+     -moz-animation: fadein 0.4s;
+      -ms-animation: fadein 0.4s;
+       -o-animation: fadein 0.4s;
+          animation: fadein 0.4s;
+
+  &.visible {
+    display: block;
+  }
+}
+
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@-moz-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@-webkit-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@-ms-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@-o-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.NetworkPicker .overlay .modal {
+  font-weight: 300;
+  margin: 10% auto;
+  padding: 20px;
+  width: 470px;
+  border: 2px solid #CCCCCC;
+  background-color: white;
+  color: #586A73;
+  box-shadow: 0 0 80px #dddddd;
+  border-radius: 3px;
+
+  .right {
+    float: right;
+  }
+
+  p, button {
+    margin-top: 1em;
+  }
+
+  a.close {
+    color: #000000;
+    font-size: 25px;
+    line-height: 20px;
+    text-decoration: none;
+  }
+}

--- a/src/utilities/stateSerializer.js
+++ b/src/utilities/stateSerializer.js
@@ -27,10 +27,16 @@ export function stateToQueryObj(slug, state) {
 
 function serializeNetworkState(state) {
   // Only return something if we were passed the current network
-  if (_.has(state, 'network.current')) {
-    return {
-      network: state.network.current,
+  if (_.has(state, 'network')) {
+    if (state.network.current.name == "custom") {
+      return {
+        network: state.network.current.name,
+        horizonURL: state.network.current.horizonURL,
+        networkPassphrase: state.network.current.networkPassphrase
+      }
     }
+
+    return {network: state.network.current.name}
   }
   return {};
 }


### PR DESCRIPTION
Allows setting current Horizon/Network passphrase to custom values:

![screen shot 2018-07-13 at 18 50 32](https://user-images.githubusercontent.com/464938/42703806-f843f9ea-86cd-11e8-92a4-61ebbc36bcf9.png)

It required changing how `state.network` looks like and the value is checked in many places in the application. I think I updated all the usages but please run the code on your local machine and try to break it (and check look&feel) when doing a review.

Close #176.
Close #173.