### PR TITLE
Changing 'signatures' to 'transactions' on the #txsigner view introduction

### DIFF
--- a/src/views/TransactionSigner.tsx
+++ b/src/views/TransactionSigner.tsx
@@ -477,7 +477,7 @@ export const TransactionSigner = () => {
             </p>
             <p>
               For simple transactions, you only need one signature from the
-              correct account. Some advanced signatures may require more than
+              correct account. Some advanced transactions may require more than
               one signature if there are multiple source accounts or signing
               keys.
             </p>


### PR DESCRIPTION
I noticed this while guiding a quester through transaction building/signing/submitting. It seems like the word 'transactions' is what is meant here, rather than 'signatures.'

I very well could be wrongly assuming the intent, and if I am feel free to ignore this PR. Just thought I'd submit it in case it's a useful catch. 👍🏻 