### PR TITLE
Add signature verification to xdr viewer for transaction envelopes

### DIFF
--- a/src/actions/xdrViewer.js
+++ b/src/actions/xdrViewer.js
@@ -1,4 +1,6 @@
+import {xdr, hash, StrKey, Network, Keypair} from 'stellar-sdk';
 import axios from 'axios';
+import SIGNATURE from '../constants/signature';
 
 export const UPDATE_XDR_INPUT = 'UPDATE_XDR_INPUT';
 export function updateXdrInput(input) {
@@ -17,13 +19,100 @@ export function updateXdrType(xdrType) {
 }
 
 export const FETCH_LATEST_TX = 'FETCH_LATEST_TX';
-export function fetchLatestTx(horizonBaseUrl) {
+export function fetchLatestTx(horizonBaseUrl, networkPassphrase) {
   return dispatch => {
     axios.get(horizonBaseUrl + '/transactions?limit=1&order=desc')
       .then(r => {
-        dispatch(updateXdrInput(r.data._embedded.records[0].envelope_xdr))
+        const xdr = r.data._embedded.records[0].envelope_xdr;
+        dispatch(updateXdrInput(xdr))
         dispatch(updateXdrType('TransactionEnvelope'))
+        dispatch(fetchSigners(xdr, horizonBaseUrl, networkPassphrase))
       })
       .catch(r => dispatch({type: FETCH_SEQUENCE_FAIL, payload: r}))
   }
+}
+
+export const FETCHED_SIGNERS_SUCCESS = 'FETCHED_SIGNERS_SUCCESS';
+export const FETCHED_SIGNERS_FAIL = 'FETCHED_SIGNERS_FAIL';
+export const FETCHED_SIGNERS_START = 'FETCHED_SIGNERS_START';
+export function fetchSigners(input, horizonBaseUrl, networkPassphrase) {
+  return dispatch => {
+    dispatch({ type: FETCHED_SIGNERS_START });
+    try {
+      // Capture network for determining signature base
+      StellarSdk.Network.use(new Network(networkPassphrase));
+
+      let tx = new StellarSdk.Transaction(input);
+      const hashedSignatureBase = hash(tx.signatureBase());
+
+      // Extract all signatures on transaction
+      const signatures = tx.signatures.map(x => ({ sig: x.signature() }));
+
+      // Extract all source accounts from transaction (base transaction and all operations)
+      let sourceAccounts = {};
+  
+      let baseAccountId = tx.source;
+      sourceAccounts[baseAccountId] = true;
+      
+      tx.operations.forEach(op => {
+        if (op.source) {
+          sourceAccounts[op.source] = true;
+        }
+      });
+
+      // Get all signers per source account - array of promises
+      sourceAccounts = Object.keys(sourceAccounts).map(accountID => axios.get(horizonBaseUrl + '/accounts/' + accountID));
+
+      Promise.all(sourceAccounts)
+      .then(response => {
+        let allSigners = {};
+        response.forEach(r => r.data.signers.forEach(signer => allSigners[signer.key] = signer));
+
+        allSigners = Object.values(allSigners);
+        
+        // We are only interested in checking if each of the signatures can be verified for some valid
+        // signer for any of the source accounts in the transaction -- we are not taking into account
+        // weights, or even if this signer makes sense.
+        for (var i = 0; i < signatures.length; i ++) {
+          const sigObj = signatures[i];
+          let isValid = false;
+
+          for (var j = 0; j < allSigners.length; j ++) {
+            const signer = allSigners[j];
+            
+            // By nature of pre-authorized transaction, we won't ever receive a pre-auth
+            // tx hash in signatures array, so we can ignore pre-authorized transactions here.
+            switch (signer.type) {
+              case 'sha256_hash':
+                const hashXSigner = StrKey.decodeSha256Hash(signer.key);
+                const hashXSignature = hash(sigObj.sig);
+                isValid = hashXSigner.equals(hashXSignature);
+                break;
+              case 'ed25519_public_key':
+                const keypair = Keypair.fromPublicKey(signer.key);
+                isValid = keypair.verify(hashedSignatureBase, sigObj.sig);
+                break;
+            }
+
+            if (isValid) {
+              break;
+            }
+          }
+
+          sigObj.isValid = isValid ? SIGNATURE.VALID : SIGNATURE.INVALID;
+        }
+        dispatch({
+          type: FETCHED_SIGNERS_SUCCESS,
+          result: signatures,
+        });
+      })
+      .catch(e => {
+        console.error(e);
+        dispatch({ type: FETCHED_SIGNERS_FAIL })
+      });
+    } catch(e) {
+      console.error(e);
+      dispatch({ type: FETCHED_SIGNERS_FAIL });
+    }
+  };
 }

--- a/src/components/TreeView.js
+++ b/src/components/TreeView.js
@@ -4,26 +4,29 @@
 import React from 'react';
 import _ from 'lodash';
 import {EasySelect} from './EasySelect';
+import SIGNATURE from '../constants/signature';
 
 // @param {array} props.nodes - Array of TreeView compatible nodes
 export default class TreeView extends React.Component {
   render() {
-    let {nodes, className} = this.props;
+    let {nodes, className, fetchedSigners, parent} = this.props;
     let rootClass = 'TreeView ' + (className) ? className : '';
 
     let result = <div className={rootClass}>
       {_.map(Array.prototype.slice.call(nodes), (node, index) => {
         let childNodes;
 
+        let position = getPosition(node, parent);
+        
         if (typeof node.nodes !== 'undefined') {
           childNodes = <div className="TreeView__child">
-            <TreeView nodes={node.nodes} />
+           <TreeView nodes={node.nodes} fetchedSigners={fetchedSigners} parent={position} />
           </div>;
         }
 
         return <div className="TreeView__set" key={index}>
           <div className="TreeView__row" key={index + node.type}>
-            <RowValue node={node} />
+            <RowValue node={node} position={position} fetchedSigners={fetchedSigners} />
           </div>
           {childNodes}
         </div>
@@ -35,8 +38,8 @@ export default class TreeView extends React.Component {
 }
 
 function RowValue(props) {
-  let value, childNodes, separatorNeeded, separator;
-  let {node} = props;
+  let value, separatorNeeded, separator;
+  let {node, position, fetchedSigners} = props;
 
   if (typeof node.value === 'string') {
     value = String(node.value);
@@ -56,7 +59,41 @@ function RowValue(props) {
     separator = ': ';
   }
 
+  if (position === 'TransactionEnvelope.signatures') {
+    checkSignatures(node, fetchedSigners);
+    return formatSignatureCheckState(node, separator)
+  }
+
+  if (position.match(/^TransactionEnvelope\.signatures\[[0-9]+\]\.signature$/)) {
+    return formatSignature(node, separator);
+  }
+
   return <span><strong>{node.type}</strong>{separator}{value}</span>
+}
+
+function checkSignatures(signatures, fetchedSigners) {
+  // catch fetch signature errors
+  if (fetchedSigners === null || fetchedSigners === "PENDING") {
+    signatures.state = SIGNATURE.NOT_VERIFIED_YET;
+    return
+  } else if (fetchedSigners === "ERROR") {
+    signatures.state = SIGNATURE.INVALID;
+    return
+  }
+  
+  signatures.state = SIGNATURE.VALID;
+
+  for (var i = 0; i < signatures.nodes.length; i ++) {
+    const sig = signatures.nodes[i].nodes.find(n => n.type == 'signature');
+    const fetchedSignature = fetchedSigners.find(x => x.sig.equals(sig.value.raw));
+    
+    let isValid = SIGNATURE.NOT_VERIFIED_YET;
+    if (fetchedSignature) {
+      isValid = fetchedSignature.isValid;
+    }
+
+    sig.value.isValid = isValid;
+  }
 }
 
 // Types values are values that will be displayed with special formatting to
@@ -70,4 +107,47 @@ function convertTypedValue({type, value}) {
   case 'amount':
     return <span>{value.parsed} (raw: <code>{value.raw}</code>)</span>;
   }
+}
+
+// Calculating position within xdr tree allows for awareness of location.
+// This is useful for many things, for example, adding visual indicators for
+// signature verification.
+function getPosition(node, parent) {
+  let sep = '.';
+
+  if (!parent || node.type.charAt(0) == '[') {
+    sep = '';
+  }
+
+  return (parent ? parent + sep : '') + node.type;
+}
+
+// Signatures have a special verification feature, so they require a 
+// richer formating with ternary based coloring based on whether the
+// signature is valid for one of the signers related to the transaction
+// envelope.
+function formatSignature(node, separator) {
+  let style = {color: "black"};
+  let symbol = '';
+  if (node.value.isValid === SIGNATURE.INVALID) {
+    style = {color: "red"};
+    symbol = ' ❌ ';
+  } else if (node.value.isValid === SIGNATURE.VALID) {
+    style = {color: "green"};
+    symbol = ' ✅ ';
+  }
+  return <span style={style}><strong>{node.type}</strong>{separator}{node.value.value} {symbol}</span>
+}
+
+// Signature fetch may exist in three different states so it requires 
+// richer formating with ternary based coloring based on whether the
+// state is valid (VALID), is pending (NOT_VERIFIED_YET), or has errored (INVALID).
+function formatSignatureCheckState(node, separator) {
+  let message = "";
+  if (node.state === SIGNATURE.INVALID) {
+    message = <span style={{color: "red"}}> Error checking signatures...</span>;
+  } else if (node.state === SIGNATURE.NOT_VERIFIED_YET) {
+    message = <span style={{fontStyle: "italic"}}> Checking signatures...</span>;
+  }
+  return <span><strong>{node.type}</strong>{separator}{node.value}{message}</span>
 }

--- a/src/components/XdrViewer.js
+++ b/src/components/XdrViewer.js
@@ -5,12 +5,11 @@ import SelectPicker from './FormComponents/SelectPicker';
 import extrapolateFromXdr from '../utilities/extrapolateFromXdr';
 import TreeView from './TreeView';
 import validateBase64 from '../utilities/validateBase64';
-import {updateXdrInput, updateXdrType, fetchLatestTx} from '../actions/xdrViewer';
-import NETWORK from '../constants/network';
+import {updateXdrInput, updateXdrType, fetchLatestTx, fetchSigners} from '../actions/xdrViewer';
 import {xdr} from 'stellar-sdk';
 
 function XdrViewer(props) {
-  let {dispatch, state, baseURL} = props;
+  let {dispatch, state, baseURL, networkPassphrase} = props;
 
   let validation = validateBase64(state.input);
   let messageClass = validation.result === 'error' ? 'xdrInput__message__alert' : 'xdrInput__message__success';
@@ -18,17 +17,22 @@ function XdrViewer(props) {
 
   let xdrTypeIsValid = _.indexOf(xdrTypes, state.type) >= 0;
   let treeView, errorMessage;
-  if (state.input === '') {
+  if (state.input === '') { 
     errorMessage = <p>Enter a base-64 encoded XDR blob to decode.</p>;
   } else if (!xdrTypeIsValid) {
     errorMessage = <p>Please select a XDR type</p>;
   } else {
     try {
-      treeView = <TreeView nodes={extrapolateFromXdr(state.input, state.type)} />
+      treeView = <TreeView nodes={extrapolateFromXdr(state.input, state.type)} fetchedSigners={state.fetchedSigners} />
     } catch (e) {
       console.error(e)
       errorMessage = <p>Unable to decode input as {state.type}</p>;
     }
+  }
+
+  // Fetch signers on initial load
+  if (state.type === "TransactionEnvelope" && state.fetchedSigners === null) {
+    dispatch(fetchSigners(state.input, baseURL, networkPassphrase))
   }
 
   return <div>
@@ -39,13 +43,18 @@ function XdrViewer(props) {
           <p>The XDR Viewer is a tool that displays contents of a Stellar XDR blob in a human readable format.</p>
         </div>
         <p className="XdrViewer__label">
-          Input a base-64 encoded XDR blob, or <a onClick={() => dispatch(fetchLatestTx(baseURL))}>fetch the latest transaction to try it out</a>:
+        Input a base-64 encoded XDR blob, or <a onClick={() => dispatch(fetchLatestTx(baseURL, networkPassphrase))}>fetch the latest transaction to try it out</a>:
         </p>
         <div className="xdrInput__input">
           <textarea
             value={state.input}
             className="xdrInput__input__textarea"
-            onChange={(event) => dispatch(updateXdrInput(event.target.value))}
+            onChange={(event) => {
+              dispatch(updateXdrInput(event.target.value));
+              if (state.type === "TransactionEnvelope") {
+                dispatch(fetchSigners(event.target.value, baseURL, networkPassphrase))
+              }
+            }}
             placeholder="Example: AAAAAGXNhB2hIkbP//jgzn4os/AAAAZAB+BaLPAAA5Q/xL..."></textarea>
         </div>
         <div className="xdrInput__message">
@@ -75,6 +84,7 @@ function chooseState(state) {
   return {
     state: state.xdrViewer,
     baseURL: state.network.current.horizonURL,
+    networkPassphrase: state.network.current.networkPassphrase
   }
 }
 

--- a/src/constants/signature.js
+++ b/src/constants/signature.js
@@ -1,0 +1,9 @@
+// This standardizes all the signature verification states
+// into a single map.
+const SIGNATURE = {
+    NOT_VERIFIED_YET: 0,
+    INVALID: 1,
+    VALID: 2,
+  };
+  export default SIGNATURE;
+  

--- a/src/reducers/xdrViewer.js
+++ b/src/reducers/xdrViewer.js
@@ -1,11 +1,11 @@
 import {combineReducers} from 'redux';
-import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE} from '../actions/xdrViewer';
+import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE, FETCHED_SIGNERS_SUCCESS, FETCHED_SIGNERS_FAIL, FETCHED_SIGNERS_START} from '../actions/xdrViewer';
 import {LOAD_STATE} from '../actions/routing';
-import url from 'url';
 
 const routing = combineReducers({
   input,
   type,
+  fetchedSigners,
 });
 
 export default routing;
@@ -35,5 +35,17 @@ function type(state = 'TransactionEnvelope', action) {
     return action.xdrType;
   }
 
+  return state;
+}
+
+function fetchedSigners(state = null, action) {
+  switch (action.type) {
+  case FETCHED_SIGNERS_SUCCESS:
+    return action.result;
+  case FETCHED_SIGNERS_FAIL:
+    return "ERROR";
+  case FETCHED_SIGNERS_START:
+    return "PENDING";
+  }
   return state;
 }

--- a/src/utilities/extrapolateFromXdr.js
+++ b/src/utilities/extrapolateFromXdr.js
@@ -150,8 +150,9 @@ function getValue(object, name) {
     return object.toString();
   }
 
+
   if (object && object._isBuffer) {
-    return {type: 'code', value: new Buffer(object).toString('base64')};
+    return {type: 'code', raw: object, value: new Buffer(object).toString('base64')};
   }
 
   if (typeof object === 'undefined') {


### PR DESCRIPTION
This may need some work making it proper React code. It also might need some touchup on design. I kept it pretty simple.

Basically, whenever the user types or pastes in an xdr of type `Transaction Envelope`, this will asynchronously query for all signers on that transaction (base source account and all operation source accounts). It will then, for each signature on the transaction check to see if it is valid for a given signer -- the red means invalid, green means valid, and during loading, black means not yet loaded.

Here is what it looks like for a transaction has two valid signers and one invalid signer:
<img width="594" alt="screen shot 2018-08-06 at 4 28 44 pm" src="https://user-images.githubusercontent.com/16689974/43745951-50ca1ac4-9996-11e8-8701-91c9b44c8468.png">

Closes #343 