### PR TITLE
Update XDR validation + show error message on View XDR page

### DIFF
--- a/src/app/(sidebar)/transaction/sign/components/Import.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Import.tsx
@@ -30,10 +30,12 @@ export const Import = () => {
     if (value.length > 0) {
       const validatedXDR = validate.xdr(value);
 
-      if (validatedXDR.result === "success") {
-        setTxSuccessMsg(validatedXDR.message);
-      } else {
-        setTxErrMsg(validatedXDR.message);
+      if (validatedXDR?.result && validatedXDR.message) {
+        if (validatedXDR.result === "success") {
+          setTxSuccessMsg(validatedXDR.message);
+        } else {
+          setTxErrMsg(validatedXDR.message);
+        }
       }
     }
   };

--- a/src/app/(sidebar)/xdr/view/page.tsx
+++ b/src/app/(sidebar)/xdr/view/page.tsx
@@ -74,7 +74,7 @@ export default function ViewXdr() {
     } catch (e) {
       return {
         jsonString: "",
-        error: `Unable to decode input as ${xdr.type}`,
+        error: `Unable to decode input as ${xdr.type}: ${e}`,
       };
     }
   };

--- a/src/components/formComponentTemplateEndpoints.tsx
+++ b/src/components/formComponentTemplateEndpoints.tsx
@@ -54,6 +54,15 @@ type TemplateRenderIncludeFailedProps = {
   isRequired?: boolean;
 };
 
+type TemplateRenderTxProps = {
+  value: string | undefined;
+  error:
+    | { result: string; message: "string"; originalError?: string }
+    | undefined;
+  onChange: (val: any) => void;
+  isRequired?: boolean;
+};
+
 type FormComponentTemplateEndpointsProps = {
   render: (...args: any[]) => JSX.Element;
   validate: ((...args: any[]) => any) | null;
@@ -656,14 +665,14 @@ export const formComponentTemplateEndpoints = (
       };
     case "tx":
       return {
-        render: (templ: TemplateRenderProps) => (
+        render: (templ: TemplateRenderTxProps) => (
           <XdrPicker
             key={id}
             id={id}
             label="Transaction Envelope XDR"
             labelSuffix={!templ.isRequired ? "optional" : undefined}
             value={templ.value || ""}
-            error={templ.error}
+            error={templ.error?.result === "error" ? templ.error?.message : ""}
             onChange={templ.onChange}
           />
         ),

--- a/src/validate/methods/xdr.ts
+++ b/src/validate/methods/xdr.ts
@@ -13,6 +13,10 @@ const validateBase64 = (value: string) => {
 };
 
 export const xdr = (value: string) => {
+  if (!value) {
+    return undefined;
+  }
+
   const sanitizedXdr = trim(value);
   const base64Validation = validateBase64(sanitizedXdr);
 


### PR DESCRIPTION
- Endpoints > Transactions > Post Transaction was breaking when XDR was invalid. Updated `validate.xdr` method to fix it (we were expecting different format for the error).
- XDR > View XDR > Added response error message to the error for clarity.