### PR TITLE
[Create Account] Fund account with Friend button behavior

### DIFF
--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -1,18 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Card, Text, Button } from "@stellar/design-system";
+import { Card, Text, Button } from "@stellar/design-system";
 import { Keypair } from "@stellar/stellar-sdk";
 
 import { useStore } from "@/store/useStore";
 import { useFriendBot } from "@/query/useFriendBot";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
 import { useIsTestingNetwork } from "@/hooks/useIsTestingNetwork";
 
 import { GenerateKeypair } from "@/components/GenerateKeypair";
 import { ExpandBox } from "@/components/ExpandBox";
+import { SuccessMsg } from "@/components/FriendBot/SuccessMsg";
+import { ErrorMsg } from "@/components/FriendBot/ErrorMsg";
 
 import "../styles.scss";
 
@@ -62,6 +63,8 @@ export default function CreateAccount() {
   }, [account.registeredNetwork, network.id]);
 
   const generateKeypair = () => {
+    resetStates();
+
     const keypair = Keypair.random();
 
     if (IS_TESTING_NETWORK) {
@@ -98,6 +101,7 @@ export default function CreateAccount() {
                 size="md"
                 disabled={!account.publicKey || isLoading}
                 variant="tertiary"
+                isLoading={isLoading}
                 onClick={() => refetch()}
                 data-testid="fundAccount-button"
               >
@@ -119,34 +123,22 @@ export default function CreateAccount() {
         </div>
       </Card>
 
-      {showAlert && isFetchedAfterMount && isSuccess && account.publicKey && (
-        <Alert
-          placement="inline"
-          variant="success"
-          actionLabel="View on stellar.expert"
-          actionLink={`https://stellar.expert/explorer/${network.id}/account/${account.publicKey}`}
-          onClose={() => {
-            setShowAlert(false);
-          }}
-          title={`Successfully funded ${shortenStellarAddress(account.publicKey)} on 
-          ${network.id}`}
-        >
-          {""}
-        </Alert>
-      )}
+      <SuccessMsg
+        isVisible={Boolean(
+          showAlert && isFetchedAfterMount && isSuccess && account.publicKey,
+        )}
+        onClose={() => {
+          setShowAlert(false);
+        }}
+      />
 
-      {showAlert && isFetchedAfterMount && isError && (
-        <Alert
-          placement="inline"
-          variant="error"
-          onClose={() => {
-            setShowAlert(false);
-          }}
-          title={error?.message}
-        >
-          {""}
-        </Alert>
-      )}
+      <ErrorMsg
+        isVisible={Boolean(showAlert && isFetchedAfterMount && isError)}
+        errorMsg={error?.message}
+        onClose={() => {
+          setShowAlert(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -132,6 +132,7 @@ export default function CreateAccount() {
       </Card>
 
       <SuccessMsg
+        publicKey={account.publicKey!}
         isVisible={Boolean(showAlert && isSuccess && account.publicKey)}
         onClose={() => {
           setShowAlert(false);

--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -40,7 +40,7 @@ export default function CreateAccount() {
     resetQuery();
   }, [resetQuery]);
 
-  const { error, isError, isLoading, isSuccess, refetch, isFetchedAfterMount } =
+  const { error, isError, isFetching, isLoading, isSuccess, refetch } =
     useFriendBot({
       network,
       publicKey: account.publicKey!,
@@ -101,8 +101,11 @@ export default function CreateAccount() {
                 size="md"
                 disabled={!account.publicKey || isLoading}
                 variant="tertiary"
-                isLoading={isLoading}
-                onClick={() => refetch()}
+                isLoading={isLoading || isFetching}
+                onClick={() => {
+                  resetQuery();
+                  refetch();
+                }}
                 data-testid="fundAccount-button"
               >
                 Fund account with Friendbot
@@ -124,16 +127,14 @@ export default function CreateAccount() {
       </Card>
 
       <SuccessMsg
-        isVisible={Boolean(
-          showAlert && isFetchedAfterMount && isSuccess && account.publicKey,
-        )}
+        isVisible={Boolean(showAlert && isSuccess && account.publicKey)}
         onClose={() => {
           setShowAlert(false);
         }}
       />
 
       <ErrorMsg
-        isVisible={Boolean(showAlert && isFetchedAfterMount && isError)}
+        isVisible={Boolean(showAlert && isError)}
         errorMsg={error?.message}
         onClose={() => {
           setShowAlert(false);

--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -92,7 +92,12 @@ export default function CreateAccount() {
             </Text>
           </div>
           <div className="Account__CTA" data-testid="createAccount-buttons">
-            <Button size="md" variant="secondary" onClick={generateKeypair}>
+            <Button
+              disabled={isLoading || isFetching}
+              size="md"
+              variant="secondary"
+              onClick={generateKeypair}
+            >
               Generate keypair
             </Button>
 

--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -1,24 +1,39 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Card, Text, Button } from "@stellar/design-system";
+import { Alert, Card, Text, Button } from "@stellar/design-system";
 import { Keypair } from "@stellar/stellar-sdk";
 
-import { useIsTestingNetwork } from "@/hooks/useIsTestingNetwork";
-import { Routes } from "@/constants/routes";
 import { useStore } from "@/store/useStore";
+import { useFriendBot } from "@/query/useFriendBot";
+
+import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
+import { useIsTestingNetwork } from "@/hooks/useIsTestingNetwork";
 import { GenerateKeypair } from "@/components/GenerateKeypair";
 import { ExpandBox } from "@/components/ExpandBox";
 
 import "../styles.scss";
 
 export default function CreateAccount() {
-  const { account } = useStore();
+  const { account, network } = useStore();
   const router = useRouter();
   const [secretKey, setSecretKey] = useState("");
+  const [showAlert, setShowAlert] = useState<boolean>(false);
 
   const IS_TESTING_NETWORK = useIsTestingNetwork();
+
+  const { error, isError, isLoading, isSuccess, refetch, isFetchedAfterMount } =
+    useFriendBot({
+      network: network.id,
+      publicKey: account.publicKey,
+    });
+
+  useEffect(() => {
+    if (isError || isSuccess) {
+      setShowAlert(true);
+    }
+  }, [isError, isSuccess]);
 
   const generateKeypair = () => {
     const keypair = Keypair.random();
@@ -46,11 +61,16 @@ export default function CreateAccount() {
             <Button size="md" variant="secondary" onClick={generateKeypair}>
               Generate keypair
             </Button>
+
             {IS_TESTING_NETWORK ? (
               <Button
                 size="md"
                 variant="tertiary"
-                onClick={() => router.push(Routes.ACCOUNT_FUND)}
+                onClick={() => {
+                  if (account.publicKey) {
+                    refetch();
+                  }
+                }}
               >
                 Fund account with Friendbot
               </Button>
@@ -67,6 +87,35 @@ export default function CreateAccount() {
           </ExpandBox>
         </div>
       </Card>
+
+      {showAlert && isFetchedAfterMount && isSuccess && (
+        <Alert
+          placement="inline"
+          variant="success"
+          actionLabel="View on stellar.expert"
+          actionLink={`https://stellar.expert/explorer/${network.id}/account/${account.publicKey}`}
+          onClose={() => {
+            setShowAlert(false);
+          }}
+          title={`Successfully funded ${shortenStellarAddress(account.publicKey)} on 
+          ${network.id}`}
+        >
+          {""}
+        </Alert>
+      )}
+
+      {showAlert && isFetchedAfterMount && isError && (
+        <Alert
+          placement="inline"
+          variant="error"
+          onClose={() => {
+            setShowAlert(false);
+          }}
+          title={error?.message}
+        >
+          {""}
+        </Alert>
+      )}
     </div>
   );
 }

--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -99,6 +99,7 @@ export default function CreateAccount() {
                 disabled={!account.publicKey || isLoading}
                 variant="tertiary"
                 onClick={() => refetch()}
+                data-testid="fundAccount-button"
               >
                 Fund account with Friendbot
               </Button>

--- a/src/app/(sidebar)/account/fund/page.tsx
+++ b/src/app/(sidebar)/account/fund/page.tsx
@@ -107,7 +107,7 @@ export default function FundAccount() {
       {showAlert && isFetchedAfterMount && isSuccess && (
         <Alert
           placement="inline"
-          variant="primary"
+          variant="success"
           actionLabel="View on stellar.expert"
           actionLink={`https://stellar.expert/explorer/${network.id}/account/${account.publicKey}`}
           onClose={() => {

--- a/src/app/(sidebar)/account/fund/page.tsx
+++ b/src/app/(sidebar)/account/fund/page.tsx
@@ -25,11 +25,18 @@ export default function FundAccount() {
 
   const IS_TESTING_NETWORK = useIsTestingNetwork();
 
-  const { error, isError, isLoading, isSuccess, refetch, isFetchedAfterMount } =
-    useFriendBot({
-      network,
-      publicKey: generatedPublicKey,
-    });
+  const {
+    error,
+    isError,
+    isFetching,
+    isLoading,
+    isSuccess,
+    refetch,
+    isFetchedAfterMount,
+  } = useFriendBot({
+    network,
+    publicKey: generatedPublicKey,
+  });
 
   useEffect(() => {
     if (
@@ -89,8 +96,8 @@ export default function FundAccount() {
             <Button
               disabled={!generatedPublicKey || Boolean(inlineErrorMessage)}
               size="md"
-              variant={isFetchedAfterMount && isError ? "error" : "secondary"}
-              isLoading={isLoading}
+              variant="secondary"
+              isLoading={isLoading || isFetching}
               onClick={() => {
                 if (!inlineErrorMessage) {
                   refetch();
@@ -101,7 +108,7 @@ export default function FundAccount() {
             </Button>
 
             <Button
-              disabled={!account.publicKey || isLoading}
+              disabled={!account.publicKey || isLoading || isFetching}
               size="md"
               variant="tertiary"
               onClick={() => {

--- a/src/app/(sidebar)/account/fund/page.tsx
+++ b/src/app/(sidebar)/account/fund/page.tsx
@@ -25,9 +25,19 @@ export default function FundAccount() {
 
   const { error, isError, isLoading, isSuccess, refetch, isFetchedAfterMount } =
     useFriendBot({
-      network: network.id,
+      network,
       publicKey: generatedPublicKey,
     });
+
+  useEffect(() => {
+    if (
+      account.registeredNetwork?.id &&
+      account.registeredNetwork.id !== network.id
+    ) {
+      account.reset();
+      setShowAlert(false);
+    }
+  }, [account.registeredNetwork, network.id]);
 
   useEffect(() => {
     if (isError || isSuccess) {
@@ -66,7 +76,6 @@ export default function FundAccount() {
             value={generatedPublicKey}
             onChange={(e) => {
               setGeneratedPublicKey(e.target.value);
-
               const error = validate.publicKey(e.target.value);
               setInlineErrorMessage(error || "");
             }}
@@ -95,7 +104,7 @@ export default function FundAccount() {
               variant="tertiary"
               onClick={() => {
                 setInlineErrorMessage("");
-                setGeneratedPublicKey(account.publicKey);
+                setGeneratedPublicKey(account.publicKey!);
               }}
             >
               Fill in with generated key
@@ -104,7 +113,7 @@ export default function FundAccount() {
         </div>
       </Card>
 
-      {showAlert && isFetchedAfterMount && isSuccess && (
+      {showAlert && isFetchedAfterMount && isSuccess && account.publicKey && (
         <Alert
           placement="inline"
           variant="success"

--- a/src/app/(sidebar)/account/fund/page.tsx
+++ b/src/app/(sidebar)/account/fund/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Alert, Card, Input, Text, Button } from "@stellar/design-system";
+import { Card, Input, Text, Button } from "@stellar/design-system";
 import Link from "next/link";
 import { Routes } from "@/constants/routes";
 
-import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
 import { useIsTestingNetwork } from "@/hooks/useIsTestingNetwork";
 import { useFriendBot } from "@/query/useFriendBot";
 import { useStore } from "@/store/useStore";
 
 import { validate } from "@/validate";
+
+import { SuccessMsg } from "@/components/FriendBot/SuccessMsg";
+import { ErrorMsg } from "@/components/FriendBot/ErrorMsg";
 
 import "../styles.scss";
 
@@ -113,33 +115,22 @@ export default function FundAccount() {
         </div>
       </Card>
 
-      {showAlert && isFetchedAfterMount && isSuccess && account.publicKey && (
-        <Alert
-          placement="inline"
-          variant="success"
-          actionLabel="View on stellar.expert"
-          actionLink={`https://stellar.expert/explorer/${network.id}/account/${account.publicKey}`}
-          onClose={() => {
-            setShowAlert(false);
-          }}
-          title={`Successfully funded ${shortenStellarAddress(account.publicKey)} on 
-          ${network.id}`}
-        >
-          {""}
-        </Alert>
-      )}
-      {showAlert && isFetchedAfterMount && isError && (
-        <Alert
-          placement="inline"
-          variant="error"
-          onClose={() => {
-            setShowAlert(false);
-          }}
-          title={error?.message}
-        >
-          {""}
-        </Alert>
-      )}
+      <SuccessMsg
+        isVisible={Boolean(
+          showAlert && isFetchedAfterMount && isSuccess && account.publicKey,
+        )}
+        onClose={() => {
+          setShowAlert(false);
+        }}
+      />
+
+      <ErrorMsg
+        isVisible={Boolean(showAlert && isFetchedAfterMount && isError)}
+        errorMsg={error?.message}
+        onClose={() => {
+          setShowAlert(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/app/(sidebar)/account/fund/page.tsx
+++ b/src/app/(sidebar)/account/fund/page.tsx
@@ -79,7 +79,7 @@ export default function FundAccount() {
           </div>
 
           <Input
-            id="generate-keypair-publickey"
+            id="fund-public-key-input"
             fieldSize="md"
             label="Public Key"
             value={generatedPublicKey}
@@ -123,9 +123,8 @@ export default function FundAccount() {
       </Card>
 
       <SuccessMsg
-        isVisible={Boolean(
-          showAlert && isFetchedAfterMount && isSuccess && account.publicKey,
-        )}
+        isVisible={Boolean(showAlert && isFetchedAfterMount && isSuccess)}
+        publicKey={generatedPublicKey}
         onClose={() => {
           setShowAlert(false);
         }}

--- a/src/app/(sidebar)/account/layout.tsx
+++ b/src/app/(sidebar)/account/layout.tsx
@@ -16,7 +16,7 @@ export default function AccountTemplate({
         navItems: [
           {
             route: Routes.ACCOUNT_CREATE,
-            label: "Create Account",
+            label: "Create Account Keypair",
           },
           {
             route: Routes.ACCOUNT_FUND,

--- a/src/components/FriendBot/ErrorMsg.tsx
+++ b/src/components/FriendBot/ErrorMsg.tsx
@@ -8,8 +8,8 @@ export const ErrorMsg = ({
   onClose: () => void | undefined;
   isVisible: boolean;
   errorMsg: string | undefined;
-}) => {
-  return isVisible ? (
+}) =>
+  isVisible ? (
     <Alert
       placement="inline"
       variant="error"
@@ -19,4 +19,3 @@ export const ErrorMsg = ({
       {""}
     </Alert>
   ) : null;
-};

--- a/src/components/FriendBot/ErrorMsg.tsx
+++ b/src/components/FriendBot/ErrorMsg.tsx
@@ -1,0 +1,22 @@
+import { Alert } from "@stellar/design-system";
+
+export const ErrorMsg = ({
+  onClose,
+  isVisible,
+  errorMsg,
+}: {
+  onClose: () => void | undefined;
+  isVisible: boolean;
+  errorMsg: string | undefined;
+}) => {
+  return isVisible ? (
+    <Alert
+      placement="inline"
+      variant="error"
+      onClose={onClose}
+      title={errorMsg}
+    >
+      {""}
+    </Alert>
+  ) : null;
+};

--- a/src/components/FriendBot/SuccessMsg.tsx
+++ b/src/components/FriendBot/SuccessMsg.tsx
@@ -1,0 +1,37 @@
+import { Alert } from "@stellar/design-system";
+
+import { useStore } from "@/store/useStore";
+
+import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
+
+export const SuccessMsg = ({
+  onClose,
+  isVisible,
+}: {
+  onClose: () => void | undefined;
+  isVisible: boolean;
+}) => {
+  const { account, network } = useStore();
+  const IS_STELLAR_EXPERT_ENABLED =
+    network.id === "testnet" || network.id === "mainnet";
+
+  return isVisible ? (
+    <Alert
+      placement="inline"
+      variant="success"
+      actionLabel={
+        IS_STELLAR_EXPERT_ENABLED ? "View on stellar.expert" : undefined
+      }
+      actionLink={
+        IS_STELLAR_EXPERT_ENABLED
+          ? `https://stellar.expert/explorer/${network.id}/account/${account.publicKey}`
+          : undefined
+      }
+      onClose={onClose}
+      title={`Successfully funded ${shortenStellarAddress(account.publicKey!)} on 
+    ${network.id}`}
+    >
+      {""}
+    </Alert>
+  ) : null;
+};

--- a/src/components/FriendBot/SuccessMsg.tsx
+++ b/src/components/FriendBot/SuccessMsg.tsx
@@ -6,12 +6,14 @@ import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
 
 export const SuccessMsg = ({
   onClose,
+  publicKey,
   isVisible,
 }: {
   onClose: () => void | undefined;
+  publicKey: string;
   isVisible: boolean;
 }) => {
-  const { account, network } = useStore();
+  const { network } = useStore();
   const IS_STELLAR_EXPERT_ENABLED =
     network.id === "testnet" || network.id === "mainnet";
 
@@ -24,11 +26,11 @@ export const SuccessMsg = ({
       }
       actionLink={
         IS_STELLAR_EXPERT_ENABLED
-          ? `https://stellar.expert/explorer/${network.id}/account/${account.publicKey}`
+          ? `https://stellar.expert/explorer/${network.id}/account/${publicKey}`
           : undefined
       }
       onClose={onClose}
-      title={`Successfully funded ${shortenStellarAddress(account.publicKey!)} on 
+      title={`Successfully funded ${shortenStellarAddress(publicKey)} on 
     ${network.id}`}
     >
       {""}

--- a/src/components/GenerateKeypair.tsx
+++ b/src/components/GenerateKeypair.tsx
@@ -4,8 +4,8 @@ export const GenerateKeypair = ({
   publicKey,
   secretKey,
 }: {
-  publicKey: string;
-  secretKey: string;
+  publicKey: string | undefined;
+  secretKey: string | undefined;
 }) => {
   return (
     <div className="Account__keypair">

--- a/src/query/useFriendBot.ts
+++ b/src/query/useFriendBot.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { EmptyObj, Network } from "@/types/types";
 
 import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
 
@@ -6,19 +7,20 @@ export const useFriendBot = ({
   network,
   publicKey,
 }: {
-  network: string;
+  network: Network | EmptyObj;
   publicKey: string;
 }) => {
-  const friendbotURL =
-    network === "futurenet"
-      ? "https://friendbot-futurenet.stellar.org"
-      : "https://friendbot.stellar.org";
-
   const query = useQuery({
     queryKey: ["friendBot"],
     queryFn: async () => {
+      if (!network.horizonUrl) {
+        throw new Error(`Please use a network that supports Horizon`);
+      }
+
       try {
-        const response = await fetch(`${friendbotURL}/?addr=${publicKey}`);
+        const response = await fetch(
+          `${network.horizonUrl}/friendbot?addr=${publicKey}`,
+        );
 
         if (!response.ok) {
           const errorBody = await response.json();

--- a/src/query/useFriendBot.ts
+++ b/src/query/useFriendBot.ts
@@ -25,15 +25,17 @@ export const useFriendBot = ({
         if (!response.ok) {
           const errorBody = await response.json();
 
-          throw new Error(errorBody.status);
+          console.log("errorBody: ", errorBody);
+          throw new Error("there was an error", { cause: errorBody });
         }
         return response;
       } catch (e: any) {
-        if (e.status === 0) {
+        if (e.cause.status === 0) {
           throw new Error(`Unable to reach Friendbot server at ${network}`);
         } else {
           throw new Error(
-            `Unable to fund ${shortenStellarAddress(publicKey)} on the test network`,
+            `Unable to fund ${shortenStellarAddress(publicKey)} on the test network. Details: ${e.cause.detail}`,
+            { cause: e },
           );
         }
       }

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -13,12 +13,14 @@ export interface Store {
 
   // Account
   account: {
-    publicKey: string;
+    publicKey: string | undefined;
+    secretKey: string | undefined;
+    registeredNetwork: Network | EmptyObj;
     generatedMuxedAccountInput: Partial<MuxedAccount> | EmptyObj;
     parsedMuxedAccountInput: string | undefined;
     generatedMuxedAccount: MuxedAccount | EmptyObj;
     parsedMuxedAccount: MuxedAccount | EmptyObj;
-    updatePublicKey: (value: string) => void;
+    updateKeypair: (publicKey: string, secretKey?: string) => void;
     updateGeneratedMuxedAccountInput: (value: Partial<MuxedAccount>) => void;
     updateParsedMuxedAccountInput: (value: string) => void;
     updateGeneratedMuxedAccount: (value: MuxedAccount) => void;
@@ -75,6 +77,16 @@ const initTransactionState = {
   },
 };
 
+const initAccountState = {
+  publicKey: undefined,
+  secretKey: undefined,
+  registeredNetwork: {},
+  generatedMuxedAccountInput: {},
+  parsedMuxedAccountInput: undefined,
+  generatedMuxedAccount: {},
+  parsedMuxedAccount: {},
+};
+
 // Store
 export const createStore = (options: CreateStoreOptions) =>
   create<Store>()(
@@ -97,11 +109,7 @@ export const createStore = (options: CreateStoreOptions) =>
           }),
         // Account
         account: {
-          publicKey: "",
-          generatedMuxedAccountInput: {},
-          parsedMuxedAccountInput: undefined,
-          generatedMuxedAccount: {},
-          parsedMuxedAccount: {},
+          ...initAccountState,
           updateGeneratedMuxedAccountInput: (value: Partial<MuxedAccount>) =>
             set((state) => {
               state.account.generatedMuxedAccountInput = {
@@ -127,13 +135,16 @@ export const createStore = (options: CreateStoreOptions) =>
                 ...value,
               };
             }),
-          updatePublicKey: (value: string) =>
+          updateKeypair: (publicKey: string, secretKey?: string) =>
             set((state) => {
-              state.account.publicKey = value;
+              const defaultSecretKey = secretKey || "";
+              state.account.publicKey = publicKey;
+              state.account.secretKey = defaultSecretKey;
+              state.account.registeredNetwork = state.network;
             }),
           reset: () =>
             set((state) => {
-              state.account.publicKey = "";
+              state.account = { ...state.account, ...initAccountState };
             }),
         },
         // Endpoints

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -137,9 +137,8 @@ export const createStore = (options: CreateStoreOptions) =>
             }),
           updateKeypair: (publicKey: string, secretKey?: string) =>
             set((state) => {
-              const defaultSecretKey = secretKey || "";
               state.account.publicKey = publicKey;
-              state.account.secretKey = defaultSecretKey;
+              state.account.secretKey = secretKey || "";
               state.account.registeredNetwork = state.network;
             }),
           reset: () =>

--- a/tests/createAccountPage.test.ts
+++ b/tests/createAccountPage.test.ts
@@ -29,11 +29,42 @@ test.describe("Create Account Page", () => {
     ).toHaveValue(/^S/);
   });
 
-  test("Test 'Fund account' button", async ({ page }) => {
-    await page
-      .getByRole("button", { name: "Fund account with Friendbot" })
-      .click();
+  test("Successfully funds an account when clicking 'Fund account' with a valid public key", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Generate keypair" }).click();
 
-    await expect(page).toHaveURL(/.*\/account\/fund/);
+    const getLumenButton = page
+      .getByTestId("fundAccount-button")
+      .getByText("Fund account with Friendbot");
+
+    await expect(getLumenButton).toBeEnabled();
+
+    // Mock the friendbot api call
+    await page.route(
+      "*/**/?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({}),
+        });
+      },
+    );
+
+    // Ensure the listener is set up before the action that triggers the request
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("?addr=") && response.status() === 200,
+    );
+
+    await getLumenButton.click();
+
+    // Wait for the mocked response
+    await responsePromise;
+
+    // Success <Alert/> is visible
+    const alertBox = page.getByText(/Successfully funded/);
+    await expect(alertBox).toBeVisible();
   });
 });

--- a/tests/createAccountPage.test.ts
+++ b/tests/createAccountPage.test.ts
@@ -42,7 +42,7 @@ test.describe("Create Account Page", () => {
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/?addr=GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3",
+      "*/**/friendbot?addr=GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3",
       async (route) => {
         await route.fulfill({
           status: 200,

--- a/tests/createAccountPage.test.ts
+++ b/tests/createAccountPage.test.ts
@@ -34,15 +34,15 @@ test.describe("Create Account Page", () => {
   }) => {
     await page.getByRole("button", { name: "Generate keypair" }).click();
 
-    const getLumenButton = page
+    const fundButton = page
       .getByTestId("fundAccount-button")
       .getByText("Fund account with Friendbot");
 
-    await expect(getLumenButton).toBeEnabled();
+    await expect(fundButton).toBeEnabled();
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/friendbot?addr=GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3",
+      "*/**/?addr=GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3",
       async (route) => {
         await route.fulfill({
           status: 200,
@@ -58,7 +58,7 @@ test.describe("Create Account Page", () => {
         response.url().includes("?addr=") && response.status() === 200,
     );
 
-    await getLumenButton.click();
+    await fundButton.click();
 
     // Wait for the mocked response
     await responsePromise;

--- a/tests/createAccountPage.test.ts
+++ b/tests/createAccountPage.test.ts
@@ -42,7 +42,7 @@ test.describe("Create Account Page", () => {
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
+      "*/**/?addr=GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3",
       async (route) => {
         await route.fulfill({
           status: 200,

--- a/tests/fundAccountPage.test.ts
+++ b/tests/fundAccountPage.test.ts
@@ -81,7 +81,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
   }) => {
     // Get a new public key
     const publicKey =
-      "GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3";
+      "GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR";
     const publicKeyInput = page.locator("#generate-keypair-publickey");
     const getLumenButton = page
       .getByTestId("fundAccount-buttons")

--- a/tests/fundAccountPage.test.ts
+++ b/tests/fundAccountPage.test.ts
@@ -49,7 +49,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
   test("By default, 'Public Key' input field is empty and buttons are disabled", async ({
     page,
   }) => {
-    await expect(page.locator("#generate-keypair-publickey")).toHaveValue("");
+    await expect(page.locator("#fund-public-key-input")).toHaveValue("");
 
     const getLumenButton = page
       .getByTestId("fundAccount-buttons")
@@ -65,7 +65,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
   test("Gets an error with an invalid public key in 'Public Key' field", async ({
     page,
   }) => {
-    const publicKeyInput = page.locator("#generate-keypair-publickey");
+    const publicKeyInput = page.locator("#fund-public-key-input");
 
     // Type in an invalid string in 'Public Key' input field
     await publicKeyInput.fill("XLKDSFJLSKDJF");
@@ -79,28 +79,25 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
   test("Successfully funds an account when clicking 'Get lumens' with a valid public key", async ({
     page,
   }) => {
-    // Get a new public key
-    const publicKey =
-      "GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR";
-    const publicKeyInput = page.locator("#generate-keypair-publickey");
+    const publicKeyInput = page.locator("#fund-public-key-input");
     const getLumenButton = page
       .getByTestId("fundAccount-buttons")
       .getByText("Get lumens");
 
-    // Type in an invalid string in 'Public Key' input field
-    await publicKeyInput.fill(publicKey);
+    await publicKeyInput.fill(
+      "GB6D5E2HRVBD6QIOXCE6ILMUFQT45LMSZSKRZUCL4ZK6Q6GCNMTJ2E3C",
+    );
 
     await expect(publicKeyInput).toHaveAttribute("aria-invalid", "false");
     await expect(getLumenButton).toBeEnabled();
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
+      "*/**/?addr=GB6D5E2HRVBD6QIOXCE6ILMUFQT45LMSZSKRZUCL4ZK6Q6GCNMTJ2E3C",
       async (route) => {
         await route.fulfill({
           status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({}),
+          contentType: "application/hal+json",
         });
       },
     );
@@ -113,10 +110,8 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     await getLumenButton.click();
 
-    // Wait for the mocked response
     await responsePromise;
 
-    // Success <Alert/> is visible
     const alertBox = page.getByText(/Successfully funded/);
     await expect(alertBox).toBeVisible();
   });
@@ -124,7 +119,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
   test("Gets an error when submitting 'Get lumens' with a public key that's already been funded", async ({
     page,
   }) => {
-    const publicKeyInput = page.locator("#generate-keypair-publickey");
+    const publicKeyInput = page.locator("#fund-public-key-input");
     const getLumenButton = page
       .getByTestId("fundAccount-buttons")
       .getByText("Get lumens");
@@ -139,12 +134,12 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
+      "*/**/?addr=GBX6W44ISK6XTBDDJ5ND6KTJHLYEYHMR4SDG635NRARYVJ3G2YXGDT6Y",
       async (route) => {
         await route.fulfill({
           status: 400,
-          contentType: "application/json",
-          body: JSON.stringify({}),
+          contentType: "application/problem+json",
+          body: JSON.stringify({ detail: "createAccountAlreadyExist" }),
         });
       },
     );

--- a/tests/fundAccountPage.test.ts
+++ b/tests/fundAccountPage.test.ts
@@ -81,7 +81,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
   }) => {
     // Get a new public key
     const publicKey =
-      "GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR";
+      "GA4X4QMSTEUKWAXXX3TBFRMGWI3O5X5IUUHPKAIH5XKNQ4IBTQ6YSVV3";
     const publicKeyInput = page.locator("#generate-keypair-publickey");
     const getLumenButton = page
       .getByTestId("fundAccount-buttons")

--- a/tests/fundAccountPage.test.ts
+++ b/tests/fundAccountPage.test.ts
@@ -95,7 +95,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
+      "*/**/friendbot?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
       async (route) => {
         await route.fulfill({
           status: 200,
@@ -118,6 +118,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     // Success <Alert/> is visible
     const alertBox = page.getByText(/Successfully funded/);
+    console.log("alertBox: ", alertBox);
     await expect(alertBox).toBeVisible();
   });
 

--- a/tests/fundAccountPage.test.ts
+++ b/tests/fundAccountPage.test.ts
@@ -95,7 +95,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     // Mock the friendbot api call
     await page.route(
-      "*/**/friendbot?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
+      "*/**/?addr=GDVOT2ALMUF3G54RBHNJUEV6LOAZCQQCARHEVNUPKGMVPWFC4PFN33QR",
       async (route) => {
         await route.fulfill({
           status: 200,
@@ -118,7 +118,6 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     // Success <Alert/> is visible
     const alertBox = page.getByText(/Successfully funded/);
-    console.log("alertBox: ", alertBox);
     await expect(alertBox).toBeVisible();
   });
 
@@ -160,7 +159,7 @@ test.describe("[futurenet/testnet] Fund Account Page", () => {
 
     await responsePromise;
 
-    const alertBox = page.getByText(/Unable to fund/);
+    const alertBox = page.getByText(/This account is already funded/);
     await expect(alertBox).toBeVisible();
   });
 


### PR DESCRIPTION
Addresses the following from the issue #819:
- [x] If a user creates an account, the [Fund account with Friendbot] button should fund the account on the screen
- [x] If a user has not created an account, the [Fund account with Friendbot] button should not be clickable and be in a disabled state
- [x] If a user is on mainnet, this button should not be available
- [x] If a user is on a custom work, this button should not be available unless they have inputted Horizon endpint
- [x] (added by Jeesun) clear the the generated public address wasn't cleared when switching network ([thanks iveta](https://github.com/stellar/laboratory/pull/808))