### PR TITLE
small UI fixes for added Fee Bump feature

### DIFF
--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -14,9 +14,7 @@ import {fetchSequence, fetchBaseFee, updateTxType, updateFeeBumpAttribute} from 
 import TransactionImporter from './TransactionImporter';
 import TX_TYPES from '../constants/transaction_types';
 
-
 function TxBuilderAttributes(props) {
-
   let {onUpdate, attributes, horizonURL, dispatch, feeBumpAttributes, networkPassphrase} = props;
   const { txType, network } = props.state;
   const [networkBaseFee, setNetworkBaseFee] = useState(attributes['fee']);

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -19,7 +19,7 @@ function TxBuilderAttributes(props) {
     dispatch(fetchBaseFee(horizonURL));
     setNetworkBaseFee(attributes['fee']);
   }, [])
-  
+
   return <div className="TransactionAttributes">
     <div className="TransactionOp__config TransactionOpConfig optionsTable">
       <OptionsTablePair label={<span>Source Account <HelpMark href="https://www.stellar.org/developers/guides/concepts/accounts.html" /></span>}>

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import OptionsTablePair from './OptionsTable/Pair';
 import HelpMark from './HelpMark';
 import PubKeyPicker from './FormComponents/PubKeyPicker';
@@ -12,10 +12,12 @@ import NETWORK from '../constants/network';
 import {fetchSequence, fetchBaseFee} from '../actions/transactionBuilder';
 
 function TxBuilderAttributes(props) {
-  let {onUpdate, attributes, horizonURL} = props;
+  let {onUpdate, attributes, horizonURL, dispatch} = props;
+  const [networkBaseFee, setNetworkBaseFee] = useState(attributes['fee']);
 
   useEffect(() => {
-    props.dispatch(fetchBaseFee(horizonURL))
+    dispatch(fetchBaseFee(horizonURL));
+    setNetworkBaseFee(attributes['fee']);
   }, [])
   
   return <div className="TransactionAttributes">
@@ -40,7 +42,7 @@ function TxBuilderAttributes(props) {
           value={attributes['fee']}
           onUpdate={(value) => {onUpdate('fee', value)}}
           />
-        <p className="optionsTable__pair__content__note">The <a href="https://www.stellar.org/developers/guides/concepts/fees.html">network base fee</a> is currently set to {attributes['fee']} stroops ({attributes['fee'] / 1e7} lumens). Transaction fee is equal to base fee times number of operations in this transaction.</p>
+        <p className="optionsTable__pair__content__note">The <a href="https://www.stellar.org/developers/guides/concepts/fees.html">network base fee</a> is currently set to {networkBaseFee} stroops ({networkBaseFee / 1e7} lumens). Transaction fee is equal to base fee times number of operations in this transaction.</p>
       </OptionsTablePair>
       <OptionsTablePair optional={true} label={<span>Memo <HelpMark href="https://www.stellar.org/developers/guides/concepts/transactions.html#memo" /></span>}>
         <MemoPicker

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -11,6 +11,7 @@ import {StrKey} from 'stellar-sdk';
 import NETWORK from '../constants/network';
 import {fetchSequence, fetchBaseFee} from '../actions/transactionBuilder';
 
+
 function TxBuilderAttributes(props) {
   let {onUpdate, attributes, horizonURL, dispatch} = props;
   const [networkBaseFee, setNetworkBaseFee] = useState(attributes['fee']);

--- a/src/reducers/transactionBuilder.js
+++ b/src/reducers/transactionBuilder.js
@@ -137,6 +137,8 @@ function feeBumpAttributes(state = defaultFeeBumpAttributes, action) {
       break;
     case UPDATE_FEE_BUMP_ATTRIBUTE:
       return Object.assign({}, state, action.newAttribute)
+    case RESET_TXBUILDER:
+      return defaultFeeBumpAttributes;
   }
   return state;
 }
@@ -151,6 +153,8 @@ function txType(state = TX_TYPES.REGULAR, action) {
       break;
     case UPDATE_TX_TYPE:
       return action.txType;
+    case RESET_TXBUILDER:
+      return TX_TYPES.REGULAR;
   }
   return state;
 }


### PR DESCRIPTION
**WHAT?**

UI fixes for added Fee Bump Transaction on the TransactionBuilder page:

1. base fee helper text should't change on base fee input. It should stay as that initial base fee pulled from the network.
2. clear form should clear fee bump as well

**WHY?**

1. The network fee shouldn't change on user input.
2. clear form should clear the whole form
