### PR TITLE
bugfix/txBuilderResult > logic to allow transactionBuild and 'readonly' to 'readOnly'

### DIFF
--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -108,9 +108,6 @@ class TxBuilderResult extends React.Component {
       <h3 className="TransactionBuilderResult__success">{successTitleText}</h3>
     ) : null;
 
-    const txBuilderHasErrors =
-      transactionBuild && !transactionBuild.errors.length;
-
     return (
       <div className="TransactionBuilderResult">
         {successTitle}
@@ -120,7 +117,7 @@ class TxBuilderResult extends React.Component {
         </pre>
         {signingInstructions}
         {signingLink} {xdrLink}
-        {window.lyra && transactionBuild ? (
+        {window.lyra && transactionBuild && !transactionBuild.errors.length ? (
           <TxLyraSign xdr={transactionBuild.xdr} />
         ) : null}
       </div>

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -109,7 +109,7 @@ class TxBuilderResult extends React.Component {
     ) : null;
 
     const txBuilderHasErrors =
-      transactionBuild && transactionBuild.errors.length > 0;
+      transactionBuild && !transactionBuild.errors.length;
 
     return (
       <div className="TransactionBuilderResult">
@@ -120,7 +120,7 @@ class TxBuilderResult extends React.Component {
         </pre>
         {signingInstructions}
         {signingLink} {xdrLink}
-        {window.lyra && !txBuilderHasErrors ? (
+        {window.lyra && transactionBuild ? (
           <TxLyraSign xdr={transactionBuild.xdr} />
         ) : null}
       </div>

--- a/src/components/TxLyraSign.js
+++ b/src/components/TxLyraSign.js
@@ -21,6 +21,7 @@ const signWithLyra = async (xdr, setTxResult) => {
 
 const TxLyraSign = ({ xdr }) => {
   const [txResult, setTxResult] = React.useState();
+
   return (
     <div>
       <hr />
@@ -35,7 +36,7 @@ const TxLyraSign = ({ xdr }) => {
         <div>
           <h1>Result: {txResult.successful ? "Success!" : "Failed!"}</h1>
           <h3>Full results:</h3>
-          <textarea readonly value={JSON.stringify(txResult)} />
+          <textarea readOnly value={JSON.stringify(txResult)} />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
`transactionBuild` needs to be true in order for `transactionBuild.xdr` to not throw an error