### PR TITLE
Update Makefile to label image with timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/laboratory:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --rfc-3339=seconds)
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
 	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # If TAG is not provided set default value
 TAG ?= stellar/laboratory:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --rfc-3339=seconds)
 
 docker-build:
-	$(SUDO) docker build --build-arg AMPLITUDE_KEY=$(AMPLITUDE_KEY) -t $(TAG) .
+	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	--build-arg AMPLITUDE_KEY=$(AMPLITUDE_KEY) -t $(TAG) .
 
 docker-push:
 	$(SUDO) docker push $(TAG)


### PR DESCRIPTION
The label can be used to determine build timestamp which can be
different from image tag or layer push timestamp