### PR TITLE
Use separate transaction submission page

### DIFF
--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -9,6 +9,7 @@ import TestnetBanner from './TestnetBanner';
 import TransactionBuilder from './TransactionBuilder';
 import TransactionSigner from './TransactionSigner';
 import XdrViewer from './XdrViewer';
+import TransactionSubmitter from './TransactionSubmitter';
 import {RouterListener} from '../utilities/simpleRouter';
 import SLUG from '../constants/slug';
 import {addEventHandler} from '../utilities/metrics'
@@ -49,11 +50,12 @@ function LaboratoryChrome(props) {
       <div className="so-chunk">
         <nav className="s-buttonList">
           {tabItem('Introduction', SLUG.HOME)}
-          {tabItem('Account Creator', SLUG.ACCOUNT_CREATOR)}
-          {tabItem('Endpoint Explorer', SLUG.EXPLORER)}
-          {tabItem('Transaction Builder', SLUG.TXBUILDER)}
-          {tabItem('Transaction Signer', SLUG.TXSIGNER)}
-          {tabItem('XDR Viewer', SLUG.XDRVIEWER)}
+          {tabItem('Create Account', SLUG.ACCOUNT_CREATOR)}
+          {tabItem('Explore Endpoint', SLUG.EXPLORER)}
+          {tabItem('Build Transaction', SLUG.TXBUILDER)}
+          {tabItem('Sign Transaction', SLUG.TXSIGNER)}
+          {tabItem('Submit Transaction', SLUG.TXSUBMITTER)}
+          {tabItem('View XDR', SLUG.XDRVIEWER)}
         </nav>
       </div>
     </div>
@@ -75,8 +77,10 @@ function getContent(slug) {
       return <TransactionBuilder />;
     case SLUG.TXSIGNER:
       return <TransactionSigner />;
-    case 'xdr-viewer':
+    case SLUG.XDRVIEWER:
       return <XdrViewer />;
+    case SLUG.TXSUBMITTER:
+      return <TransactionSubmitter />;
     default:
       return <SimplePage><p>Page "{slug}" not found</p></SimplePage>
   }

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -83,15 +83,20 @@ class TransactionSigner extends React.Component {
         };
       }
 
