### PR TITLE
Update laborabory-v2 Dockerfile to serve content via node server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,11 @@
-FROM ubuntu:22.04 as build
+FROM node:18-alpine
 
-LABEL maintainer="SDF Ops Team <ops@stellar.org>"
-
-RUN mkdir -p /app
+ENV NEXT_TELEMETRY_DISABLED 1
+ENV PORT 80
 WORKDIR /app
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install --no-install-recommends -y gpg curl git make ca-certificates apt-transport-https && \
-    curl -sSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key|gpg --dearmor >/etc/apt/trusted.gpg.d/nodesource-key.gpg && \
-    echo "deb https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |gpg --dearmor >/etc/apt/trusted.gpg.d/yarnpkg.gpg && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install -y nodejs yarn && apt-get clean
-
-
-COPY . /app/
-RUN yarn git-info
+COPY . .
 RUN yarn install
 RUN yarn build
-
-FROM nginx:1.17
-
-COPY --from=build /app/build/ /usr/share/nginx/html/
-COPY --from=build /app/nginx.conf /etc/nginx/conf.d/default.conf
+# Run on port 80 for compatibility with laboratory v1
+EXPOSE 80
+CMD ["npm", "start"]

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "export",
+  //output: "export",
   distDir: "build",
 };
 


### PR DESCRIPTION
### What

 Update laborabory-v2 Dockerfile to serve content via node server #743 

### Why

Previews for laboratory-v2 are currently broken