### PR TITLE
Fix Netlify PR preview builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 yarn-error.log
 .env
+out

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/ /laboratory

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "webpack-dev-server --config ./webpack.config.dev.js",
     "build": "webpack --config webpack.config.prod.js",
-    "build:netlify": "yarn build; mkdir out; mkdir out/laboratory; mv dist/* out/laboratory; cp _redirects out/redirects",
+    "build:netlify": "yarn build; mkdir out; mkdir out/laboratory; mv dist/* out/laboratory; cp _redirects out/_redirects",
     "test": "mocha './test/**/*.js'"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "webpack-dev-server --config ./webpack.config.dev.js",
     "build": "webpack --config webpack.config.prod.js",
-    "build:netlify": "yarn build; mkdir out; mkdir out/laboratory; mv dist/* out/laboratory",
+    "build:netlify": "yarn build; mkdir out; mkdir out/laboratory; mv dist/* out/laboratory; cp _redirects out/redirects",
     "test": "mocha './test/**/*.js'"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "webpack-dev-server --config ./webpack.config.dev.js",
     "build": "webpack --config webpack.config.prod.js",
+    "build:netlify": "yarn build; mkdir out; mkdir out/laboratory; mv dist/* out/laboratory",
     "test": "mocha './test/**/*.js'"
   },
   "dependencies": {


### PR DESCRIPTION
The netlify preview currently doesn't work because the app expects to be served from `/laboratory`, and netlify wants to serve it from the root. This changes the build so it copies the contents of the output folder to `/out/laboratory`, so we can use `/out` as the public directory.