### PR TITLE
Fix signer hash

### DIFF
--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -49,7 +49,7 @@ class TransactionSigner extends React.Component {
     } else {
       let ledgerSigs = ledgerwalletStatus.signatures;
       let result = signTransaction(xdr, signers, networkObj, ledgerSigs);
-      let transaction = new Transaction(xdr, networkObj);
+      let transaction = new Transaction(xdr, networkPassphrase);
 
       let infoTable = {
         'Signing for': <pre className="so-code so-code__wrap"><code>{networkPassphrase}</code></pre>,


### PR DESCRIPTION
The transaction signer is using an outdated method to set network mode, which results in an incorrect hash being displayed.

Many thanks to @jeesunikim for helping hunt down the [first bad commit](https://github.com/stellar/laboratory/commit/d6654fe4ff696bf6c32f3abfad33f9c30d43e40c) which made this fix much faster to spot, and to @bartekn for the report.