### PR TITLE
Remove amplitude module, simplify user/device metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@ledgerhq/hw-app-str": "^5.9.0",
     "@ledgerhq/hw-transport-u2f": "^5.9.0",
     "@stellar/prettier-config": "^1.0.1",
-    "amplitude-js": "^4.6.0",
     "axios": "^0.18.1",
     "babel-loader": "^8.1.0",
     "browser-sync": "^2.9.11",

--- a/src/utilities/metrics.js
+++ b/src/utilities/metrics.js
@@ -1,24 +1,64 @@
-import Amplitude from 'amplitude-js'
+/**
+ * @prettier
+ */
+import throttle from "lodash/throttle";
 
-const instance = Amplitude.getInstance();
-instance.init(process.env.AMPLITUDE_KEY)
+const METRICS_ENDPOINT = "https://api.amplitude.com/2/httpapi";
+let cache = [];
+
+const uploadMetrics = throttle(() => {
+  const toUpload = cache;
+  cache = [];
+  if (!process.env.AMPLITUDE_KEY) {
+    // eslint-disable-next-line no-console
+    console.log("Not uploading metrics", toUpload);
+    return;
+  }
+  fetch(METRICS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      api_key: process.env.AMPLITUDE_KEY,
+      events: toUpload,
+    }),
+  });
+}, 500);
+
+const getUserId = () => {
+  const storedId = localStorage.getItem("metrics_user_id");
+  if (!storedId) {
+    // Create a random ID by taking the decimal portion of a random number
+    const newId = Math.random()
+      .toString()
+      .split(".")[1];
+    localStorage.setItem("metrics_user_id", newId);
+    return newId;
+  }
+  return storedId;
+};
 
 export function logEvent(type, properties) {
-  // In development, track when events are fired for debugging purposes.
-  if (process.env.NODE_ENV === 'development') {
-    console.log(`[METRICS]: "${type}", ${JSON.stringify(properties)}`)
-  }
-  instance.logEvent(type, properties)
+  cache.push({
+    /* eslint-disable camelcase */
+    event_type: type,
+    event_properties: properties,
+    user_id: getUserId(),
+    device_id: window.navigator.userAgent,
+    /* eslint-enable camelcase */
+  });
+  uploadMetrics();
 }
 
-const eventHandlers = []
+const eventHandlers = [];
 
 export function addEventHandler(handler) {
-  eventHandlers.push(handler)
+  eventHandlers.push(handler);
 }
 
 export function broadcastEvent(state, action) {
   eventHandlers.forEach((handler) => {
-    handler(state, action)
-  })
+    handler(state, action);
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@amplitude/ua-parser-js@0.7.11":
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.11.tgz#e3e411912aa88b1832ce3fb4dd4996839bd39243"
-  integrity sha512-uBYLbl5dRh0w7yWATTiKwfzae4EU6B/jHK6xsY8vRgbNEfwJZLG44Z18B1sBGjeaUYCk2nP8lWNehKGeQf3jgw==
-
 "@babel/code-frame@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
@@ -1198,16 +1193,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplitude-js@^4.6.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/amplitude-js/-/amplitude-js-4.7.0.tgz#82a3f23d0dbe0e7ad3e319a974bd102389713fbb"
-  integrity sha512-4ZlJjZafznb6TDh/Bwr2DYWDDmivsrayqXoCK5p/1T59eqNHuEea41QwWde4S7kKz+CEeq4piaCS3sTQT1jJRg==
-  dependencies:
-    "@amplitude/ua-parser-js" "0.7.11"
-    blueimp-md5 "^2.10.0"
-    json3 "^3.3.2"
-    query-string "5"
-
 ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
@@ -1590,11 +1575,6 @@ bluebird@^3.5.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
-blueimp-md5@^2.10.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.16.0.tgz#9018bb805e4ee05512e0e8cbdb9305eeecbdc87c"
-  integrity sha512-j4nzWIqEFpLSbdhUApHRGDwfXbV8ALhqOn+FY5L6XBdKPAXU9BpGgFSbDsgqogfqPPR9R2WooseWCsfhfEC6uQ==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
@@ -5684,15 +5664,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-query-string@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
-  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
 
 query-string@^4.1.0:
   version "4.3.4"


### PR DESCRIPTION
[`amplitude-js` is about 60kb](https://bundlephobia.com/result?p=amplitude-js@4.6.0), and post-build I see the vendor bundle reduced by 58kb with this change. It's doing a lot of complex stuff to fingerprint users and devices, which we're not interested in. This PR replaces it with a much simpler and more transparent way of gathering metrics.