### PR TITLE
Updates keypair generator view to include funding link on futurenet

### DIFF
--- a/src/views/KeypairGenerator.tsx
+++ b/src/views/KeypairGenerator.tsx
@@ -11,6 +11,7 @@ export const KeypairGenerator = () => {
   const { keypairGeneratorResult, keypairGeneratorPubKey } = accountCreator;
   const baseURL = network.current.horizonURL;
   const IS_TESTNET = baseURL === NETWORK.available.test.horizonURL;
+  const IS_FUTURENET = baseURL === NETWORK.available.futurenet.horizonURL;
 
   const dispatch = useDispatch();
 
@@ -39,7 +40,7 @@ export const KeypairGenerator = () => {
   };
 
   const renderKeypairGeneratorLink = () => {
-    if (IS_TESTNET && keypairGeneratorPubKey !== "") {
+    if ((IS_TESTNET || IS_FUTURENET) && keypairGeneratorPubKey !== "") {
       return (
         <a
           onClick={() =>


### PR DESCRIPTION
The link to fund with freidnbot underneath the generated public/secret key does not show up when using futurenet. It's a small problem, but has slowed me down enought times I thought I'd contribute a fix.