### PR TITLE
Include the babel-polyfill

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,7 @@
 require("./styles/main.scss");
 
+import 'babel-polyfill';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {createStore, applyMiddleware} from 'redux';


### PR DESCRIPTION
Unable to run in development due to regeneratorRuntime errors. The babel-polyfill fixes this issue and you already have it in the package.json. You just need to include it in the project.

![Screen Shot 2019-05-31 at 9 25 18 AM](https://user-images.githubusercontent.com/4383610/58709024-3389c000-8387-11e9-8cd1-b4c134af150a.png)
