### PR TITLE
Fix base fee when returning to Build Txn tab

### DIFF
--- a/src/views/TxBuilderAttributes.js
+++ b/src/views/TxBuilderAttributes.js
@@ -33,7 +33,11 @@ function TxBuilderAttributes(props) {
   const [networkMinFee, setNetworkMinFee] = useState(attributes["minFee"]);
 
   useEffect(() => {
-    dispatch(fetchBaseFee(horizonURL));
+    // Don't fetch base fee again if txn has a sequence number (when returning
+    // to Build Transaction tab). Refetching base fee resets previously set fee.
+    if (!attributes.sequence) {
+      dispatch(fetchBaseFee(horizonURL));
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Keep the base fee when returning to the Build Transaction tab. Without the fix, it resets to the base fee.