### PR TITLE
Gracefully fail statuspage.io call

### DIFF
--- a/src/components/MaintenanceBanner.js
+++ b/src/components/MaintenanceBanner.js
@@ -73,8 +73,15 @@ export default class TestnetBanner extends React.Component {
         return (
           <div className="LaboratoryChrome__network_reset_alert s-alert">
             <div className="so-chunk">
-              Failed to fetch testnet reset date. Your browser extension may be
-              blocking the call.
+              Failed to fetch testnet reset date. Check status{" "}
+              <a
+                href="https://9sl3dhr1twv1.statuspage.io/"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                here
+              </a>
+              .
             </div>
           </div>
         );

--- a/src/components/MaintenanceBanner.js
+++ b/src/components/MaintenanceBanner.js
@@ -5,12 +5,17 @@ import React from "react";
 
 // If we're on the test network, we care about all scheduled maintenance. If
 // we're on the public network, we only care about public network maintenance
-const isMaintenanceRelevant = (allMaintenance, currentNetwork) =>
-  allMaintenance.filter((m) =>
+const isMaintenanceRelevant = (allMaintenance, currentNetwork) => {
+  if (!allMaintenance) {
+    return null;
+  }
+
+  return allMaintenance.filter((m) =>
     m.components.some((c) =>
       currentNetwork === "test" ? true : c.name === "Stellar Public Network",
     ),
   );
+};
 
 const getNextMaintenance = (schedule) =>
   schedule.sort(
@@ -62,6 +67,20 @@ export default class TestnetBanner extends React.Component {
       maintenance,
       currentNetwork,
     );
+
+    if (!relevantMaintenance) {
+      if (currentNetwork === "test") {
+        return (
+          <div className="LaboratoryChrome__network_reset_alert s-alert">
+            <div className="so-chunk">
+              Failed to fetch testnet reset date. Your browser extension may be
+              blocking the call.
+            </div>
+          </div>
+        );
+      }
+      return null;
+    }
 
     if (relevantMaintenance.length === 0) {
       if (currentNetwork === "test") {


### PR DESCRIPTION
Privacy Badger Chrome extension was crashing Laboratory (nothing but a white page was rendered). This fix gracefully fails if `statuspage.io` call is blocked, showing a message in the banner.

![image](https://user-images.githubusercontent.com/7346473/108119552-f8a15180-706d-11eb-9579-ac387c5b7211.png)