### PR TITLE
Add an introduction/tour 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.9",
     "route-recognizer": "^0.3.4",
+    "shepherd.js": "^8.3.1",
     "solar-stellarorg": "git+https://github.com/stellar/solar-stellarorg#master",
     "stellar-sdk": "^9.0.0-beta.0",
     "trezor-connect": "^8.1.27",

--- a/src/constants/tour.ts
+++ b/src/constants/tour.ts
@@ -10,6 +10,7 @@ const options: Tour.TourOptions = {
         },
         buttons: [
             {
+                classes: 's-button',
                 text: 'Continue',
                 action() {
                     this.next();
@@ -37,6 +38,17 @@ const awaitElementExistence = (selector: string) => {
     });
 };
 
+/**
+ * The other Hackaround. 
+ * Could probably be replaced by manipulating state-management directly.
+ */
+const click = (selector: string) => {
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLElement) {
+        element.click();
+    }
+};
+
 
 const steps: Step.StepOptions[] = [
     {
@@ -52,10 +64,11 @@ const steps: Step.StepOptions[] = [
         },
         buttons: [
             {
+                classes: 's-button',
                 text: 'Continue',
                 action() {
                     // TODO: think how to make this workaround less hacky
-                    (document.querySelector('.NetworkPicker .s-buttonGroup__wrapper:first-child') as HTMLElement).click();
+                    click('.NetworkPicker .s-buttonGroup__wrapper:first-child');
                     this.next();
                 },
             },
@@ -71,7 +84,7 @@ const steps: Step.StepOptions[] = [
         when: {
             show() {
                 // TODO: think how to make this workaround less hacky
-                (document.querySelector('[href="#account-creator"]') as HTMLElement).click();
+                click('[href="#account-creator"]');
             },
         },
     },
@@ -98,7 +111,7 @@ const steps: Step.StepOptions[] = [
         when: {
             show() {
                 // TODO: think how to make this workaround less hacky
-                (document.querySelector('[href="#explorer"]') as HTMLElement).click();
+                click('[href="#explorer"]');
             },
         },
         attachTo: {
@@ -116,9 +129,10 @@ const steps: Step.StepOptions[] = [
         },
         buttons: [
             {
+                classes: 's-button',
                 text: 'Continue',
                 action() {
-                    (document.querySelector('.EndpointPicker__section nav li:first-child') as HTMLElement).click();
+                    click('.EndpointPicker__section nav li:first-child');
                     this.next();
                 },
             },
@@ -141,7 +155,7 @@ const steps: Step.StepOptions[] = [
         },
         when: {
             show() {
-                (document.querySelector('[href="#txbuilder"]') as HTMLElement).click();
+                click('[href="#txbuilder"]');
             },
         },
     },
@@ -179,7 +193,7 @@ const steps: Step.StepOptions[] = [
         },
         when: {
             show() {
-                (document.querySelector('[href="#txsigner"]') as HTMLElement).click();
+                click('[href="#txsigner"]');
             },
         },
     },
@@ -203,7 +217,7 @@ const steps: Step.StepOptions[] = [
         },
         when: {
             show() {
-                (document.querySelector('[href="#xdr-viewer"]') as HTMLElement).click();
+                click('[href="#xdr-viewer"]');
             },
         },
     },

--- a/src/constants/tour.ts
+++ b/src/constants/tour.ts
@@ -38,7 +38,7 @@ const awaitElementExistence = (selector: string) => {
 };
 
 /**
- * The other Hackaround. 
+ * The other Hackaround.
  * Could probably be replaced by manipulating state-management directly.
  */
 const click = (selector: string) => {
@@ -52,11 +52,11 @@ const click = (selector: string) => {
 const steps: Step.StepOptions[] = [
     {
         title: 'Welcome in Laboratories Tour!',
-        text: 'In the next few minutes you\'ll go through the Steps on how to explore state on the Stellar Network, create Transactions and more.',
+        text: 'In the next few minutes you\'ll go through the Steps on how to explore the state of the Stellar Network, create Transactions and more.',
     },
     {
         title: 'The network selector',
-        text: 'This is the network selector, there are multiple Stellar Networks. You can even run your own and connect to it via the "custom" button. The most used networks are the public network and the SDF testnet. For now we\'ll stay on testnet.',
+        text: 'This is the network selector. There are multiple Stellar Networks. You can even run your own and connect to it via the "custom" button. The most used networks are the public network and the SDF testnet. For now we\'ll stay on testnet.',
         attachTo: {
             element: '.NetworkPicker',
             on: 'bottom-end',
@@ -75,7 +75,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'Account creation',
-        text: 'Before you can start making transactions on the network, you need a keypair and fund an account. On testnet you can do both under the "Create account" tab.',
+        text: 'Before you can start making transactions on the network, you need a keypair to an account and you need to fund that account. On testnet you can do both under the "Create account" tab.',
         attachTo: {
             element: '[href="#account-creator"]',
             on: 'bottom',
@@ -98,7 +98,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'Friendbot',
-        text: 'To fund an account on testnet, you can utilise Friendbot! Just paste your public key and friendbot will give you a few testnet XLM.',
+        text: 'To fund an account on testnet, you can utilise Friendbot! Just paste the generated public key and friendbot will give you a few XLM to use on the testnet.',
         attachTo: {
             element: '[data-testid="page-friendbot"]',
             on: 'bottom',
@@ -106,7 +106,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'Explore Endpoints',
-        text: 'The "Explore Endpoints" tab allows you to query Horizon for different resources on the network.',
+        text: 'The "Explore Endpoints" tab allows you to query Horizon for information about different resources on the network.',
         when: {
             show() {
                 // TODO: think how to make this workaround less hacky
@@ -139,7 +139,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'Resources',
-        text: 'For most resource (e.g. accounts in this case) you can select if you want to query a specific resource by its id or if you want to list multiple. In any case Laboratory will show you fields and options you can (or need to) specify to get a result that matches your needs.',
+        text: 'For most resources (e.g. accounts in this case) you can select if you want to query a specific resource by its id or if you want to list multiple. In any case Laboratory will show you fields and options you can (or need to) specify to get a result that matches your needs.',
         attachTo: {
             element: '.EndpointExplorer__picker div:nth-child(2) nav',
             on: 'bottom',
@@ -147,7 +147,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'Build Transaction',
-        text: 'Laboratories Transaction Builder lets you compose transactions without writing a single line of code.',
+        text: 'Laboratory\'s "Transaction Builder" tab lets you compose transactions without writing a single line of code. This is often the easiest way to learn how Stellar transactions work.',
         attachTo: {
             element: '[href="#txbuilder"]',
             on: 'bottom',
@@ -164,7 +164,7 @@ const steps: Step.StepOptions[] = [
         text: 'This form allows you to set general transaction parameters like the source account, sequence number or memo.',
         attachTo: {
             element: '.TransactionOp__config',
-            on: 'top', 
+            on: 'top',
         },
     },
     {
@@ -176,7 +176,7 @@ const steps: Step.StepOptions[] = [
         scrollTo: true,
     },
     {
-        text: 'Laboratory shows you the result of building your transaction here. This can be either error messages if some of your parameters didn\'t match basic validation or the build transaction XDR and buttons to sign or view it.',
+        text: 'Laboratory shows you the result of building your transaction here. This can be either error messages (if some of your parameters didn\'t match basic validation), or the transaction XDR you\'ve built along with buttons to sign or view it.',
         attachTo: {
             element: '.TransactionBuilder__result',
             on: 'top',
@@ -185,7 +185,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'Sign Transaction',
-        text: 'In most cases you\'ll want to sign your transaction after building it. Laboratories "Sign Transaction" tab got you covered for that.',
+        text: 'In most cases you\'ll want to sign your transaction after building it. Laboratory\'s "Sign Transaction" tab has got you covered for that.',
         attachTo: {
             element: '[href="#txsigner"]',
             on: 'bottom',
@@ -200,7 +200,7 @@ const steps: Step.StepOptions[] = [
         // TODO: either "live create" XDR in a transaction builder tutorial or include example XDR to import.
         beforeShowPromise: () => awaitElementExistence('.TransactionSigner'),
         title: 'Signing Transactions',
-        text: 'To import your transaction, you can either click the button on the "Build Transaction" tab or paste it into this text field. Once the tranaaction got imported, you got multiple options to sign it. For example directly with a secret key, using a hardware wallet or with browser extension wallets like albedo or freighter.',
+        text: 'To import your transaction, you can either click the "Sign in Transaction Signer" button on the "Build Transaction" tab or paste it into this text field. Once the transaction has been imported, you have multiple options to sign it. For example directly with a secret key, using a hardware wallet or with browser extension wallets like albedo or freighter.',
         attachTo: {
             element: '.xdrInput__input__textarea',
             on: 'top',
@@ -209,7 +209,7 @@ const steps: Step.StepOptions[] = [
     {
         // TODO: include example XDR to show.
         title: 'View XDR',
-        text: 'Sometimes you want to know what XDR you got does. This can be helpful when for example your tranaction returned errors when you tried to submit it. The result XDR can show you what went wrong.',
+        text: 'Sometimes you want to know what the XDR you have is actually doing. This can be very helpful, for example your tranaction may have returned errors when you tried to submit it. The result XDR you receive from the network can show you what went wrong.',
         attachTo: {
             element: '[href="#xdr-viewer"]',
             on: 'bottom',
@@ -223,7 +223,7 @@ const steps: Step.StepOptions[] = [
     {
         beforeShowPromise: () => awaitElementExistence('.xdrInput__input__textarea'),
         title: 'View XDR',
-        text: 'Here you can enter your XDR but pasting it. You may also get here page by clicking XDR (or related buttons) at some of Laboratories sections, for example by clicking XDR in Horizons responses in the "Explore Endpoints" tab.',
+        text: 'Here you can enter your XDR by pasting it. You may also arrive here by clicking XDR (or related buttons) contained in some of Laboratory\'s sections, for example by clicking XDR in Horizon\'s responses in the "Explore Endpoints" tab.',
         attachTo: {
             element: '.xdrInput__input__textarea',
             on: 'right',
@@ -231,7 +231,7 @@ const steps: Step.StepOptions[] = [
     },
     {
         title: 'View XDR',
-        text: 'When you entered your XDR you may need to change the type of the XDR. You can find the most commonly viewed types at the top of the list.',
+        text: 'When you have entered your XDR, you may need to change the type of the XDR. You can find the most commonly viewed types at the top of this list.',
         attachTo: {
             element: '.XdrViewer__setup .so-dropdown',
             on: 'right',

--- a/src/constants/tour.ts
+++ b/src/constants/tour.ts
@@ -1,0 +1,234 @@
+import Shepherd from 'shepherd.js';
+import type Tour from 'shepherd.js/src/types/tour';
+import type Step from 'shepherd.js/src/types/step';
+import "shepherd.js/dist/css/shepherd.css";
+
+const options: Tour.TourOptions = {
+    defaultStepOptions: {
+        cancelIcon: {
+            enabled: true,
+        },
+        buttons: [
+            {
+                text: 'Continue',
+                action() {
+                    this.next();
+                },
+            },
+        ],
+    },
+    useModalOverlay: true,
+};
+
+/**
+ * required to wait for async loaded chunks and let the tour pause until we got content
+ * TODO: dig into labs statemanagement to find out if the state is mapped internally
+ * and without dirty hacks
+ */
+const awaitElementExistence = (selector: string) => {
+    return new Promise<void>(res => {
+        let interval: NodeJS.Timer;
+        interval = setInterval(() => {
+            if (document.querySelector(selector) != null) {
+                clearInterval(interval);
+                res();
+            }
+        }, 200);
+    });
+};
+
+
+const steps: Step.StepOptions[] = [
+    {
+        title: 'Welcome in Laboratories Tour!',
+        text: 'In the next few minutes you\'ll go through the Steps on how to explore state on the Stellar Network, create Transactions and more.',
+    },
+    {
+        title: 'The network selector',
+        text: 'This is the network selector, there are multiple Stellar Networks. You can even run your own and connect to it via the "custom" button. The most used networks are the public network and the SDF testnet. For now we\'ll stay on testnet.',
+        attachTo: {
+            element: '.NetworkPicker',
+            on: 'bottom-end',
+        },
+        buttons: [
+            {
+                text: 'Continue',
+                action() {
+                    // TODO: think how to make this workaround less hacky
+                    (document.querySelector('.NetworkPicker .s-buttonGroup__wrapper:first-child') as HTMLElement).click();
+                    this.next();
+                },
+            },
+        ],
+    },
+    {
+        title: 'Account creation',
+        text: 'Before you can start making transactions on the network, you need a keypair and fund an account. On testnet you can do both under the "Create account" tab.',
+        attachTo: {
+            element: '[href="#account-creator"]',
+            on: 'bottom',
+        },
+        when: {
+            show() {
+                // TODO: think how to make this workaround less hacky
+                (document.querySelector('[href="#account-creator"]') as HTMLElement).click();
+            },
+        },
+    },
+    {
+        beforeShowPromise: () => awaitElementExistence('.AccountCreator__section'),
+        title: 'Keypairs',
+        text: 'Every account on the network starts with a keypair. You can generate a new one here.',
+        attachTo: {
+            element: '.AccountCreator__section .s-button',
+            on: 'top',
+        },
+    },
+    {
+        title: 'Friendbot',
+        text: 'To fund an account on testnet, you can utilise Friendbot! Just paste your public key and friendbot will give you a few testnet XLM.',
+        attachTo: {
+            element: '[data-testid="page-friendbot"]',
+            on: 'bottom',
+        },
+    },
+    {
+        title: 'Explore Endpoints',
+        text: 'The "Explore Endpoints" tab allows you to query Horizon for different resources on the network.',
+        when: {
+            show() {
+                // TODO: think how to make this workaround less hacky
+                (document.querySelector('[href="#explorer"]') as HTMLElement).click();
+            },
+        },
+        attachTo: {
+            element: '[href="#explorer"]',
+            on: 'bottom',
+        },
+    },
+    {
+        beforeShowPromise: () => awaitElementExistence('.EndpointPicker__section'),
+        title: 'Resources',
+        text: 'Here you can select what resource you are looking for, for example accounts, assets or offers.',
+        attachTo: {
+            element: '.EndpointPicker__section nav',
+            on: 'right',
+        },
+        buttons: [
+            {
+                text: 'Continue',
+                action() {
+                    (document.querySelector('.EndpointPicker__section nav li:first-child') as HTMLElement).click();
+                    this.next();
+                },
+            },
+        ],
+    },
+    {
+        title: 'Resources',
+        text: 'For most resource (e.g. accounts in this case) you can select if you want to query a specific resource by its id or if you want to list multiple. In any case Laboratory will show you fields and options you can (or need to) specify to get a result that matches your needs.',
+        attachTo: {
+            element: '.EndpointExplorer__picker div:nth-child(2) nav',
+            on: 'bottom',
+        },
+    },
+    {
+        title: 'Build Transaction',
+        text: 'Laboratories Transaction Builder lets you compose transactions without writing a single line of code.',
+        attachTo: {
+            element: '[href="#txbuilder"]',
+            on: 'bottom',
+        },
+        when: {
+            show() {
+                (document.querySelector('[href="#txbuilder"]') as HTMLElement).click();
+            },
+        },
+    },
+    {
+        beforeShowPromise: () => awaitElementExistence('.TransactionOp__config'),
+        title: 'Transaction Builder',
+        text: 'This form allows you to set general transaction parameters like the source account, sequence number or memo.',
+        attachTo: {
+            element: '.TransactionOp__config',
+            on: 'top', 
+        },
+    },
+    {
+        title: 'Operations',
+        text: 'For your transactions to do anything, you need to add operations. Laboratory will show you added operations and fields depending on the type of operation here.',
+        attachTo: {
+            element: '.TransactionOperations',
+            on: 'top',
+        },
+    },
+    {
+        title: 'Transaction',
+        text: 'Laboratory shows you the result of building your transaction here. This can be either error messages if some of your parameters didn\'t match basic validation or the build transaction XDR and button to sign or view it.',
+        attachTo: {
+            element: '.TransactionBuilder__result',
+            on: 'top',
+        },
+    },
+    {
+        title: 'Sign Transaction',
+        text: 'In most cases you\'ll want to sign your transaction after building it. Laboratories "Sign Transaction" tab got you covered for that.',
+        attachTo: {
+            element: '[href="#txsigner"]',
+            on: 'bottom',
+        },
+        when: {
+            show() {
+                (document.querySelector('[href="#txsigner"]') as HTMLElement).click();
+            },
+        },
+    },
+    {
+        // TODO: either "live create" XDR in a transaction builder tutorial or include example XDR to import.
+        beforeShowPromise: () => awaitElementExistence('.TransactionSigner'),
+        title: 'Signing Transactions',
+        text: 'To import your transaction, you can either click the button on the "Build Transaction" tab or paste it into this text field. Once the tranaaction got imported, you got multiple options to sign it. For example directly with the secret key, using a hardware wallet like Ledger or with albedo.',
+        attachTo: {
+            element: '.xdrInput__input__textarea',
+            on: 'top',
+        },
+    },
+    {
+        // TODO: include example XDR to show.
+        title: 'View XDR',
+        text: 'Sometimes you want to know what XDR you got does. This can be helpful when for example your tranaction returned errors when you tried to submit it. The result XDR can show you what went wrong.',
+        attachTo: {
+            element: '[href="#xdr-viewer"]',
+            on: 'bottom',
+        },
+        when: {
+            show() {
+                (document.querySelector('[href="#xdr-viewer"]') as HTMLElement).click();
+            },
+        },
+    },
+    {
+        beforeShowPromise: () => awaitElementExistence('.xdrInput__input__textarea'),
+        title: 'View XDR',
+        text: 'Here you can enter your XDR but pasting it. You may also get here page by clicking XDR (or related buttons) at some of Laboratories sections, for example by clicking XDR in Horizons responses in the "Explore Endpoints" tab.',
+        attachTo: {
+            element: '.xdrInput__input__textarea',
+            on: 'right',
+        },
+    },
+    {
+        title: 'View XDR',
+        text: 'When you entered your XDR you may need to change the type of the XDR. You can find the most commonly viewed types at the top of the list.',
+        attachTo: {
+            element: '.XdrViewer__setup .so-dropdown',
+            on: 'right',
+        },
+    },
+    {
+        title: 'End of Tour',
+        text: 'You now have seen all sections of Laboratory and reached the end of this tour. You can restart it at any time from the "Introduction" tab, if you whish to.',
+    },
+];
+
+export const tour = new Shepherd.Tour(options);
+tour.addSteps(steps);

--- a/src/constants/tour.ts
+++ b/src/constants/tour.ts
@@ -1,7 +1,6 @@
 import Shepherd from 'shepherd.js';
 import type Tour from 'shepherd.js/src/types/tour';
 import type Step from 'shepherd.js/src/types/step';
-import "shepherd.js/dist/css/shepherd.css";
 
 const options: Tour.TourOptions = {
     defaultStepOptions: {
@@ -169,20 +168,20 @@ const steps: Step.StepOptions[] = [
         },
     },
     {
-        title: 'Operations',
         text: 'For your transactions to do anything, you need to add operations. Laboratory will show you added operations and fields depending on the type of operation here.',
         attachTo: {
             element: '.TransactionOperations',
             on: 'top',
         },
+        scrollTo: true,
     },
     {
-        title: 'Transaction',
-        text: 'Laboratory shows you the result of building your transaction here. This can be either error messages if some of your parameters didn\'t match basic validation or the build transaction XDR and button to sign or view it.',
+        text: 'Laboratory shows you the result of building your transaction here. This can be either error messages if some of your parameters didn\'t match basic validation or the build transaction XDR and buttons to sign or view it.',
         attachTo: {
             element: '.TransactionBuilder__result',
             on: 'top',
         },
+        scrollTo: true,
     },
     {
         title: 'Sign Transaction',
@@ -201,7 +200,7 @@ const steps: Step.StepOptions[] = [
         // TODO: either "live create" XDR in a transaction builder tutorial or include example XDR to import.
         beforeShowPromise: () => awaitElementExistence('.TransactionSigner'),
         title: 'Signing Transactions',
-        text: 'To import your transaction, you can either click the button on the "Build Transaction" tab or paste it into this text field. Once the tranaaction got imported, you got multiple options to sign it. For example directly with the secret key, using a hardware wallet like Ledger or with albedo.',
+        text: 'To import your transaction, you can either click the button on the "Build Transaction" tab or paste it into this text field. Once the tranaaction got imported, you got multiple options to sign it. For example directly with a secret key, using a hardware wallet or with browser extension wallets like albedo or freighter.',
         attachTo: {
             element: '.xdrInput__input__textarea',
             on: 'top',

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -6,8 +6,13 @@
 @import 'solar-css/styles/index';
 @import '~solar-stellarorg/styles/index';
 
+
 // External libraries
 @import 'prism';
+// Shepherd css for the tour overlay modals
+// Probably could be moved into a async loaded chunk before the tour starts
+// but reacts build system is a mystery to me
+@import 'shepherd.js/dist/css/shepherd';
 
 // General css modules (these go first to allow for low specificity overwriting for page components)
 @import 'optionsTable';

--- a/src/views/Introduction.tsx
+++ b/src/views/Introduction.tsx
@@ -1,4 +1,8 @@
-import { tour } from "constants/tour";
+// helper to import the tour and it's dependencies 
+// only when it's needed and not on every page load
+const startTour = () => {
+  import("constants/tour").then(module => module.tour.start());
+};
 
 export const Introduction = () => {
   return (
@@ -24,7 +28,7 @@ export const Introduction = () => {
             <p>
               If you need a quick tour to find you way around Laboratory, we got you covered!
             </p>
-            <button onClick={tour.start} className="s-button">
+            <button onClick={startTour} className="s-button">
               Start Tour
             </button>
             <p>

--- a/src/views/Introduction.tsx
+++ b/src/views/Introduction.tsx
@@ -1,4 +1,4 @@
-// helper to import the tour and it's dependencies 
+// helper to import the tour and it's dependencies
 // only when it's needed and not on every page load
 const startTour = () => {
   import("constants/tour").then(module => module.tour.start());
@@ -26,7 +26,7 @@ export const Introduction = () => {
               .
             </p>
             <p>
-              If you need a quick tour to find you way around Laboratory, we got you covered!
+              If you need a quick tour to find your way around Laboratory, we got you covered!
             </p>
             <button onClick={startTour} className="s-button">
               Start Tour

--- a/src/views/Introduction.tsx
+++ b/src/views/Introduction.tsx
@@ -23,10 +23,10 @@ export const Introduction = () => {
             </p>
             <p>
               If you need a quick tour to find you way around Laboratory, we got you covered!
-              <button onClick={tour.start}>
-                Start Tour
-              </button>
             </p>
+            <button onClick={tour.start} className="s-button">
+              Start Tour
+            </button>
             <p>
               For Stellar docs, take a look at the{" "}
               <a href="https://developers.stellar.org/">

--- a/src/views/Introduction.tsx
+++ b/src/views/Introduction.tsx
@@ -1,7 +1,7 @@
 // helper to import the tour and it's dependencies
 // only when it's needed and not on every page load
 const startTour = () => {
-  import("constants/tour").then(module => module.tour.start());
+  import("./Tour").then(module => module.tour.start());
 };
 
 export const Introduction = () => {

--- a/src/views/Introduction.tsx
+++ b/src/views/Introduction.tsx
@@ -1,3 +1,5 @@
+import { tour } from "constants/tour";
+
 export const Introduction = () => {
   return (
     <div className="Introduction" data-testid="page-introduction">
@@ -19,7 +21,12 @@ export const Introduction = () => {
               </a>
               .
             </p>
-
+            <p>
+              If you need a quick tour to find you way around Laboratory, we got you covered!
+              <button onClick={tour.start}>
+                Start Tour
+              </button>
+            </p>
             <p>
               For Stellar docs, take a look at the{" "}
               <a href="https://developers.stellar.org/">

--- a/src/views/Tour.ts
+++ b/src/views/Tour.ts
@@ -15,15 +15,18 @@ const options: Tour.TourOptions = {
                     this.next();
                 },
             },
+            // We should probably add a previous step button
+            // but that would require UI state to be changed 
+            // "backwarts" for most steps navigating between pages
         ],
     },
     useModalOverlay: true,
 };
 
 /**
- * required to wait for async loaded chunks and let the tour pause until we got content
- * TODO: dig into labs statemanagement to find out if the state is mapped internally
- * and without dirty hacks
+ * Hackaround/helper required to wait for async rendered content.
+ * The tour encounters this when navigating between pages as most pages 
+ * import() their chunk when needed.
  */
 const awaitElementExistence = (selector: string) => {
     return new Promise<void>(res => {
@@ -38,8 +41,10 @@ const awaitElementExistence = (selector: string) => {
 };
 
 /**
- * The other Hackaround.
- * Could probably be replaced by manipulating state-management directly.
+ * The workaround/helper used to navigate / modify UI state.
+ * 99.9% of this could be replaced by manipulating the store directly.
+ * But this may introduce behaviour changes when buttons are changed without updating the tour,
+ * so I'm not sure if faking the bahavior via store or relying on click-listeners is uglier. 
  */
 const click = (selector: string) => {
     const element = document.querySelector(selector);
@@ -66,7 +71,6 @@ const steps: Step.StepOptions[] = [
                 classes: 's-button',
                 text: 'Continue',
                 action() {
-                    // TODO: think how to make this workaround less hacky
                     click('.NetworkPicker .s-buttonGroup__wrapper:first-child');
                     this.next();
                 },
@@ -82,7 +86,6 @@ const steps: Step.StepOptions[] = [
         },
         when: {
             show() {
-                // TODO: think how to make this workaround less hacky
                 click('[href="#account-creator"]');
             },
         },
@@ -109,7 +112,6 @@ const steps: Step.StepOptions[] = [
         text: 'The "Explore Endpoints" tab allows you to query Horizon for information about different resources on the network.',
         when: {
             show() {
-                // TODO: think how to make this workaround less hacky
                 click('[href="#explorer"]');
             },
         },
@@ -197,7 +199,6 @@ const steps: Step.StepOptions[] = [
         },
     },
     {
-        // TODO: either "live create" XDR in a transaction builder tutorial or include example XDR to import.
         beforeShowPromise: () => awaitElementExistence('.TransactionSigner'),
         title: 'Signing Transactions',
         text: 'To import your transaction, you can either click the "Sign in Transaction Signer" button on the "Build Transaction" tab or paste it into this text field. Once the transaction has been imported, you have multiple options to sign it. For example directly with a secret key, using a hardware wallet or with browser extension wallets like albedo or freighter.',
@@ -207,7 +208,7 @@ const steps: Step.StepOptions[] = [
         },
     },
     {
-        // TODO: include example XDR to show.
+        // Would be awsome to either build or include some example XDR to show in the following steps
         title: 'View XDR',
         text: 'Sometimes you want to know what the XDR you have is actually doing. This can be very helpful, for example your tranaction may have returned errors when you tried to submit it. The result XDR you receive from the network can show you what went wrong.',
         attachTo: {


### PR DESCRIPTION
This is a more or less "prototype" version to pitch the idea.
Most of the work I've done started at Meridian 2021's Docsprint.
You can find a [demo of the current state here](https://laboratory.kany.xyz).

## The idea 💡 
Most developers starting their journey into the Stellar Network will sooner or later meet Laboratory.
While Laboratory is an awsome tool, it can be hard to wrap your head around at first.
So a more or less interactive Tutorial/Tour should give people a headstart on where they need to look out for specific features.

I could go deep into Labs features but for now it's a very basic overview over the different pages. We could expand it later as far as needed.

## The implementation ⚙️ 
I've seen (non open source) tour components build in react, but all of them have/had trouble with steps across js-chunks and blow up the js bundle size even when they're not used by the user.
For this prototype I'm using [Sheperd](https://shepherdjs.dev/), a well known library for Tour overlays.
The js is dynamically import()-ed when the tour is started, the only overhead loaded every time is shepherds css as I did't get around to lookup how I could dynamically import it without breaking jest.

### Open TODOs / Things to discuss 🔧 
- In this version I'm manipulating Labs state by [emitting click events](https://github.com/Kanaye/laboratory/blob/430526851dabf5d338b695d8dd7a728c8635c1a9/src/views/Tour.ts#L43-L54) on buttons/links.
Most of this could be replaced by using the redux store, as this code is fairly ugly and easy to break.
But manipulating the store could lead to different behavior of the tour and the real UI elements.
- The selectos I've used are either [href attributes](https://github.com/Kanaye/laboratory/blob/430526851dabf5d338b695d8dd7a728c8635c1a9/src/views/Tour.ts#L89), [easy to break selector chains](https://github.com/Kanaye/laboratory/blob/430526851dabf5d338b695d8dd7a728c8635c1a9/src/views/Tour.ts#L74) or event [data-testid](https://github.com/Kanaye/laboratory/blob/430526851dabf5d338b695d8dd7a728c8635c1a9/src/views/Tour.ts#L106). This should probably be changed to either fixed ids or it's own data-attribute like `data-tour-anchor` to make it more obvious that this element is part of the tour.
- Integration tests: As the tour (by it's nature of living along with react) is seperated from the views but interacts with them, it's fairly easy to break it by accident. So adding integration tests to ensure that elements are highlighted and the "next" button works are probably a good idea.

---

I'll happily continue work on this, but it may take time as I'm fairly busy.
But I'd love to hear thought and feedback on the idea, my points from above and anything else implementation related.