### PR TITLE
Remove /laboratory/ prefix from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD . /app/src
 
 WORKDIR /app/src
 
-RUN apt-get update && apt-get install -y curl git apt-transport-https && \
+RUN apt-get update && apt-get install -y curl git make apt-transport-https && \
     curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     echo "deb https://deb.nodesource.com/node_10.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,14 @@ RUN apt-get update && apt-get install -y curl git apt-transport-https && \
     echo "deb https://deb.nodesource.com/node_10.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install -y nodejs yarn && \
-    /app/src/jenkins.bash
+    apt-get update && apt-get install -y nodejs yarn && apt-get clean
+
+RUN yarn install && yarn build
 
 FROM nginx:1.17
 
-COPY --from=build /app/src/dist/* /usr/share/nginx/html/laboratory/
+COPY --from=build /app/src/dist/ /usr/share/nginx/html/
+
+# We're removing /laboratory/ prefix. To allow for transition
+# period we'll support /laboratory/ links using rewrites
+COPY --from=build /app/src/nginx_default.conf /etc/nginx/conf.d/default.conf

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 # Check if we need to prepend docker commands with sudo
 SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
-# If LABEL is not provided set default value
-LABEL ?= $(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # If TAG is not provided set default value
-TAG ?= docker-registry.services.stellar-ops.com/dev/laboratory:$(LABEL)
+TAG ?= stellar/laboratory:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 
 docker-build:
 	$(SUDO) docker build -t $(TAG) .

--- a/nginx_default.conf
+++ b/nginx_default.conf
@@ -12,5 +12,6 @@ server {
         root   /usr/share/nginx/html;
     }
 
+    rewrite ^/laboratory$ /laboratory/ permanent;
     rewrite ^/laboratory/(.*)$ /$1 break;
 }

--- a/nginx_default.conf
+++ b/nginx_default.conf
@@ -1,0 +1,16 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    rewrite ^/laboratory/(.*)$ /$1 break;
+}


### PR DESCRIPTION
The image is not in use yet and we'd like to simplify architecture a little bit