### PR TITLE
pull base_fee from horizon, update text to pull from there too

### DIFF
--- a/src/actions/transactionBuilder.js
+++ b/src/actions/transactionBuilder.js
@@ -95,7 +95,7 @@ export function fetchBaseFee(horizonBaseUrl) {
     axios.get(horizonBaseUrl + '/fee_stats')
       .then(r => dispatch({
         type: FETCH_BASE_FEE_SUCCESS,
-        base_fee: r.data.last_ledger_base_fee
+        base_fee: r.data.fee_charged.mode
       }))
       .catch(r => dispatch({type: FETCH_BASE_FEE_FAIL, payload: r}))
   }

--- a/src/actions/transactionBuilder.js
+++ b/src/actions/transactionBuilder.js
@@ -82,3 +82,23 @@ export function fetchSequence(accountId, horizonBaseUrl) {
       .catch(r => dispatch({type: FETCH_SEQUENCE_FAIL, payload: r}))
   }
 }
+
+
+export const FETCH_BASE_FEE = 'FETCH_BASE_FEE';
+export const FETCH_BASE_FEE_FAIL = 'FETCH_BASE_FEE_FAIL';
+export const FETCH_BASE_FEE_SUCCESS = 'FETCH_BASE_FEE_SUCCESS';
+export function fetchBaseFee(horizonBaseUrl) {
+  return dispatch => {
+    dispatch({
+      type: FETCH_BASE_FEE
+    });
+    axios.get(horizonBaseUrl + '/fee_stats')
+      .then(r => dispatch({
+        type: FETCH_BASE_FEE_SUCCESS,
+        base_fee: r.data.last_ledger_base_fee
+      }))
+      .catch(r => dispatch({type: FETCH_BASE_FEE_FAIL, payload: r}))
+  }
+}
+
+

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import OptionsTablePair from './OptionsTable/Pair';
 import HelpMark from './HelpMark';
 import PubKeyPicker from './FormComponents/PubKeyPicker';
@@ -9,11 +9,15 @@ import TimeBoundsPicker from './FormComponents/TimeBoundsPicker';
 import {connect} from 'react-redux';
 import {StrKey} from 'stellar-sdk';
 import NETWORK from '../constants/network';
-import {fetchSequence} from '../actions/transactionBuilder';
+import {fetchSequence, fetchBaseFee} from '../actions/transactionBuilder';
 
-export default function TxBuilderAttributes(props) {
+function TxBuilderAttributes(props) {
   let {onUpdate, attributes} = props;
 
+  useEffect(() => {
+    props.dispatch(fetchBaseFee(props.horizonURL))
+  }, [])
+  
   return <div className="TransactionAttributes">
     <div className="TransactionOp__config TransactionOpConfig optionsTable">
       <OptionsTablePair label={<span>Source Account <HelpMark href="https://www.stellar.org/developers/guides/concepts/accounts.html" /></span>}>
@@ -36,7 +40,7 @@ export default function TxBuilderAttributes(props) {
           value={attributes['fee']}
           onUpdate={(value) => {onUpdate('fee', value)}}
           />
-        <p className="optionsTable__pair__content__note">The <a href="https://www.stellar.org/developers/guides/concepts/fees.html">network base fee</a> is currently set to 100 stroops (0.00001 lumens). Transaction fee is equal to base fee times number of operations in this transaction.</p>
+        <p className="optionsTable__pair__content__note">The <a href="https://www.stellar.org/developers/guides/concepts/fees.html">network base fee</a> is currently set to {attributes['fee']} stroops ({attributes['fee'] / 1e7} lumens). Transaction fee is equal to base fee times number of operations in this transaction.</p>
       </OptionsTablePair>
       <OptionsTablePair optional={true} label={<span>Memo <HelpMark href="https://www.stellar.org/developers/guides/concepts/transactions.html#memo" /></span>}>
         <MemoPicker
@@ -68,6 +72,8 @@ export default function TxBuilderAttributes(props) {
     </div>
   </div>
 }
+
+export default connect(chooseState)(TxBuilderAttributes);
 
 class sequenceFetcherClass extends React.Component {
   render() {

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -12,10 +12,10 @@ import NETWORK from '../constants/network';
 import {fetchSequence, fetchBaseFee} from '../actions/transactionBuilder';
 
 function TxBuilderAttributes(props) {
-  let {onUpdate, attributes} = props;
+  let {onUpdate, attributes, horizonURL} = props;
 
   useEffect(() => {
-    props.dispatch(fetchBaseFee(props.horizonURL))
+    props.dispatch(fetchBaseFee(horizonURL))
   }, [])
   
   return <div className="TransactionAttributes">

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -10,6 +10,8 @@ import {
   FETCH_SEQUENCE_SUCCESS,
   FETCH_SEQUENCE_FAIL,
   RESET_TXBUILDER,
+  FETCH_BASE_FEE_SUCCESS,
+  FETCH_BASE_FEE_FAIL
 } from '../actions/transactionBuilder';
 import {LOAD_STATE} from '../actions/routing';
 import {rehydrate} from '../utilities/hydration';
@@ -95,6 +97,7 @@ const defaultAttributes = {
   minTime: '',
   maxTime: '',
 };
+
 function attributes(state = defaultAttributes, action) {
   switch(action.type) {
   case LOAD_STATE:
@@ -106,6 +109,10 @@ function attributes(state = defaultAttributes, action) {
     return Object.assign({}, state, action.newAttributes);
   case FETCH_SEQUENCE_SUCCESS:
     return Object.assign({}, state, { sequence: action.sequence });
+  case FETCH_BASE_FEE_SUCCESS:
+    return Object.assign({}, state, {fee: action.base_fee});
+  case FETCH_BASE_FEE_FAIL:
+    return Object.assign({}, state, {fee: defaultAttributes.fee});
   case RESET_TXBUILDER:
     return defaultAttributes;
   }

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -110,9 +110,9 @@ function attributes(state = defaultAttributes, action) {
   case FETCH_SEQUENCE_SUCCESS:
     return Object.assign({}, state, { sequence: action.sequence });
   case FETCH_BASE_FEE_SUCCESS:
-    return Object.assign({}, state, {fee: action.base_fee});
+    return Object.assign({}, state, { fee: action.base_fee });
   case FETCH_BASE_FEE_FAIL:
-    return Object.assign({}, state, {fee: defaultAttributes.fee});
+    return Object.assign({}, state, { fee: defaultAttributes.fee });
   case RESET_TXBUILDER:
     return defaultAttributes;
   }


### PR DESCRIPTION
@vcarl @stellar/nebula 

WHAT?
Changing the base_fee source when building a transaction to be pulled from Horizon instead of a constant from the "stellar-sdk" package. If for whatever reason the pull fails, falls back to the constant.

WHY?
In case the network base fee value changes the input reflects it accordingly.

