### PR TITLE
Update docker image build timestamp format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/laboratory:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \


### PR DESCRIPTION
Golang time parser is not compatible with format rendered by the GNU date,
even though both claim to be RFC3339. This change replaces space separator
between date and time with "T" which will allow golang to parse it.
It also switches from `--utc` to `-u` that's supported by both GNU and BSD
date commands.