### PR TITLE
Add ToS/privacy links, minor fixes

### DIFF
--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -72,6 +72,16 @@ function LaboratoryChrome(props) {
 
       {renamed(props.routing.location)}
       <RouterListener />
+
+      <div className="so-back LaboratoryChrome__terms">
+        <div className="so-chunk ">
+          <a href="https://www.stellar.org/terms-of-service">
+            Terms of Service
+          </a>
+          <span className="spacer" />
+          <a href="https://www.stellar.org/privacy-policy">Privacy Policy</a>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -75,11 +75,21 @@ function LaboratoryChrome(props) {
 
       <div className="so-back LaboratoryChrome__terms">
         <div className="so-chunk ">
-          <a href="https://www.stellar.org/terms-of-service">
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://www.stellar.org/terms-of-service"
+          >
             Terms of Service
           </a>
           <span className="spacer" />
-          <a href="https://www.stellar.org/privacy-policy">Privacy Policy</a>
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://www.stellar.org/privacy-policy"
+          >
+            Privacy Policy
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/LaboratoryChrome.js
+++ b/src/components/LaboratoryChrome.js
@@ -1,3 +1,6 @@
+/**
+ * @prettier
+ */
 import React from "react";
 import { connect } from "react-redux";
 import classNames from "classnames";
@@ -73,13 +76,29 @@ function LaboratoryChrome(props) {
   );
 }
 
-const Loading = ({ pastDelay, retry, error }) => {
+const Loading = ({ pastDelay, error }) => {
   if (error) {
     return (
       <div className="so-back">
-        <div className="so-chunk">
-          Error! <button onClick={retry}>Retry</button>
-          <pre>{error.stack}</pre>
+        <div className="so-chunk Introduction">
+          <p>
+            There was a problem loading this page. If your network connection is
+            still working, try reloading.
+          </p>
+          <p>
+            <button
+              className="s-button"
+              onClick={() => {
+                window.history.go(0);
+              }}
+            >
+              Reload
+            </button>
+          </p>
+          <details>
+            <summary>View stack trace</summary>
+            <pre>{error.stack}</pre>
+          </details>
         </div>
       </div>
     );

--- a/src/data/endpoints.js
+++ b/src/data/endpoints.js
@@ -173,7 +173,7 @@ export const endpointsMap = {
         method: "GET",
         path: {
           template:
-            "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+            "/offers{?selling,buying,seller,cursor,limit,order}",
         },
         setupComponent: AllOffers,
       },

--- a/src/styles/_LaboratoryChrome.scss
+++ b/src/styles/_LaboratoryChrome.scss
@@ -1,3 +1,6 @@
+/**
+ * @prettier
+ */
 .LaboratoryChrome__header {
   justify-content: space-between;
 }
@@ -14,4 +17,19 @@
   border-radius: 0;
   border-bottom: 1px solid $white;
   margin-bottom: -1px;
+}
+
+.spacer {
+  display: inline-block;
+  width: 2rem;
+  height: 1px;
+}
+
+.LaboratoryChrome__terms {
+  padding: 4rem 0;
+
+  a {
+    text-decoration: none;
+    color: $s-color-neutral3;
+  }
 }


### PR DESCRIPTION
* Fix all offers endpoint template, which was coming through with duplicated URL
* Improve error message when async chunks fail to load
* Add ToS and privacy policy links

New async chunk error:
<img width="819" alt="Screen Shot 2020-07-20 at 5 15 00 PM" src="https://user-images.githubusercontent.com/1551487/87990551-3deaaa00-cab2-11ea-8233-de735b422a9d.png">
