### PR TITLE
[Sign Transaction] Enable persisting data on page refresh 

### DIFF
--- a/src/app/(sidebar)/transaction/sign/components/Import.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Import.tsx
@@ -49,6 +49,7 @@ export const Import = () => {
       updateSignActiveView("overview");
     } catch (e) {
       setTxErrMsg("Unable to import a transaction envelope");
+      updateSignImportXdr("");
       updateSignActiveView("import");
     }
   };

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -141,6 +141,7 @@ export const Overview = () => {
           <div className="SignTx__FieldViewer">
             {mergedFields?.map((field) => {
               const className =
+                field.value &&
                 field.value.toString().length >= MIN_LENGTH_FOR_FULL_WIDTH_FIELD
                   ? "full-width"
                   : "half-width";
@@ -152,7 +153,7 @@ export const Overview = () => {
                       readOnly
                       id={field.label}
                       label={field.label}
-                      value={field.value.toString()}
+                      value={field.value ? field.value.toString() : ""}
                     />
                   </div>
                 );
@@ -163,7 +164,7 @@ export const Overview = () => {
                       readOnly
                       id={field.label}
                       label={field.label}
-                      value={field.value.toString()}
+                      value={field.value ? field.value.toString() : ""}
                       copyButton={{
                         position: "right",
                       }}

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -46,9 +46,7 @@ export const Overview = () => {
 
   useEffect(() => {
     if (!sign.importTx) {
-      if (!sign.importXdr) {
-        updateSignActiveView("import");
-      } else {
+      if (sign.importXdr) {
         // used to persist page data when accessed by query string
         const transaction = TransactionBuilder.fromXDR(
           sign.importXdr,
@@ -56,6 +54,8 @@ export const Overview = () => {
         );
 
         updateSignImportTx(transaction);
+      } else {
+        updateSignActiveView("import");
       }
     }
   }, [

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -49,6 +49,7 @@ export const Overview = () => {
       if (!sign.importXdr) {
         updateSignActiveView("import");
       } else {
+        // used to persist page data when accessed by query string
         const transaction = TransactionBuilder.fromXDR(
           sign.importXdr,
           network.passphrase,

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Card, Icon, Text, Button } from "@stellar/design-system";
-import { FeeBumpTransaction } from "@stellar/stellar-sdk";
+import { FeeBumpTransaction, TransactionBuilder } from "@stellar/stellar-sdk";
 
 import { FEE_BUMP_TX_FIELDS, TX_FIELDS } from "@/constants/signTransactionPage";
 
@@ -23,7 +23,13 @@ const MIN_LENGTH_FOR_FULL_WIDTH_FIELD = 30;
 
 export const Overview = () => {
   const { network, transaction } = useStore();
-  const { sign, updateSignActiveView, updateSignedTx, resetSign } = transaction;
+  const {
+    sign,
+    updateSignActiveView,
+    updateSignImportTx,
+    updateSignedTx,
+    resetSign,
+  } = transaction;
 
   const [secretInputs, setSecretInputs] = useState<string[]>([""]);
   const [signedTxSuccessMsg, setSignedTxSuccessMsg] = useState<string>("");
@@ -40,9 +46,24 @@ export const Overview = () => {
 
   useEffect(() => {
     if (!sign.importTx) {
-      updateSignActiveView("import");
+      if (!sign.importXdr) {
+        updateSignActiveView("import");
+      } else {
+        const transaction = TransactionBuilder.fromXDR(
+          sign.importXdr,
+          network.passphrase,
+        );
+
+        updateSignImportTx(transaction);
+      }
     }
-  }, []);
+  }, [
+    network.passphrase,
+    sign.importTx,
+    sign.importXdr,
+    updateSignActiveView,
+    updateSignImportTx,
+  ]);
 
   const onUpdateSecretInputs = (val: string[]) => {
     setSecretInputs(val);
@@ -83,7 +104,7 @@ export const Overview = () => {
     },
     {
       label: "Transaction Hash",
-      value: sign.importTx!.hash().toString("hex"),
+      value: sign.importTx?.hash().toString("hex"),
     },
   ];
 

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -341,6 +341,10 @@ export const createStore = (options: CreateStoreOptions) =>
             },
             transaction: {
               build: true,
+              sign: {
+                activeView: true,
+                importXdr: true,
+              },
             },
           };
         },


### PR DESCRIPTION
**Summary:** Enable persisting data on page refresh by enabling `select()` for `transaction.sign`

**Steps to reproduce:**
1. Go to `Transactions` -> `Sign Transaction`
2. Use the following XDR address to import transaction: `AAAAAgAAAAB7qREX3pwI1I7gAudjK5DjEh9hFSHA4ALW8V5X7uJnHwAAAGQAAk6yAAAAAwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAC5Z0vCzEVIzmKBmJL9ccsX4yS7Ehcg5Obf8veHb14oQAAAAAAAAAAATEtAAAAAAAAAAAA`
3. Once imported, make sure you're on the `Transaction Overview`
4. Either - Refresh the page **or** go to another page and come back to `Sign Transaction`, the previous displayed data should be persisted 