### PR TITLE
bugfix/394 > options <select> color to be darker for firefox

### DIFF
--- a/src/styles/_Reskin.scss
+++ b/src/styles/_Reskin.scss
@@ -53,6 +53,12 @@ input, textarea, select, .so-dropdown__select {
   border-color: $gray;
 }
 
+.so-dropdown__select {
+  option {
+    color: #3a3f43;
+  }
+}
+
 .buttonList__item.buttonList__item {
   background-color: transparent;
   border-color: transparent;


### PR DESCRIPTION
Chrome and Safari use their default webkit styling which explains why this light color only affected firefox.

Fixes #394 