### PR TITLE
Fix streaming error

### DIFF
--- a/src/actions/endpointExplorer.js
+++ b/src/actions/endpointExplorer.js
@@ -90,7 +90,6 @@ function httpRequest(request) {
 }
 
 function streamingRequest(url, onmessage) {
-  var callBuilder = new CallBuilder();
-  callBuilder.url = URI(url);
+  var callBuilder = new CallBuilder(URI(url));
   return callBuilder.stream({onmessage});
 }


### PR DESCRIPTION
Verbatim from my comment on the issue:


As part of [new CallBuilder](https://github.com/stellar/js-stellar-sdk/blob/master/src/call_builder.js#L21) we call:
```javascript
this.url.segment()
```

which causes the following error:
```shell
Uncaught TypeError: Cannot read property 'segment' of undefined
```

since we are trying to call a function on an undefined property (no url until added in the next line). Fixed if we just specify the url as part of the initial `CallBuilder` instantiation.

Closes #349 