### PR TITLE
bugfix/transaction-failed-horizon-error > updated styling for success and error handling

### DIFF
--- a/src/components/TxLyraSign.js
+++ b/src/components/TxLyraSign.js
@@ -4,6 +4,8 @@
 
 import React from "react";
 
+import { CodeBlock } from "./CodeBlock";
+
 const signWithLyra = async (xdr, setTxResult) => {
   let res = { transactionStatus: "" };
 
@@ -34,9 +36,18 @@ const TxLyraSign = ({ xdr }) => {
       </button>
       {txResult ? (
         <div>
-          <h1>Result: {txResult.successful ? "Success!" : "Failed!"}</h1>
-          <h3>Full results:</h3>
-          <textarea readOnly value={JSON.stringify(txResult)} />
+          <div
+            className={`AccountCreator__spaceTop s-alert ${
+              txResult.successful ? "s-alert--success" : "s-alert--alert"
+            }`}
+          >
+            Result: {txResult.successful ? "Success!" : "Failed!"}
+          </div>
+          <CodeBlock
+            className="AccountCreator__spaceTop"
+            code={JSON.stringify(txResult, null, 2)}
+            language="json"
+          />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Ticket: [Transaction failed should return Horizon error message](https://app.asana.com/0/1168666457741233/1182844823111073)
Related Lyra [PR](https://github.com/stellar/lyra/pull/41/)
- Updated its styling for error and success handling to match other pages' handling
- The ticket is requesting for just a message but other parts of the lab are just returning the entire json so I updated to match how the other labs are doing. Let me know if I should still adhere to the ticket.

**Before:**
<img width="447" alt="before" src="https://user-images.githubusercontent.com/3912060/87726018-45e1db80-c78c-11ea-829e-7fcc3e203bec.png">

**After:**
<img width="1139" alt="after-fail" src="https://user-images.githubusercontent.com/3912060/87726019-467a7200-c78c-11ea-8921-fcc3ca3eadc0.png">
<img width="1115" alt="after-success" src="https://user-images.githubusercontent.com/3912060/87726020-467a7200-c78c-11ea-9baf-88bdf6ce0b8c.png">

