### PR TITLE
Switch build image to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:16.04 as build
+FROM ubuntu:20.04 as build
 
 MAINTAINER SDF Ops Team <ops@stellar.org>
 
 WORKDIR /app/src
 
-RUN apt-get update && apt-get install -y curl git make apt-transport-https && \
-    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb https://deb.nodesource.com/node_10.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install --no-install-recommends -y gpg curl git make ca-certificates apt-transport-https && \
+    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key|gpg --dearmor >/etc/apt/trusted.gpg.d/nodesource.gpg && \
+    echo "deb https://deb.nodesource.com/node_10.x focal main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |gpg --dearmor >/etc/apt/trusted.gpg.d/yarnpkg.gpg && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install -y nodejs yarn && apt-get clean
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TAG ?= stellar/laboratory:$(shell git rev-parse --short HEAD)$(and $(shell git s
 BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
-	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg AMPLITUDE_KEY=$(AMPLITUDE_KEY) -t $(TAG) .
 
 docker-push:


### PR DESCRIPTION
* switch to ubuntu 20.04 base image
* move away from deprecated "apt-key add"
* use --no-install-recommends to reduce number of packages installed
* add --pull to the Makefile to ensure we always use latest images