### PR TITLE
Upgrade Ubuntu to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:22.04 as build
 
 MAINTAINER SDF Ops Team <ops@stellar.org>
 


### PR DESCRIPTION
### What:
Upgrade Ubuntu to 22.04 from 20.04


### Why:

We want to upgrade Ubuntu base image to 22.04.