-      let codeResult, submitLink, resultTitle, submitInstructions;
+      let codeResult, submitLink, xdrLink, resultTitle, submitInstructions;
 
       if (!_.isUndefined(result.xdr)) {
         codeResult = <pre className="TxSignerResult__xdr so-code so-code__wrap" onClick={clickToSelect}><code>{result.xdr}</code></pre>;
         submitLink = <a
           className="s-button TxSignerResult__submit"
-          href={xdrViewer(result.xdr, 'TransactionEnvelope', true)}
+          href={txPostLink(result.xdr)}
           onClick={scrollOnAnchorOpen}
-          >View and Submit in XDR Viewer</a>;
+          >Submit to Post Transaction endpoint</a>;
+        xdrLink = <a
+          className="s-button TxSignerResult__submit"
+          href={xdrViewer(result.xdr, 'TransactionEnvelope')}
+          onClick={scrollOnAnchorOpen}
+          >View in XDR Viewer</a>;
         resultTitle = <h3 className="TxSignerResult__title">Transaction signed!</h3>;
         submitInstructions = <p className="TxSignerResult__instructions">
           Now that this transaction is signed, you can submit it to the network. Horizon provides an endpoint called Post Transaction that will relay your transaction to the network and inform you of the result.
@@ -170,7 +175,7 @@ class TransactionSigner extends React.Component {
             <p className="TxSignerResult__summary">{result.message}</p>
             {codeResult}
             {submitInstructions}
-            {submitLink}
+            {submitLink} {xdrLink}
           </div>
         </div>
       </div>

--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -91,7 +91,7 @@ class TransactionSigner extends React.Component {
           className="s-button TxSignerResult__submit"
           href={txPostLink(result.xdr)}
           onClick={scrollOnAnchorOpen}
-          >Submit to Post Transaction endpoint</a>;
+          >Submit in Transaction Submitter</a>;
         xdrLink = <a
           className="s-button TxSignerResult__submit"
           href={xdrViewer(result.xdr, 'TransactionEnvelope')}

--- a/src/components/TransactionSubmitter.js
+++ b/src/components/TransactionSubmitter.js
@@ -1,0 +1,122 @@
+import React from "react";
+import { connect } from "react-redux";
+import _ from "lodash";
+import FETCHED_SIGNERS from "../constants/fetched_signers";
+import extrapolateFromXdr from "../utilities/extrapolateFromXdr";
+import TreeView from "./TreeView";
+import validateBase64 from "../utilities/validateBase64";
+import { updateXdrInput, fetchSigners } from "../actions/xdrViewer";
+import { xdr } from "stellar-sdk";
+import { addEventHandler, logEvent } from "../utilities/metrics";
+import xdrViewerMetrics, { metricsEvents } from "../metricsHandlers/xdrViewer";
+import { TxSubmitterResult } from "./TxSubmitterResult";
+
+// XDR decoding doesn't happen in redux, but is pretty much the only thing on
+// this page that we care about. Log metrics from the component as well.
+addEventHandler(xdrViewerMetrics);
+
+const tLogEvent = _.debounce(logEvent, 1000);
+
+function TransactionSubmitter(props) {
+  let { dispatch, state, baseURL, networkPassphrase, horizonURL } = props;
+
+  const { error, nodes } = React.useMemo(() => {
+    if (state.input === "") {
+      return {
+        error: `Enter a base-64 encoded XDR blob to decode.`,
+        nodes: null,
+      };
+    } else {
+      let validation = validateBase64(state.input);
+      if (validation.result === "error") {
+        return {
+          error: validation.message,
+          nodes: null,
+        };
+      }
+      try {
+        return {
+          nodes: extrapolateFromXdr(state.input, "TransactionEnvelope"),
+          error: null,
+        };
+      } catch (e) {
+        console.error(e);
+        tLogEvent(metricsEvents.decodeFailed, { type: state.type });
+        return {
+          error: `Unable to decode input as TransactionEnvelope`,
+          nodes: null,
+        };
+      }
+    }
+  });
+
+  // Fetch signers on initial load
+  if (state.fetchedSigners.state === FETCHED_SIGNERS.NONE) {
+    dispatch(fetchSigners(state.input, baseURL, networkPassphrase));
+  }
+
+  return (
+    <div>
+      <div className="XdrViewer__setup so-back">
+        <div className="so-chunk">
+          <p className="XdrViewer__label" style={{ marginTop: "2em" }}>
+            Input a base-64 encoded TransactionEnvelope:
+          </p>
+          <div className="xdrInput__input">
+            <textarea
+              value={state.input || ""}
+              className="xdrInput__input__textarea"
+              onChange={(event) => {
+                dispatch(updateXdrInput(event.target.value));
+                dispatch(
+                  fetchSigners(event.target.value, baseURL, networkPassphrase),
+                );
+              }}
+              placeholder="Example: AAAAAGXNhB2hIkbP//jgzn4os/AAAAZAB+BaLPAAA5Q/xL..."
+            ></textarea>
+          </div>
+        </div>
+      </div>
+      <TxSubmitterResult
+        txXdr={state.input}
+        networkPassphrase={networkPassphrase}
+        horizonURL={horizonURL}
+      />
+      <div className="XdrViewer__submit so-back">
+        <div className="so-chunk">
+          {error && (
+            <div className="xdrInput__message">
+              <p className="xdrInput__message__alert">{error}</p>
+            </div>
+          )}
+          {nodes && (
+            <TreeView nodes={nodes} fetchedSigners={state.fetchedSigners} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default connect(chooseState)(TransactionSubmitter);
+function chooseState(state) {
+  return {
+    state: state.xdrViewer,
+    baseURL: state.network.current.horizonURL,
+    networkPassphrase: state.network.current.networkPassphrase,
+    horizonURL: state.network.current.horizonURL,
+  };
+}
+
+// Array of all the xdr types. Then, the most common ones appear at the top
+// again for convenience
+let xdrTypes = _(xdr)
+  .functions()
+  .sort()
+  .value();
+xdrTypes = [
+  "TransactionEnvelope",
+  "TransactionResult",
+  "TransactionMeta",
+  "---",
+].concat(xdrTypes);

--- a/src/components/TxSubmitterResult.js
+++ b/src/components/TxSubmitterResult.js
@@ -52,6 +52,7 @@ export const TxSubmitterResult = ({ txXdr, networkPassphrase, horizonURL }) => {
   const [submission, dispatch] = React.useReducer(reducer, initialState);
 
   const isIdle = submission.state === NETWORK_STATES.idle;
+  const isDisabled = !txXdr || !isIdle;
 
   return (
     <div className="TransactionSubmitter">
@@ -59,7 +60,7 @@ export const TxSubmitterResult = ({ txXdr, networkPassphrase, horizonURL }) => {
         <div className="so-chunk">
           <button
             className="s-button"
-            disabled={submission.state !== NETWORK_STATES.idle}
+            disabled={isDisabled}
             onClick={() => {
               dispatch({ type: ACTIONS.submit });
               const transaction = TransactionBuilder.fromXDR(
@@ -136,12 +137,14 @@ const Error = ({ error }) => {
     extras = null;
   if (error instanceof AccountRequiresMemoError) {
     message = "This destination requires a memo.";
-    extras = <React.Fragment>
+    extras = (
+      <React.Fragment>
         Destination account:
         <br /> <EasySelect>{error.accountId}</EasySelect> <br />
         Operation index:
         <br /> <EasySelect>{error.operationIndex}</EasySelect> <br />
-        </React.Fragment>
+      </React.Fragment>
+    );
   } else if (error instanceof BadResponseError) {
     message = "An unknown error occurred";
     extras = (

--- a/src/components/XdrViewer.js
+++ b/src/components/XdrViewer.js
@@ -10,7 +10,6 @@ import {updateXdrInput, updateXdrType, fetchLatestTx, fetchSigners} from '../act
 import {xdr} from 'stellar-sdk';
 import {addEventHandler, logEvent} from '../utilities/metrics'
 import xdrViewerMetrics, {metricsEvents} from '../metricsHandlers/xdrViewer'
-import { TxSubmitterResult } from './TxSubmitterResult';
 
 // XDR decoding doesn't happen in redux, but is pretty much the only thing on
 // this page that we care about. Log metrics from the component as well.
@@ -20,7 +19,7 @@ const tLogEvent = _.debounce(logEvent, 1000)
 
 
 function XdrViewer(props) {
-  let { dispatch, state, baseURL, networkPassphrase, horizonURL } = props;
+  let {dispatch, state, baseURL, networkPassphrase} = props;
 
   let validation = validateBase64(state.input);
   let messageClass = validation.result === 'error' ? 'xdrInput__message__alert' : 'xdrInput__message__success';
@@ -70,24 +69,9 @@ function XdrViewer(props) {
             }}
             placeholder="Example: AAAAAGXNhB2hIkbP//jgzn4os/AAAAZAB+BaLPAAA5Q/xL..."></textarea>
         </div>
-      </div>
-    </div>
-    {state.type === 'TransactionEnvelope' && state.canSubmit &&
-      <TxSubmitterResult
-        txXdr={state.input}
-        networkPassphrase={networkPassphrase}
-        horizonURL={horizonURL}
-      />
-    }
-    <div className="XdrViewer__submit so-back">
-      <div className="so-chunk">
         <div className="xdrInput__message">
           {message}
         </div>
-      </div>
-    </div>
-    <div className="XdrViewer__type so-back">
-      <div className="so-chunk">
 
         <p className="XdrViewer__label">XDR type:</p>
         <SelectPicker
@@ -112,8 +96,7 @@ function chooseState(state) {
   return {
     state: state.xdrViewer,
     baseURL: state.network.current.horizonURL,
-    networkPassphrase: state.network.current.networkPassphrase,
-    horizonURL: state.network.current.horizonURL,
+    networkPassphrase: state.network.current.networkPassphrase
   }
 }
 

--- a/src/constants/slug.js
+++ b/src/constants/slug.js
@@ -7,5 +7,6 @@ const SLUG = {
   TXBUILDER: 'txbuilder',
   TXSIGNER: 'txsigner',
   XDRVIEWER: 'xdr-viewer',
+  TXSUBMITTER: 'txsubmitter',
 };
 export default SLUG;

--- a/src/reducers/xdrViewer.js
+++ b/src/reducers/xdrViewer.js
@@ -1,34 +1,16 @@
 import {combineReducers} from 'redux';
 import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE} from '../actions/xdrViewer';
 import FETCHED_SIGNERS from '../constants/fetched_signers';
-import {LOAD_STATE, UPDATE_LOCATION} from '../actions/routing';
+import {LOAD_STATE, } from '../actions/routing';
 import {SET_PARAMS} from "../actions/network";
 
 const routing = combineReducers({
   input,
   type,
   fetchedSigners,
-  canSubmit,
 });
 
 export default routing;
-
-function canSubmit(state = false, action) {
-  switch (action.type) {
-    case UPDATE_LOCATION:
-      if (action.slug === 'xdr-viewer' && state) {
-        return true
-      }
-      return false;
-    case LOAD_STATE:
-      if (action.slug === 'xdr-viewer' && action.queryObj.canSubmit) {
-        return action.queryObj.canSubmit;
-      }
-      return false;
-    default:
-      return state
-  }
-}
 
 function input(state = '', action) {
   switch (action.type) {

--- a/src/reducers/xdrViewer.js
+++ b/src/reducers/xdrViewer.js
@@ -3,6 +3,7 @@ import {UPDATE_XDR_INPUT, UPDATE_XDR_TYPE} from '../actions/xdrViewer';
 import FETCHED_SIGNERS from '../constants/fetched_signers';
 import {LOAD_STATE, } from '../actions/routing';
 import {SET_PARAMS} from "../actions/network";
+import SLUG from '../constants/slug';
 
 const routing = combineReducers({
   input,
@@ -15,7 +16,10 @@ export default routing;
 function input(state = '', action) {
   switch (action.type) {
   case LOAD_STATE:
-    if (action.slug === 'xdr-viewer' && action.queryObj.input) {
+    if (
+      (action.slug === SLUG.XDRVIEWER || action.slug === SLUG.TXSUBMITTER) &&
+      action.queryObj.input
+    ) {
       return action.queryObj.input;
     }
     break;

--- a/src/utilities/linkBuilder.js
+++ b/src/utilities/linkBuilder.js
@@ -19,26 +19,19 @@ export function txSignerLink(xdr) {
 }
 
 export function txPostLink(xdr) {
-  let query = stateToQueryObj(SLUG.EXPLORER, {
-    endpointExplorer: {
-      currentEndpoint: 'create',
-      currentResource: 'transactions',
-      pendingRequest: {
-        values: {
-          tx: xdr,
-        },
-      },
+  let query = stateToQueryObj(SLUG.TXSUBMITTER, {
+    xdrViewer: {
+      input: xdr,
     },
   });
-  return hashBuilder(SLUG.EXPLORER, query);
+  return hashBuilder(SLUG.TXSUBMITTER, query);
 }
 
-export function xdrViewer(xdr, type, canSubmit = false) {
+export function xdrViewer(xdr, type) {
   let query = stateToQueryObj(SLUG.XDRVIEWER, {
     xdrViewer: {
       input: xdr,
       type,
-      canSubmit
     },
   });
   return hashBuilder(SLUG.XDRVIEWER, query);

--- a/src/utilities/stateSerializer.js
+++ b/src/utilities/stateSerializer.js
@@ -90,7 +90,7 @@ function serializePageSpecificState(slug, state) {
         txsignerResult.xdr = state.transactionSigner.xdr;
       }
       return txsignerResult;
-    case 'xdr-viewer':
+    case SLUG.XDRVIEWER:
       let xdrViewer = {};
       if (state.xdrViewer.input !== '') {
         xdrViewer.input = state.xdrViewer.input;
@@ -98,10 +98,13 @@ function serializePageSpecificState(slug, state) {
       if (state.xdrViewer.type !== '') {
         xdrViewer.type = state.xdrViewer.type;
       }
-      if (state.xdrViewer.canSubmit) {
-        xdrViewer.canSubmit = state.xdrViewer.canSubmit;
-      }
       return xdrViewer;
+      case SLUG.TXSUBMITTER:
+      let txsubmitter = {};
+      if (state.xdrViewer.input !== '') {
+        txsubmitter.input = state.xdrViewer.input;
+      }
+      return txsubmitter;
     default:
       return {};
   }

--- a/test/smoke/routingRoundTrip.js
+++ b/test/smoke/routingRoundTrip.js
@@ -117,15 +117,6 @@ describe('routing system', () => {
         input: 'AAAAAOviDWZdAxfxZ83i1Dx6ZGbnSM8pxoPMrtc5VuSJSBKsAAAAZAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAJAAAAAAAAAAA=',
       });
     });
-
-    describe('when submitting', () => {
-      itCircularlyConvertsState(SLUG.XDRVIEWER, {
-        network: 'test',
-        type: 'TransactionEnvelope',
-        input: 'AAAAAOviDWZdAxfxZ83i1Dx6ZGbnSM8pxoPMrtc5VuSJSBKsAAAAZAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAJAAAAAAAAAAA=',
-        canSubmit: true
-      });
-    });
   });
 
   describe('for any page', () => {

--- a/test/unit/linkBuilder.js
+++ b/test/unit/linkBuilder.js
@@ -11,7 +11,7 @@ describe('linkBuilder', () => {
   describe('txPostLink()', () => {
     it('returns the correct url', () => {
       expect(linkBuilder.txPostLink('AG/eK0AAAAAAA='))
-        .to.equal('#explorer?resource=transactions&endpoint=create&values=eyJ0eCI6IkFHL2VLMEFBQUFBQUE9In0%3D');
+        .to.equal('#txsubmitter?input=AG%2FeK0AAAAAAA%3D');
     });
   });
 


### PR DESCRIPTION
This changes #448's submission UI so that there's a separate Submit Transaction page, listed in the top nav, and removes the submission flow from the View XDR page.

For space reasons, I had to rename all the nav items to squish a few characters out, otherwise the new item causes "XDR Viewer" to wrap onto a new line.

Before:
<img width="957" alt="Screen Shot 2020-05-01 at 2 23 36 PM" src="https://user-images.githubusercontent.com/1551487/80834910-afa40d80-8bbf-11ea-81a7-69c958bc94ed.png">
After:
<img width="1079" alt="Screen Shot 2020-05-01 at 2 23 27 PM" src="https://user-images.githubusercontent.com/1551487/80834909-afa40d80-8bbf-11ea-9f8b-a85dbd7551c8.png">
