### PR TITLE
Friendbot should be disabled on non-test networks

### DIFF
--- a/src/components/AccountCreator.js
+++ b/src/components/AccountCreator.js
@@ -6,6 +6,7 @@ import {
   updateFriendbotTarget,
   startFriendbotRequest,
 } from '../actions/accountCreator';
+import NETWORK from '../constants/network';
 import {CodeBlock} from './CodeBlock';
 import {addEventHandler} from '../utilities/metrics'
 import accountCreatorMetrics from '../metricsHandlers/accountCreator'
@@ -16,6 +17,9 @@ class AccountCreator extends React.Component {
   render() {
     let {state, dispatch} = this.props;
     let keypairTable, keypairGeneratorLink, friendbotResultCodeblock;
+
+    const IS_TESTNET = this.props.baseURL === NETWORK.available.test.horizonURL;
+
     if (state.keypairGeneratorResult !== null) {
       keypairTable = <div className="simpleTable AccountCreator__generator__table">
         <div className="simpleTable__row">
@@ -35,10 +39,8 @@ class AccountCreator extends React.Component {
       friendbotResultCodeblock = <CodeBlock className="AccountCreator__spaceTop" code={state.friendbotStatus.code} language="json" />
     }
 
-
     let friendbotMessage;
     if (state.friendbotStatus.message) {
-
       let messageAlertType;
       if (state.friendbotStatus.status === 'loading') {
         messageAlertType = 's-alert--info';
@@ -65,27 +67,31 @@ class AccountCreator extends React.Component {
           {keypairGeneratorLink}
         </div>
       </div>
-      <div className="so-back AccountCreator__separator">
-      </div>
-      <div className="so-back AccountCreator__section">
-        <div className="so-chunk">
-          <h3>2. Friendbot: Fund a test network account</h3>
-          <p>The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network.</p>
 
-          <PubKeyPicker
-            className="picker--spaceBottom"
-            value={state.friendbotTarget}
-            onUpdate={(accountId) => {
-              dispatch(updateFriendbotTarget(accountId))
-            }} />
-          <button className="s-button"
-            disabled={state.friendbotTarget.length === 0}
-            onClick={() => dispatch(startFriendbotRequest(state.friendbotTarget))}
-            >Get test network lumens</button>
-          {friendbotMessage}
-          {friendbotResultCodeblock}
+      {IS_TESTNET && (
+        <div>
+          <div className="so-back AccountCreator__separator"></div>
+          <div className="so-back AccountCreator__section">
+            <div className="so-chunk">
+              <h3>2. Friendbot: Fund a test network account</h3>
+              <p>The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network.</p>
+
+              <PubKeyPicker
+                className="picker--spaceBottom"
+                value={state.friendbotTarget}
+                onUpdate={(accountId) => {
+                  dispatch(updateFriendbotTarget(accountId))
+                }} />
+              <button className="s-button"
+                disabled={state.friendbotTarget.length === 0}
+                onClick={() => dispatch(startFriendbotRequest(state.friendbotTarget))}
+                >Get test network lumens</button>
+              {friendbotMessage}
+              {friendbotResultCodeblock}
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   }
 }
@@ -94,5 +100,6 @@ export default connect(chooseState)(AccountCreator);
 function chooseState(state) {
   return {
     state: state.accountCreator,
+    baseURL: state.network.current.horizonURL,
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/stellar/laboratory/issues/380

* Find out if the network the user is on is either test or public via comparing `constant/network.js` to the network field of the redux state this component receives.