### PR TITLE
lyra-feature-address-input-btn > calling Lyra's getPublicKey() api to get a public key; updated its svg button to include alt like text

### DIFF
--- a/src/components/FormComponents/PubKeyPicker.js
+++ b/src/components/FormComponents/PubKeyPicker.js
@@ -4,7 +4,7 @@ import { StrKey } from "stellar-sdk";
 
 import TextPicker from "./TextPicker";
 import { ImportMark } from "../ImportMark";
-import { useLyra } from "../../utilities/useLyra";
+import { useLyra, lyraGetPublicKey } from "../../utilities/useLyra";
 
 export default function PubKeyPicker({
   placeholder,
@@ -33,10 +33,7 @@ export default function PubKeyPicker({
       {hasLyra && (
         <button
           type="button"
-          onClick={() => {
-            // TODO
-            console.log(new Error("not implemented"));
-          }}
+          onClick={() => lyraGetPublicKey(onUpdate)}
           className="s-button__icon PubKeyPicker__activator"
         >
           <ImportMark width={24} />

--- a/src/components/ImportMark.js
+++ b/src/components/ImportMark.js
@@ -8,9 +8,12 @@ export const ImportMark = ({ width = 32, height = width, ...props }) => (
     height={height}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 50 52"
+    aria-labelledby="importMarkTitle"
+    role="img"
   >
+    ><title id="importMarkTitle">Import Public Key via Lyra Button</title>
     <path
-      fill-rule="nonzero"
+      fillRule="nonzero"
       d="M1.8 1A1 1 0 001 2v48c0 .6.4 1 1 1h30c.6 0 1-.4 1-1V40h-2v9H3V3h28v9h2V2c0-.6-.4-1-1-1H2h-.2zm23 15a1 1 0 00-.6.4l-9 8.9-.6.7.7.7 8.9 8.9a1 1 0 001.7-.4c.1-.4 0-.8-.3-1L18.4 27H48c.4 0 .7-.2.9-.5a1 1 0 000-1 1 1 0 00-.9-.5H18.4l7.2-7.2a1 1 0 00-.8-1.7z"
     />
   </svg>

--- a/src/components/TxBuilderAttributes.js
+++ b/src/components/TxBuilderAttributes.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { isConnected, getPublicKey } from "@stellar/lyra-api";
 import OptionsTablePair from './OptionsTable/Pair';
 import HelpMark from './HelpMark';
 import TxTypePicker from './FormComponents/TxTypePicker';
@@ -15,25 +14,6 @@ import {fetchSequence, fetchBaseFee, updateTxType, updateFeeBumpAttribute} from 
 import TransactionImporter from './TransactionImporter';
 import TX_TYPES from '../constants/transaction_types';
 
-const ConnectWithLyra = ({ onUpdate }) => {
-  const connectLyra = async() => {
-  let response = "";
-
-  try {
-    response = await getPublicKey();
-  } catch (e) {
-    console.error(e);
-  }
-  const { publicKey, error } = response;
-  onUpdate('sourceAccount', publicKey);
-  }
-
-
-  return (
-    <button className="s-button" type="button" onClick={connectLyra}>Connect Source Account with Lyra</button>
-  )
-}
-
 function TxBuilderAttributes(props) {
   let {onUpdate, attributes, horizonURL, dispatch, feeBumpAttributes, networkPassphrase} = props;
   const {txType, network} = props.state;
@@ -46,7 +26,6 @@ function TxBuilderAttributes(props) {
 
   return <div className="TransactionAttributes">
     <div className="TransactionOp__config TransactionOpConfig optionsTable">
-      {isConnected() ? <ConnectWithLyra onUpdate={onUpdate} /> : null}
       <OptionsTablePair label={<span>Transaction Type <HelpMark href="https://developers.stellar.org/docs/glossary/fee-bumps" /></span>}>
         <TxTypePicker
           value={txType}

--- a/src/utilities/useLyra.js
+++ b/src/utilities/useLyra.js
@@ -1,6 +1,6 @@
 /** @format */
 import React from "react";
-import { isConnected } from "@stellar/lyra-api";
+import { isConnected, getPublicKey } from "@stellar/lyra-api";
 
 export const useLyra = () => {
   const [hasLyra, setHasLyra] = React.useState(false);
@@ -9,4 +9,17 @@ export const useLyra = () => {
     setHasLyra(isConnected());
   });
   return hasLyra;
+};
+
+export const lyraGetPublicKey = async (onUpdate) => {
+  try {
+    const lyraResponse = await getPublicKey();
+
+    if (lyraResponse.error) {
+      return lyraResponse.error;
+    }
+    return onUpdate(lyraResponse.publicKey);
+  } catch (e) {
+    console.log("error while getting a public key: ", e);
+  }
 };

--- a/src/utilities/useLyra.js
+++ b/src/utilities/useLyra.js
@@ -12,14 +12,15 @@ export const useLyra = () => {
 };
 
 export const lyraGetPublicKey = async (onUpdate) => {
+  let lyraPublicKey = "";
+  let error = "";
+
   try {
     const lyraResponse = await getPublicKey();
-
-    if (lyraResponse.error) {
-      return lyraResponse.error;
-    }
-    return onUpdate(lyraResponse.publicKey);
+    lyraPublicKey = lyraResponse.publicKey;
   } catch (e) {
-    console.log("error while getting a public key: ", e);
+    error = e;
   }
+
+  return onUpdate(lyraPublicKey || error);
 };


### PR DESCRIPTION
**Summary:**
- Placed an import button to get a public key in multiple input fields instead of just one "Connect Source Account with Lyra"
- Updated SVG to include `<title/>` so when users don't know what this button is about, they can just hover over and see the text "Import Public Key via Lyra Button"

<img width="386" alt="screenshot-laboratory" src="https://user-images.githubusercontent.com/3912060/93933235-5748e600-fcef-11ea-807d-7e245b4cb06f.png">
