### PR TITLE
prettified and hid 'Sign with Lyra' until transaction is valid

### DIFF
--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -1,78 +1,130 @@
-import React from 'react';
-import {connect} from 'react-redux';
-import reduce from 'lodash/reduce'
-import {EasySelect} from './EasySelect';
-import Libify from '../utilities/Libify';
-import {txSignerLink, xdrViewer} from '../utilities/linkBuilder';
-import scrollOnAnchorOpen from '../utilities/scrollOnAnchorOpen';
-import TxLyraSign from './TxLyraSign';
+/**
+ * @prettier
+ */
+
+import React from "react";
+import { connect } from "react-redux";
+import reduce from "lodash/reduce";
+import { EasySelect } from "./EasySelect";
+import Libify from "../utilities/Libify";
+import { txSignerLink, xdrViewer } from "../utilities/linkBuilder";
+import scrollOnAnchorOpen from "../utilities/scrollOnAnchorOpen";
+import TxLyraSign from "./TxLyraSign";
 
 class TxBuilderResult extends React.Component {
   render() {
-    let {attributes, operations} = this.props.state;
+    let { attributes, operations } = this.props.state;
     let validationErrors = [];
     let transactionBuild;
 
-    if (attributes.sourceAccount === '') {
-      validationErrors.push('Source account ID is a required field');
+    if (attributes.sourceAccount === "") {
+      validationErrors.push("Source account ID is a required field");
     }
-    if (attributes.sequence === '') {
-      validationErrors.push('Sequence number is a required field');
+    if (attributes.sequence === "") {
+      validationErrors.push("Sequence number is a required field");
     }
-    let memoIsNone = attributes.memoType === 'MEMO_NONE' || attributes.memoType === '';
-    if (!memoIsNone && attributes.memoContent === '') {
-      validationErrors.push('Memo content is required if memo type is selected');
+    let memoIsNone =
+      attributes.memoType === "MEMO_NONE" || attributes.memoType === "";
+    if (!memoIsNone && attributes.memoContent === "") {
+      validationErrors.push(
+        "Memo content is required if memo type is selected",
+      );
     }
 
-    let finalResult, errorTitleText, successTitleText, signingInstructions, signingLink, xdrLink;
+    let finalResult,
+      errorTitleText,
+      successTitleText,
+      signingInstructions,
+      signingLink,
+      xdrLink;
     if (validationErrors.length > 0) {
-      errorTitleText = 'Form validation errors:';
+      errorTitleText = "Form validation errors:";
       finalResult = formatErrorList(validationErrors);
     } else {
-      transactionBuild = Libify.buildTransaction(attributes, operations, this.props.networkPassphrase);
+      transactionBuild = Libify.buildTransaction(
+        attributes,
+        operations,
+        this.props.networkPassphrase,
+      );
 
       if (transactionBuild.errors.length > 0) {
         errorTitleText = `Transaction building errors:`;
         finalResult = formatErrorList(transactionBuild.errors);
       } else {
         successTitleText = `Success! Transaction Envelope XDR:`;
-        finalResult = <div>
-          Network Passphrase:<br />
-          {this.props.networkPassphrase}<br />
-          Hash:<br />
-          <EasySelect>{transactionBuild.hash}</EasySelect><br />
-          XDR:<br />
-          <EasySelect>{transactionBuild.xdr}</EasySelect>
+        finalResult = (
+          <div>
+            Network Passphrase:
+            <br />
+            {this.props.networkPassphrase}
+            <br />
+            Hash:
+            <br />
+            <EasySelect>{transactionBuild.hash}</EasySelect>
+            <br />
+            XDR:
+            <br />
+            <EasySelect>{transactionBuild.xdr}</EasySelect>
           </div>
-        signingInstructions = <p className="TransactionBuilderResult__instructions">
-          In order for the transaction to make it into the ledger, a transaction must be successfully
-          signed and submitted to the network. The laboratory provides
-          the <a href="#txsigner">Transaction Signer</a> to for signing a
-          transaction, and the <a href="#explorer?resource=transactions&endpoint=create">Post Transaction endpoint</a> for
-          submitting one to the network.
-        </p>;
-        signingLink = <a className="s-button"
-          href={txSignerLink(transactionBuild.xdr)}
-          onClick={scrollOnAnchorOpen}>Sign in Transaction Signer</a>
-        xdrLink = <a className="s-button"
-          href={xdrViewer(transactionBuild.xdr, 'TransactionEnvelope')}
-          onClick={scrollOnAnchorOpen}>View in XDR Viewer</a>
+        );
+        signingInstructions = (
+          <p className="TransactionBuilderResult__instructions">
+            In order for the transaction to make it into the ledger, a
+            transaction must be successfully signed and submitted to the
+            network. The laboratory provides the{" "}
+            <a href="#txsigner">Transaction Signer</a> to for signing a
+            transaction, and the{" "}
+            <a href="#explorer?resource=transactions&endpoint=create">
+              Post Transaction endpoint
+            </a>{" "}
+            for submitting one to the network.
+          </p>
+        );
+        signingLink = (
+          <a
+            className="s-button"
+            href={txSignerLink(transactionBuild.xdr)}
+            onClick={scrollOnAnchorOpen}
+          >
+            Sign in Transaction Signer
+          </a>
+        );
+        xdrLink = (
+          <a
+            className="s-button"
+            href={xdrViewer(transactionBuild.xdr, "TransactionEnvelope")}
+            onClick={scrollOnAnchorOpen}
+          >
+            View in XDR Viewer
+          </a>
+        );
       }
     }
 
-    let errorTitle = errorTitleText ? <h3 className="TransactionBuilderResult__error">{errorTitleText}</h3> : null
-    let successTitle = successTitleText ? <h3 className="TransactionBuilderResult__success">{successTitleText}</h3> : null
+    let errorTitle = errorTitleText ? (
+      <h3 className="TransactionBuilderResult__error">{errorTitleText}</h3>
+    ) : null;
+    let successTitle = successTitleText ? (
+      <h3 className="TransactionBuilderResult__success">{successTitleText}</h3>
+    ) : null;
 
-    return <div className="TransactionBuilderResult">
-      {successTitle}
-      {errorTitle}
-      <pre className="TransactionXDR so-code so-code__wrap TransactionBuilderResult__code">
-        <code>{finalResult}</code>
-      </pre>
-      {signingInstructions}
-      {signingLink} {xdrLink}
-      { window.lyra && transactionBuild ? <TxLyraSign xdr={transactionBuild.xdr} /> : null }
-    </div>
+    const txBuilderHasErrors =
+      transactionBuild && transactionBuild.errors.length > 0;
+
+    return (
+      <div className="TransactionBuilderResult">
+        {successTitle}
+        {errorTitle}
+        <pre className="TransactionXDR so-code so-code__wrap TransactionBuilderResult__code">
+          <code>{finalResult}</code>
+        </pre>
+        {signingInstructions}
+        {signingLink} {xdrLink}
+        {window.lyra && !txBuilderHasErrors ? (
+          <TxLyraSign xdr={transactionBuild.xdr} />
+        ) : null}
+      </div>
+    );
   }
 }
 
@@ -82,11 +134,15 @@ function chooseState(state) {
   return {
     state: state.transactionBuilder,
     networkPassphrase: state.network.current.networkPassphrase,
-  }
+  };
 }
 
 function formatErrorList(errors) {
-  return reduce(errors, (result, error) => {
-    return `${result}- ${error} \n`;
-  }, '');
+  return reduce(
+    errors,
+    (result, error) => {
+      return `${result}- ${error} \n`;
+    },
+    "",
+  );
 }

--- a/src/components/TxLyraSign.js
+++ b/src/components/TxLyraSign.js
@@ -1,39 +1,45 @@
-import React from 'react';
+/**
+ * @prettier
+ */
+
+import React from "react";
 
 const signWithLyra = async (xdr, setTxResult) => {
-      let res = {transactionStatus: "" };
+  let res = { transactionStatus: "" };
 
-    try {
-      res = await window.lyra.requestSignature({
-        transactionXdr: xdr,
-      });
-    } catch (e) {
-      res = e;
-      console.error(e);
-    }
+  try {
+    res = await window.lyra.requestSignature({
+      transactionXdr: xdr,
+    });
+  } catch (e) {
+    res = e;
+    console.error(e);
+  }
 
-    setTxResult(res.transactionStatus);
-
-}
+  setTxResult(res.transactionStatus);
+};
 
 const TxLyraSign = ({ xdr }) => {
-  const [ txResult, setTxResult ] = React.useState();
+  const [txResult, setTxResult] = React.useState();
   return (
     <div>
       <hr />
-    <button className="s-button" type="button" onClick={() => signWithLyra(xdr, setTxResult)}>
-      Sign with Lyra
-    </button>
-    {
-      txResult ? 
+      <button
+        className="s-button"
+        type="button"
+        onClick={() => signWithLyra(xdr, setTxResult)}
+      >
+        Sign with Lyra
+      </button>
+      {txResult ? (
         <div>
-          <h1>Result: { txResult.successful ? 'Success!' : 'Failed!' }</h1>
+          <h1>Result: {txResult.successful ? "Success!" : "Failed!"}</h1>
           <h3>Full results:</h3>
           <textarea readonly value={JSON.stringify(txResult)} />
-        </div> : null
-    }
-  </div>
-  )
+        </div>
+      ) : null}
+    </div>
+  );
 };
 
 export default TxLyraSign;


### PR DESCRIPTION
Ticket: [Update Lab to hide `Sign with Lyra` btn until transaction is valid](https://app.asana.com/0/1168666457741233/1182884933849923)

Prettified two files: `TxBuilderResult.js` and `TxLyraSign.js`.
- It looks like we are using `requiredPragma` to prettify only the newer files. Correct me, if I am wrong 😄 

I added a comment where I updated the actual code to hide `Sign with Lyra` button until transaction is valid