### PR TITLE
Added 'sign with lyra' in TransactionSigner; Styled its api's result

### DIFF
--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -27,6 +27,7 @@ import NETWORK from '../constants/network';
 import Libify from '../utilities/Libify';
 import {addEventHandler} from '../utilities/metrics'
 import transactionSignerMetrics from '../metricsHandlers/transactionSigner'
+import TxLyraSign from "./TxLyraSign";
 
 const {signTransaction} = Libify
 
@@ -172,18 +173,11 @@ class TransactionSigner extends React.Component {
                   >Sign with BIP Path</button>
                   {ledgerwalletMessage}
                 </OptionsTablePair>
-                {isConnected() && <OptionsTablePair label="Lyra">
-                  <button
-                    className="s-button TxSignerKeys__signLyra"
-                    onClick={() => {
-                      // TODO: dispatch(signWithLyra(xdr, networkPassphrase))
-                      console.log(new Error('not implemented'))
-                    }}
-                  >
-                    Sign with Lyra
-                  </button>
-                  {ledgerwalletMessage}
-                </OptionsTablePair>}
+                {isConnected() && (
+                    <OptionsTablePair label="Lyra">
+                      <TxLyraSign xdr={xdr} />
+                    </OptionsTablePair>
+                  )}
               </div>
 
             </div>

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -16,8 +16,6 @@ import TransactionImporter from './TransactionImporter';
 import TX_TYPES from '../constants/transaction_types';
 
 const ConnectWithLyra = ({ onUpdate }) => {
-
-
   const connectLyra = async() => {
   let response = "";
 

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -129,6 +129,7 @@ class TxBuilderResult extends React.Component {
         </pre>
         {signingInstructions}
         {signingLink} {xdrLink}
+        <hr />
         {isConnected() && transactionBuild && !transactionBuild.errors.length ? (
           <TxLyraSign xdr={transactionBuild.xdr} />
         ) : null}

--- a/src/components/TxBuilderResult.js
+++ b/src/components/TxBuilderResult.js
@@ -129,9 +129,11 @@ class TxBuilderResult extends React.Component {
         </pre>
         {signingInstructions}
         {signingLink} {xdrLink}
-        <hr />
         {isConnected() && transactionBuild && !transactionBuild.errors.length ? (
+          <>
+          <hr />
           <TxLyraSign xdr={transactionBuild.xdr} />
+          </>
         ) : null}
       </div>
     );

--- a/src/components/TxLyraSign.js
+++ b/src/components/TxLyraSign.js
@@ -28,31 +28,6 @@ const signWithLyra = async (xdr, setTxResultMessage, setErrorStatus) => {
   }
 };
 
-const ErrorResultDetails = ({ resultMessage, hasError }) => {
-  const [isClicked, setOnClick] = React.useState(false);
-
-  let arrowIconType = isClicked
-    ? "s-button__dropdown-icon--right"
-    : "s-button__dropdown-icon";
-
-  return (
-    <div>
-      <button
-        type="button"
-        className={arrowIconType}
-        onClick={() => setOnClick(!isClicked)}
-      >
-        Details
-      </button>
-      {isClicked ? (
-        <div className="TxLyraSign__result-error">
-          <code>{resultMessage}</code>
-        </div>
-      ) : null}
-    </div>
-  );
-};
-
 const TxLyraSign = ({ xdr }) => {
   const [txResultMessage, setTxResultMessage] = React.useState("");
   const [hasError, setErrorStatus] = React.useState(false);
@@ -70,10 +45,9 @@ const TxLyraSign = ({ xdr }) => {
         hasError ? (
           <div className="TxLyraSign__result">
             There was an error signing the transaction:
-            <ErrorResultDetails
-              resultMessage={txResultMessage}
-              hasError={hasError}
-            />
+            <div className="TxLyraSign__result-error">
+              <code>{txResultMessage}</code>
+            </div>
           </div>
         ) : (
           <div className="TxLyraSign__result">

--- a/src/components/TxLyraSign.js
+++ b/src/components/TxLyraSign.js
@@ -7,8 +7,8 @@ import { signTransaction } from "@stellar/lyra-api";
 
 import { CodeBlock } from "./CodeBlock";
 
-const signWithLyra = async (xdr, setTxResult) => {
-  let res = { signedTransaction: "" };
+const signWithLyra = async (xdr, setTxResultMessage, setErrorStatus) => {
+  let res = { signedTransaction: "", error: "" };
 
   try {
     res = await signTransaction({
@@ -19,30 +19,72 @@ const signWithLyra = async (xdr, setTxResult) => {
     console.error(e);
   }
 
-  setTxResult(res.signedTransaction);
+  if (res.error) {
+    setTxResultMessage(res.error);
+    setErrorStatus(true);
+  } else {
+    setTxResultMessage(res.signedTransaction);
+    setErrorStatus(false);
+  }
 };
 
-const TxLyraSign = ({ xdr }) => {
-  const [txResult, setTxResult] = React.useState();
+const ErrorResultDetails = ({ resultMessage, hasError }) => {
+  const [isClicked, setOnClick] = React.useState(false);
+
+  let arrowIconType = isClicked
+    ? "s-button__dropdown-icon--right"
+    : "s-button__dropdown-icon";
 
   return (
     <div>
-      <hr />
+      <button
+        type="button"
+        className={arrowIconType}
+        onClick={() => setOnClick(!isClicked)}
+      >
+        Details
+      </button>
+      {isClicked ? (
+        <div className="TxLyraSign__result-error">
+          <code>{resultMessage}</code>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const TxLyraSign = ({ xdr }) => {
+  const [txResultMessage, setTxResultMessage] = React.useState("");
+  const [hasError, setErrorStatus] = React.useState(false);
+
+  return (
+    <div>
       <button
         className="s-button"
         type="button"
-        onClick={() => signWithLyra(xdr, setTxResult)}
+        onClick={() => signWithLyra(xdr, setTxResultMessage, setErrorStatus)}
       >
-        Sign with Lyra
+        {txResultMessage ? "Sign again" : "Sign with Lyra"}
       </button>
-      {txResult ? (
-        <div>
-          <CodeBlock
-            className="AccountCreator__spaceTop"
-            code={JSON.stringify(txResult, null, 2)}
-            language="json"
-          />
-        </div>
+      {txResultMessage ? (
+        hasError ? (
+          <div className="TxLyraSign__result">
+            There was an error signing the transaction:
+            <ErrorResultDetails
+              resultMessage={txResultMessage}
+              hasError={hasError}
+            />
+          </div>
+        ) : (
+          <div className="TxLyraSign__result">
+            Successfully signed!
+            <CodeBlock
+              className="AccountCreator__spaceTop so-code so-code__wrap"
+              code={JSON.stringify(txResultMessage, null, 2)}
+              language="json"
+            />
+          </div>
+        )
       ) : null}
     </div>
   );

--- a/src/styles/_TxLyraSign.scss
+++ b/src/styles/_TxLyraSign.scss
@@ -1,0 +1,56 @@
+.TxLyraSign__result {
+    padding: 15px 0;
+
+    .CodeBlock {
+        background: $white;
+    }
+    .CodeBlock__code, code {
+        padding: 0;
+    }
+    .token.string {
+        white-space: break-spaces;
+        word-break: break-all;
+    }
+}
+
+.TxLyraSign__result-error {
+    code {
+        color: red;
+    }
+}
+
+.s-button__dropdown-icon, .s-button__dropdown-icon--right {
+  position: relative;
+  padding-left: 20px;
+  padding-top: 5px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    right:0;
+    top:0;
+    bottom:0;
+    z-index:0;
+    width: 3rem;
+  }
+
+  &:after {
+    top: calc(50% - 4px);
+    left:0;
+    width: 0; 
+    height: 0; 
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 9px solid $black;
+    transform: rotate(150deg);
+  }
+}
+
+.s-button__dropdown-icon--right {
+  &:after {
+    transform: rotate(0deg);
+  }
+}

--- a/src/styles/_TxLyraSign.scss
+++ b/src/styles/_TxLyraSign.scss
@@ -14,43 +14,10 @@
 }
 
 .TxLyraSign__result-error {
+  display: inline-block;
+  padding-left: 10px;
+
     code {
         color: red;
     }
-}
-
-.s-button__dropdown-icon, .s-button__dropdown-icon--right {
-  position: relative;
-  padding-left: 20px;
-  padding-top: 5px;
-  cursor: pointer;
-  border: none;
-  background: transparent;
-
-  &:before, &:after {
-    content: '';
-    position: absolute;
-    right:0;
-    top:0;
-    bottom:0;
-    z-index:0;
-    width: 3rem;
-  }
-
-  &:after {
-    top: calc(50% - 4px);
-    left:0;
-    width: 0; 
-    height: 0; 
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 9px solid $black;
-    transform: rotate(150deg);
-  }
-}
-
-.s-button__dropdown-icon--right {
-  &:after {
-    transform: rotate(0deg);
-  }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -49,6 +49,7 @@
   @import 'TxSignerOverview';
   @import 'TxSignerKeys';
   @import 'TxSignerResult';
+  @import 'TxLyraSign';
 
 @import 'XdrViewer';
 


### PR DESCRIPTION
Ticket: [success/error for lyra integration on laboratory](https://app.asana.com/0/1168666457741233/1190641579177919)

I didn't strictly follow the comp that was provided in the ticket:

**Comp:**
<img width="472" alt="comp" src="https://user-images.githubusercontent.com/3912060/93406296-4b77a280-f85d-11ea-862a-8648cf61e37f.png">

**Updates:**
- Using `TxLyraSign` component in `TransactionSigner.js`
- Styling adjustments for responses
- The comp for error message looks like it's expecting an error code and more information. Our current lyra api response is strictly `string`. Also, in `Transaction Builder`, unless all the inputs are verified, signing buttons won't show.

**Screenshot: Transaction Builder Success**
<img width="800" alt="txbuilder-result-success" src="https://user-images.githubusercontent.com/3912060/93406217-2125e500-f85d-11ea-97d4-0b4ac0a864a7.png">

**Screenshot: Transaction Builder Error**
<img width="800" alt="txbuilder-result-error" src="https://user-images.githubusercontent.com/3912060/93406222-23883f00-f85d-11ea-9eac-e1bf3dc54d5e.png">

**Screenshot: Transaction Signer Success**
<img width="800" alt="txsigner-result-success" src="https://user-images.githubusercontent.com/3912060/93406218-22571200-f85d-11ea-99fd-1c5ba327a42b.png">

**Screenshot: Transaction Signer Error**
<img width="800" alt="txsigner-result-error" src="https://user-images.githubusercontent.com/3912060/93406224-23883f00-f85d-11ea-827e-a19b8b241248.png">
