### PR TITLE
upgrade freighter-api to use latest and pass it network passphrase

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ledgerhq/hw-app-str": "^6.24.1",
     "@ledgerhq/hw-transport-webusb": "^6.24.1",
     "@reduxjs/toolkit": "^1.7.2",
-    "@stellar/freighter-api": "1.1.2",
+    "@stellar/freighter-api": "^1.3.1",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",
     "axios": "^0.25.0",

--- a/src/views/TransactionSigner.tsx
+++ b/src/views/TransactionSigner.tsx
@@ -434,14 +434,7 @@ export const TransactionSigner = () => {
                       className="s-button"
                       data-testid="transaction-signer-freighter-sign-button"
                       onClick={() => {
-                        dispatch(
-                          signWithFreighter(
-                            xdr,
-                            networkPassphrase === Networks.TESTNET
-                              ? "TESTNET"
-                              : "PUBLIC",
-                          ),
-                        );
+                        dispatch(signWithFreighter(xdr, { networkPassphrase }));
                       }}
                     >
                       Sign with Freighter

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,10 +2587,10 @@
   resolved "https://registry.yarnpkg.com/@stellar/eslint-config/-/eslint-config-2.1.2.tgz#95c223d10a5dfc2c89486e76cc7c9f1b56df3564"
   integrity sha512-5aUkncDMmx0SvVlZD4rld5snGKt3mc0Gno1Jik3Pp31HUmpgrkRUD3ZZekEOqB9mDKadZhQZNNsS0jhyuXaayw==
 
-"@stellar/freighter-api@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@stellar/freighter-api/-/freighter-api-1.1.2.tgz#9529352c7e4ac59087e14d16620d69322fca2e76"
-  integrity sha512-2vrPsOn1N3DYTff1763lM1eOy+LNKfkQPH5A3mXlKb3mDUK50wsyM6U03Y1DK/C/9dlMA49FspQ9Es2RF6NpPw==
+"@stellar/freighter-api@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@stellar/freighter-api/-/freighter-api-1.3.1.tgz#8cd38d054f9b670ed64a226164b92a63b3aedbc7"
+  integrity sha512-Up8TjHxhw6NCZb1qA1O2jlnnRrd5ZKs9ZHLGa2D501HmVD4yav2SKiuG18xe/PMsbg3S4mAIN4nhG+c06wPCYw==
 
 "@stellar/prettier-config@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
This change fixes an issue where Lab was telling Freighter that an XDR was either on MAINNET or TESTNET. It didn't allow for signing on FUTURENET or custom networks.