### PR TITLE
Fix setOptions unselected errors

### DIFF
--- a/src/components/FormComponents/FlagfieldPicker.js
+++ b/src/components/FormComponents/FlagfieldPicker.js
@@ -64,7 +64,7 @@ function intToExistenceArray(inputInt) {
 function existenceArrayToInt(existenceArray) {
   return _.reduce(existenceArray, (result, intValue) => {
     return result | parseInt(intValue);
-  }, 0);
+  }, undefined);
 }
 
 function isInteger(input) {

--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -49,7 +49,7 @@ let castIntOrUndefined = function(value) {
   if (typeof value === 'number') {
     return value;
   }
-  if (_.isString(value) && value.match(/^[0-9]*$/g)) {
+  if (value !== '' && _.isString(value) && value.match(/^[0-9]*$/g)) {
     return Number(value);
   }
   return undefined;


### PR DESCRIPTION
Fixes two issues:

1. When unselecting master weight, or thresholds, it defaulted to zero instead of undefined (#351 )
2. When unselecting flags, it defaulted to zero instead of undefined

Closes #351 