### PR TITLE
Fix tx_set_operation_count parsing

### DIFF
--- a/src/utilities/prism-jsonLinkHighlighter.js
+++ b/src/utilities/prism-jsonLinkHighlighter.js
@@ -60,6 +60,7 @@ let validSecondSiblingClasses = {
   'token string': true,
   'token boolean': true,
   'token number': true,
+  'token null': true,
   'token property': true, // Prism.js incorrectly parses strings with escape sequences
 }
 function validatePropertyTokenSiblings(propertyToken) {


### PR DESCRIPTION
The new `tx_set_operation_count` property (added in stellar/js-stellar-sdk#559) is nullable, and apparently the JSON highlighting logic is not set to allow for nullable fields. This adds `null` to the list of valid property value types.