### PR TITLE
Pass through Amplitude key from build server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.tmp

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ yarn start --public randomsubdomain.ngrok.io
 yarn build
 ```
 
+A complete production build, including nginx and docker image, can be build and run as well.
+
+```sh
+yarn production
+# or
+yarn prod:build
+yarn prod:serve
+```
+
+Production uses Amplify to emit metrics, so to fully emulate a production build, you'll need to set an `AMPLITUDE_KEY` environment variable in the shell you start a build from.
+
 ## Internal documentation
 
 The [docs.md](./docs.md) file contains code documentation on the laboratory. The

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-/ /laboratory

--- a/jenkins.bash
+++ b/jenkins.bash
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-set -e
-
-yarn install
-
-yarn build

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "build": "webpack-cli --config webpack.config.prod.js",
     "analyze": "webpack-cli --config webpack.config.analyze.js",
     "build:netlify": "yarn build; mkdir out; mkdir out/laboratory; mv dist/* out/laboratory; cp _redirects out/_redirects",
-    "test": "mocha './test/**/*.js'"
+    "test": "mocha './test/**/*.js'",
+    "prod:build": "docker image build --build-arg AMPLITUDE_KEY=$AMPLITUDE_KEY -t lab:localbuild .",
+    "prod:serve": "docker run -p 8000:80 lab:localbuild",
+    "production": "yarn prod:build && yarn prod:serve"
   },
   "dependencies": {
     "@babel/core": "^7.6.2",


### PR DESCRIPTION
Also optimizes the Docker build so it caches better, and removes some unused files