### PR TITLE
Update style of sign transaction buttons

### DIFF
--- a/src/components/TransactionSigner.js
+++ b/src/components/TransactionSigner.js
@@ -90,7 +90,7 @@ class TransactionSigner extends React.Component {
       if (!isUndefined(result.xdr)) {
         codeResult = <pre className="TxSignerResult__xdr so-code so-code__wrap" onClick={clickToSelect}><code>{result.xdr}</code></pre>;
         submitLink = <a
-          className="s-button TxSignerResult__submit"
+          className="s-button TxSignerResult__primary"
           href={txPostLink(result.xdr)}
           onClick={scrollOnAnchorOpen}
           >Submit in Transaction Submitter</a>;

--- a/src/styles/_TxSignerKeys.scss
+++ b/src/styles/_TxSignerKeys.scss
@@ -5,4 +5,13 @@
 
 .TxSignerKeys__signBipPath {
   margin-top: 0.5em;
+  background-color: white !important;
+  border-color: gray !important;
+  color: black;
+}
+
+.TxSignerKeys__signBipPath:hover {
+  border-color: black !important;
+  background-color: white !important;
+  color: black !important;
 }

--- a/src/styles/_TxSignerResult.scss
+++ b/src/styles/_TxSignerResult.scss
@@ -16,4 +16,15 @@
   }
   .TxSignerResult__submit {
     margin-top: 1em;
+    background-color: #009688    !important; 
+    border: 1px solid #00897b !important; 
+  }
+  .TxSignerResult__submit:hover {
+    margin-top: 1em;
+    background-color: #00897b !important; 
+    border: 1px solid #00897b !important; 
+  }
+  .TxSignerResult__primary {
+    margin-top: 1em;
+
   }


### PR DESCRIPTION
# Before:
<img width="1159" alt="Screen Shot 2020-10-31 at 22 48 16" src="https://user-images.githubusercontent.com/34353640/97790714-28197480-1bcb-11eb-8e3f-880d76f6df3d.png">

___


# After 
<img width="1159" alt="Screen Shot 2020-10-31 at 22 47 52" src="https://user-images.githubusercontent.com/34353640/97790704-1afc8580-1bcb-11eb-8e82-1a9701279760.png">

I'm not a designer, but I still think that will be more intuitive than before. 

closes #494