### PR TITLE
correct a link on the endpoint explorer to Horizon API documentation

### DIFF
--- a/src/views/EndpointExplorer.tsx
+++ b/src/views/EndpointExplorer.tsx
@@ -32,7 +32,7 @@ export const EndpointExplorer = () => {
           <p>
             This tool can be used to run queries against the{" "}
             <a
-              href="https://developers.stellar.org/api/introduction/"
+              href="https://developers.stellar.org/api/horizon"
               rel="noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
We were made aware of an incorrect link in the "Endpoint Explorer" to the REST API documentation that pointed to the URL that used to serve only Horizon, but now is a "generalized" intro page for all the APIs documentation.

This commit fixes that incorrect link.

Refs: stellar/stellar-docs#300