### PR TITLE
Add Fee Bump Tx

### DIFF
--- a/src/app/(sidebar)/transaction/fee-bump/page.tsx
+++ b/src/app/(sidebar)/transaction/fee-bump/page.tsx
@@ -193,7 +193,7 @@ export default function FeeBumpTransaction() {
             title="Transaction Sign Error:"
             response={feeBumpedTx.errors}
           />
-        ) : null}{" "}
+        ) : null}
       </>
     </Box>
   );

--- a/src/app/(sidebar)/transaction/fee-bump/page.tsx
+++ b/src/app/(sidebar)/transaction/fee-bump/page.tsx
@@ -1,5 +1,200 @@
 "use client";
 
+import { useState } from "react";
+import { Button, Card, Icon, Text } from "@stellar/design-system";
+
+import { useStore } from "@/store/useStore";
+
+import { validate } from "@/validate";
+
+import { txHelper, FeeBumpedTxResponse } from "@/helpers/txHelper";
+
+import { useRouter } from "next/navigation";
+
+import { Box } from "@/components/layout/Box";
+import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
+import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
+import { SdsLink } from "@/components/SdsLink";
+import { TxResponse } from "@/components/TxResponse";
+import { ValidationResponseCard } from "@/components/ValidationResponseCard";
+import { XdrPicker } from "@/components/FormElements/XdrPicker";
+
 export default function FeeBumpTransaction() {
-  return <div>Fee Bump Transaction</div>;
+  const router = useRouter();
+  const { network, transaction } = useStore();
+  const {
+    feeBump,
+    updateBaseFeeSource,
+    updateBaseFeeBase,
+    updateBaseFeeInnerXdr,
+    updateSignActiveView,
+    updateSignImportXdr,
+    resetBaseFee,
+  } = transaction;
+  const { source_account, fee, innerTxXdr } = feeBump;
+
+  // Sign tx status related
+  const [feeBumpedTx, setFeeBumpedTx] = useState<FeeBumpedTxResponse>({
+    errors: [],
+    xdr: "",
+  });
+  const [xdrError, setXdrError] = useState<string>("");
+  const [sourceErrorMessage, setSourceErrorMessage] = useState<string>("");
+  const [baseErrorMessage, setBaseErrorMessage] = useState<string>("");
+
+  const onXdrChange = (value: string) => {
+    // reset messages onChange
+    setXdrError("");
+    setFeeBumpedTx({
+      errors: [],
+      xdr: "",
+    });
+
+    updateBaseFeeInnerXdr(value);
+
+    if (value.length > 0) {
+      const validatedXDR = validate.xdr(value);
+
+      if (validatedXDR?.result && validatedXDR.message) {
+        if (validatedXDR.result === "success") {
+          const result = txHelper.buildFeeBumpTx({
+            innerTxXDR: value,
+            maxFee: fee,
+            sourceAccount: source_account,
+            networkPassphrase: network.passphrase,
+          });
+
+          setFeeBumpedTx(result);
+        } else {
+          setXdrError(validatedXDR.message);
+        }
+      }
+    }
+  };
+
+  return (
+    <Box gap="md">
+      <div className="PageHeader">
+        <Text size="md" as="h1" weight="medium">
+          Fee Bump
+        </Text>
+
+        <Button
+          size="md"
+          variant="error"
+          icon={<Icon.RefreshCw01 />}
+          iconPosition="right"
+          onClick={() => {
+            resetBaseFee();
+          }}
+        >
+          Clear and import new
+        </Button>
+      </div>
+      <Card>
+        <Box gap="lg">
+          <PubKeyPicker
+            id="source_account"
+            label="Source Account"
+            value={source_account}
+            error={sourceErrorMessage}
+            onChange={(e) => {
+              const error = validate.publicKey(e.target.value);
+              setSourceErrorMessage(error || "");
+              updateBaseFeeSource(e.target.value);
+            }}
+            note={<>The account responsible for paying the transaction fee.</>}
+            infoLink="https://developers.stellar.org/docs/learn/glossary#source-account"
+          />
+
+          <PositiveIntPicker
+            id="fee"
+            label="Base Fee"
+            value={fee}
+            error={baseErrorMessage}
+            onChange={(e) => {
+              const error = validate.positiveInt(e.target.value);
+              setBaseErrorMessage(error || "");
+              updateBaseFeeBase(e.target.value);
+            }}
+            note={
+              <>
+                The{" "}
+                <SdsLink href="https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering">
+                  network base fee
+                </SdsLink>{" "}
+                fee is currently set to 100 stroops (0.00001 lumens). Based on
+                current network activity, we suggest setting it to 100 stroops.
+                Final transaction fee is equal to base fee times number of
+                operations in this transaction.
+              </>
+            }
+            infoLink="https://developers.stellar.org/docs/learn/glossary#base-fee"
+          />
+
+          <XdrPicker
+            id="submit-tx-xdr"
+            label="Input a base-64 encoded TransactionEnvelope:"
+            value={innerTxXdr}
+            error={xdrError}
+            onChange={(e) => onXdrChange(e.target.value)}
+            note="Enter a base-64 encoded XDR blob to decode."
+            hasCopyButton
+          />
+        </Box>
+      </Card>
+      <>
+        {feeBumpedTx.xdr ? (
+          <ValidationResponseCard
+            variant="success"
+            title="Success! Transaction Envelope XDR:"
+            response={
+              <Box gap="xs">
+                <TxResponse
+                  label="Network Passphrase:"
+                  value={network.passphrase}
+                />
+                <TxResponse label="XDR:" value={feeBumpedTx.xdr} />
+              </Box>
+            }
+            note={<></>}
+            footerLeftEl={
+              <>
+                <Button
+                  size="md"
+                  variant="secondary"
+                  onClick={() => {
+                    updateSignImportXdr(feeBumpedTx.xdr);
+                    updateSignActiveView("overview");
+
+                    router.push("/transaction/sign");
+                  }}
+                >
+                  Sign in Transaction Signer
+                </Button>
+                <Button
+                  size="md"
+                  variant="tertiary"
+                  onClick={() => {
+                    alert("TODO: handle view in xdr flow");
+                  }}
+                >
+                  View in XDR viewer
+                </Button>
+              </>
+            }
+          />
+        ) : null}
+      </>
+      <>
+        {feeBumpedTx.errors.length && innerTxXdr ? (
+          <ValidationResponseCard
+            variant="error"
+            title="Transaction Sign Error:"
+            response={feeBumpedTx.errors}
+          />
+        ) : null}{" "}
+      </>
+    </Box>
+  );
 }

