### PR TITLE
BUG: Fix `claimClaimableBalance` source account being ignored

### DIFF
--- a/src/utilities/Libify.js
+++ b/src/utilities/Libify.js
@@ -350,7 +350,7 @@ Libify.Operation.claimClaimableBalance = function(opts) {
 
   return Sdk.Operation.claimClaimableBalance({
     balanceId: opts.balanceId,
-    claimant: opts.sourceAccount,
+    source: opts.sourceAccount
   });
 }
 


### PR DESCRIPTION
If a source account was specified in the `Claim Claimable Balance` operation it was ignored and thus the transactions source account was being used.  
I was able to trace this back to a misnamed field in the `Libify.js`.