### PR TITLE
Refine metrics

### DIFF
--- a/src/metricsHandlers/README.md
+++ b/src/metricsHandlers/README.md
@@ -59,6 +59,9 @@ For purposes of improving the tools we provide our users, we track some metrics 
   * (no properties)
 * removed operation
   * (no properties)
+* changed operation attributes
+  * changedAttributes
+  * operationType
 * began signing transaction
   * operations
 * view XDR

--- a/src/metricsHandlers/README.md
+++ b/src/metricsHandlers/README.md
@@ -47,6 +47,9 @@ For purposes of improving the tools we provide our users, we track some metrics 
   * detail
   * extras
   * status
+* clicked internal link
+  * resource
+  * endpoint
 
 ## Transaction builder
 

--- a/src/metricsHandlers/endpointExplorer.js
+++ b/src/metricsHandlers/endpointExplorer.js
@@ -4,6 +4,7 @@ import {
   UPDATE_REQUEST,
   ERROR_REQUEST
 } from '../actions/endpointExplorer'
+import {LOAD_STATE} from '../actions/routing';
 import {logEvent} from '../utilities/metrics'
 
 const metricsEvents = {
@@ -65,6 +66,17 @@ export default function endpointExplorerMetrics(state, action) {
         status
       })
       return;
+    }
+
+    case LOAD_STATE: {
+      // If we're on the txbuilder and loading state, we might be transitioning
+      // to another feature with a complete transaction.
+      if (payload.slug === "explorer") {
+        logEvent(metricsEvents.signTransaction, {
+          endpoint: payload.endpoint,
+          resource: payload.resource
+        });
+      }
     }
   }
 }

--- a/src/metricsHandlers/transactionBuilder.js
+++ b/src/metricsHandlers/transactionBuilder.js
@@ -1,7 +1,9 @@
+import debounce from 'lodash/debounce'
 import {
   ADD_OPERATION,
   REMOVE_OPERATION,
   UPDATE_OPERATION_TYPE,
+  UPDATE_OPERATION_ATTRIBUTES,
 } from '../actions/transactionBuilder'
 import {logEvent} from '../utilities/metrics'
 import { LOAD_STATE } from '../actions/routing';
@@ -10,9 +12,14 @@ const metricsEvents = {
   changeOperation: 'transaction builder: changed operation type',
   addOperation: 'transaction builder: added operation',
   removeOperation: 'transaction builder: removed operation',
+  updateAttributes: 'transaction builder: changed operation attributes',
   signTransaction: 'transaction builder: began signing transaction',
   viewTransaction: 'transaction builder: view XDR'
 }
+
+// "Update attribute" events might fire in quick succession as somebody types
+// information in. Aggressively debounce it to minimize duplicates.
+const slowLogEvent = debounce(logEvent, 3000)
 
 export default function networkMetrics(state, action) {
   const {type, ...payload} = action
@@ -29,6 +36,15 @@ export default function networkMetrics(state, action) {
     }
     case REMOVE_OPERATION: {
       logEvent(metricsEvents.removeOperation)
+      return;
+    }
+    case UPDATE_OPERATION_ATTRIBUTES: {
+      slowLogEvent(metricsEvents.updateAttributes, {
+        changedAttributes: Object.keys(payload.newAttributes),
+        operationType: (state.transactionBuilder.operations.find(
+          o => o.id === payload.opId
+        ) || {name: ''}).name
+      })
       return;
     }
     case LOAD_STATE: {


### PR DESCRIPTION
* Track what links people click in endpoint explorer
* Track what attributes are changed in transaction builder

This is mainly to see how `setOptions` is used, but should help us figure out what optional properties are used for other operations.