### PR TITLE
Bug fix: allow muxed account in fee bump transactions

### DIFF
--- a/src/helpers/Libify.js
+++ b/src/helpers/Libify.js
@@ -731,18 +731,10 @@ Libify.buildFeeBumpTransaction = function (attributes, networkPassphrase) {
     return result;
   }
 
-  let keyPair;
-  try {
-    keyPair = Sdk.Keypair.fromPublicKey(sourceAccount);
-  } catch (e) {
-    result.errors.push(e.message);
-    return result;
-  }
-
   let feeBumpTx;
   try {
     feeBumpTx = new Sdk.TransactionBuilder.buildFeeBumpTransaction(
-      keyPair,
+      sourceAccount,
       maxFee,
       innerTx,
       networkPassphrase,


### PR DESCRIPTION
We can replace `Keypair` with a `string` in `buildFeeBumpTransaction` as the source account (only public address would be used from `Keypair` anyway). This fixes the bug where the muxed account wasn't accepted as a source in fee bump transactions.