### PR TITLE
Add thousands separators to amounts in XDR viewer

### DIFF
--- a/src/components/TreeView.js
+++ b/src/components/TreeView.js
@@ -104,6 +104,7 @@ function checkSignatures(signatures, fetchedSigners) {
   }
 }
 
+const formatter = new Intl.NumberFormat();
 // Types values are values that will be displayed with special formatting to
 // provide for a more rich experience other than just plain text.
 // "untyped" values are simply strings. They will be displayed as strings in the
@@ -113,7 +114,7 @@ function convertTypedValue({type, value}) {
   case 'code':
     return <EasySelect><code>{value}</code></EasySelect>;
   case 'amount':
-    return <span>{value.parsed} (raw: <code>{value.raw}</code>)</span>;
+    return <span>{formatter.format(value.parsed)} (raw: <code>{value.raw}</code>)</span>;
   }
 }
 

--- a/src/components/TreeView.js
+++ b/src/components/TreeView.js
@@ -104,7 +104,10 @@ function checkSignatures(signatures, fetchedSigners) {
   }
 }
 
-const formatter = new Intl.NumberFormat();
+const formatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 7,
+});
 // Types values are values that will be displayed with special formatting to
 // provide for a more rich experience other than just plain text.
 // "untyped" values are simply strings. They will be displayed as strings in the


### PR DESCRIPTION
Before:
<img width="507" alt="Screen Shot 2020-04-01 at 5 03 39 PM" src="https://user-images.githubusercontent.com/1551487/78186553-ee1ca000-743a-11ea-81d1-3ad6be433d4a.png">

After:
<img width="436" alt="Screen Shot 2020-04-01 at 5 24 15 PM" src="https://user-images.githubusercontent.com/1551487/78188207-d5fa5000-743d-11ea-9b24-5ee4a4870527.png">

Since this is already intended to be human readable, I don't think it's a bad thing that it doesn't display trailing 0s, but it'd be relatively easy to force them to show.