### PR TITLE
Fix public path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var webpackOptions = {
     vendor: ["axios", "react", "react-dom", "lodash", "stellar-sdk"]
   },
   output: {
-    publicPath: '/laboratory'
+    publicPath: '/laboratory/'
   },
   devtool: "source-map",
   resolve: {


### PR DESCRIPTION
The public path was being prepended without a slash for the fonts, causing an incorrect path.