--- a/src/app/(sidebar)/transaction/fee-bump/page.tsx
+++ b/src/app/(sidebar)/transaction/fee-bump/page.tsx
@@ -103,7 +103,7 @@ export default function FeeBumpTransaction() {
               setSourceErrorMessage(error || "");
               updateBaseFeeSource(e.target.value);
             }}
-            note={<>The account responsible for paying the transaction fee.</>}
+            note="The account responsible for paying the transaction fee."
             infoLink="https://developers.stellar.org/docs/learn/glossary#source-account"
           />
 

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -13,7 +13,7 @@ import { FEE_BUMP_TX_FIELDS, TX_FIELDS } from "@/constants/signTransactionPage";
 
 import { useStore } from "@/store/useStore";
 
-import { txSigner } from "@/helpers/txSigner";
+import { txHelper } from "@/helpers/txHelper";
 
 import { validate } from "@/validate";
 
@@ -102,7 +102,7 @@ export const Overview = () => {
     networkPassphrase: string,
     hardWalletSigs: xdr.DecoratedSignature[],
   ) => {
-    const { xdr, message } = txSigner.signTx({
+    const { xdr, message } = txHelper.signTx({
       txXdr,
       signers,
       networkPassphrase,
@@ -128,7 +128,7 @@ export const Overview = () => {
 
     try {
       if (selectedHardware === "ledger") {
-        const { signature, error } = await txSigner.signWithLedger({
+        const { signature, error } = await txHelper.signWithLedger({
           bipPath: sign.bipPath,
           transaction: sign.importTx as FeeBumpTransaction | Transaction,
           isHash: false,
@@ -139,7 +139,7 @@ export const Overview = () => {
       }
 
       if (selectedHardware === "ledger_hash") {
-        const { signature, error } = await txSigner.signWithLedger({
+        const { signature, error } = await txHelper.signWithLedger({
           bipPath: sign.bipPath,
           transaction: sign.importTx as FeeBumpTransaction | Transaction,
           isHash: true,
@@ -152,7 +152,7 @@ export const Overview = () => {
       if (selectedHardware === "trezor") {
         const path = `m/${sign.bipPath}`;
 
-        const { signature, error } = await txSigner.signWithTrezor({
+        const { signature, error } = await txHelper.signWithTrezor({
           bipPath: path,
           transaction: sign.importTx as Transaction,
         });

--- a/src/helpers/txHelper.ts
+++ b/src/helpers/txHelper.ts
@@ -27,7 +27,7 @@ const buildFeeBumpTx = ({
   sourceAccount,
   networkPassphrase,
 }: {
-  innerTxXDR: string;
+  innerTxXdr: string;
   maxFee: string;
   sourceAccount: string;
   networkPassphrase: string;
@@ -41,7 +41,7 @@ const buildFeeBumpTx = ({
 
   try {
     innerTx = TransactionBuilder.fromXDR(
-      innerTxXDR,
+      innerTxXdr,
       networkPassphrase,
     ) as Transaction;
   } catch (e) {
@@ -54,10 +54,8 @@ const buildFeeBumpTx = ({
     return result;
   }
 
-  let feeBumpTx;
-
   try {
-    feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+    const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
       sourceAccount,
       maxFee,
       innerTx,

--- a/src/helpers/txHelper.ts
+++ b/src/helpers/txHelper.ts
@@ -22,7 +22,7 @@ export type FeeBumpedTxResponse = {
 };
 
 const buildFeeBumpTx = ({
-  innerTxXDR,
+  innerTxXdr,
   maxFee,
   sourceAccount,
   networkPassphrase,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -95,6 +95,11 @@ export interface Store {
       bipPath: string;
       hardWalletSigs: xdr.DecoratedSignature[] | [];
     };
+    feeBump: {
+      source_account: string;
+      fee: string;
+      innerTxXdr: string;
+    };
     // [Transaction] Build Transaction actions
     updateBuildActiveTab: (tabId: string) => void;
     updateBuildParams: (params: TransactionBuildParamsObj) => void;
@@ -121,6 +126,10 @@ export interface Store {
     updateHardWalletSigs: (signer: xdr.DecoratedSignature[]) => void;
     resetSign: () => void;
     resetSignHardWalletSigs: () => void;
+    updateBaseFeeSource: (source: string) => void;
+    updateBaseFeeBase: (feeBase: string) => void;
+    updateBaseFeeInnerXdr: (xdr: string) => void;
+    resetBaseFee: () => void;
   };
 
   // XDR
@@ -177,6 +186,11 @@ const initTransactionState = {
     signedTx: "",
     bipPath: "44'/148'/0'",
     hardWalletSigs: [],
+  },
+  feeBump: {
+    source_account: "",
+    fee: "",
+    innerTxXdr: "",
   },
 };
 
@@ -363,6 +377,22 @@ export const createStore = (options: CreateStoreOptions) =>
               state.transaction.sign.hardWalletSigs =
                 initTransactionState.sign.hardWalletSigs;
             }),
+          updateBaseFeeSource: (source: string) =>
+            set((state) => {
+              state.transaction.feeBump.source_account = source;
+            }),
+          updateBaseFeeBase: (feeBase: string) =>
+            set((state) => {
+              state.transaction.feeBump.fee = feeBase;
+            }),
+          updateBaseFeeInnerXdr: (xdr: string) =>
+            set((state) => {
+              state.transaction.feeBump.innerTxXdr = xdr;
+            }),
+          resetBaseFee: () =>
+            set((state) => {
+              state.transaction.feeBump = initTransactionState.feeBump;
+            }),
         },
         xdr: {
           ...initXdrState,
@@ -408,6 +438,7 @@ export const createStore = (options: CreateStoreOptions) =>
                 importXdr: true,
                 bipPath: true,
               },
+              feeBump: true,
             },
             xdr: {
               blob: true,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -17,6 +17,16 @@ import {
   TxnOperation,
 } from "@/types/types";
 
+export type FeeBumpParams = {
+  source_account: string;
+  fee: string;
+  xdr: string;
+};
+
+type FeeBumpParamsObj = {
+  [K in keyof FeeBumpParams]?: FeeBumpParams[K];
+};
+
 export type TransactionBuildParams = {
   source_account: string;
   fee: string;
@@ -95,11 +105,7 @@ export interface Store {
       bipPath: string;
       hardWalletSigs: xdr.DecoratedSignature[] | [];
     };
-    feeBump: {
-      source_account: string;
-      fee: string;
-      innerTxXdr: string;
-    };
+    feeBump: FeeBumpParams;
     // [Transaction] Build Transaction actions
     updateBuildActiveTab: (tabId: string) => void;
     updateBuildParams: (params: TransactionBuildParamsObj) => void;
@@ -126,9 +132,7 @@ export interface Store {
     updateHardWalletSigs: (signer: xdr.DecoratedSignature[]) => void;
     resetSign: () => void;
     resetSignHardWalletSigs: () => void;
-    updateBaseFeeSource: (source: string) => void;
-    updateBaseFeeBase: (feeBase: string) => void;
-    updateBaseFeeInnerXdr: (xdr: string) => void;
+    updateFeeBumpParams: (params: FeeBumpParamsObj) => void;
     resetBaseFee: () => void;
   };
 
@@ -190,7 +194,7 @@ const initTransactionState = {
   feeBump: {
     source_account: "",
     fee: "",
-    innerTxXdr: "",
+    xdr: "",
   },
 };
 
@@ -377,17 +381,12 @@ export const createStore = (options: CreateStoreOptions) =>
               state.transaction.sign.hardWalletSigs =
                 initTransactionState.sign.hardWalletSigs;
             }),
-          updateBaseFeeSource: (source: string) =>
+          updateFeeBumpParams: (params: FeeBumpParamsObj) =>
             set((state) => {
-              state.transaction.feeBump.source_account = source;
-            }),
-          updateBaseFeeBase: (feeBase: string) =>
-            set((state) => {
-              state.transaction.feeBump.fee = feeBase;
-            }),
-          updateBaseFeeInnerXdr: (xdr: string) =>
-            set((state) => {
-              state.transaction.feeBump.innerTxXdr = xdr;
+              state.transaction.feeBump = {
+                ...state.transaction.feeBump,
+                ...params,
+              };
             }),
           resetBaseFee: () =>
             set((state) => {


### PR DESCRIPTION
**Summary:**
- Add a Fee Bump TX page
- Rename helper function `txSigner` to `txHelpers` to support building fee bump tx
- Add a `TransactionBuilder.buildFeeBumpTransaction` to `txHelpers`
- Hook `Sign in Transaction` button to Sign Transaction page
- Check error handling / missing fields on page mount 

<img width="575" alt="Screenshot 2024-06-20 at 5 45 44 PM" src="https://github.com/stellar/laboratory/assets/3912060/081df61d-60aa-4308-bb6e-e9e31a74eb81">
