### PR TITLE
[banner] display the correct soroban network

### DIFF
--- a/src/components/SorobanBanner.tsx
+++ b/src/components/SorobanBanner.tsx
@@ -1,7 +1,9 @@
 import { useIsSoroban } from "hooks/useIsSoroban";
+import { useRedux } from "hooks/useRedux";
 
 export const SorobanBanner = () => {
   let isSoroban = useIsSoroban();
+  const { network } = useRedux("network");
 
   return isSoroban ? (
     <div className="LaboratoryChrome__soroban_alert s-alert">
@@ -14,7 +16,7 @@ export const SorobanBanner = () => {
         >
           Soroban
         </a>{" "}
-        test network
+        {network.current.name} network
       </div>
     </div>
   ) : null;

--- a/src/hooks/useIsSoroban.ts
+++ b/src/hooks/useIsSoroban.ts
@@ -2,7 +2,7 @@ import NETWORK from "constants/network.js";
 import { useRedux } from "hooks/useRedux";
 
 export const useIsSoroban = () => {
-  const { network } = useRedux("network", "routing");
+  const { network } = useRedux("network");
   const { horizonURL, networkPassphrase } = network.current;
   const url = new URL(horizonURL);
 


### PR DESCRIPTION
our current [laboratory](https://laboratory.stellar.org/) isn't showing the correct network for `futurenet`. It displays `testnet`.

Before:
![before](https://github.com/stellar/laboratory/assets/3912060/5e331565-2a7b-4091-9137-76c9eac71038)

After:
<img width="687" alt="after" src="https://github.com/stellar/laboratory/assets/3912060/4a906b0f-5abb-41a0-87a9-b6af203a1dc0">
