### PR TITLE
[Switch Network] enable the switch button when rpc url is different on mainnet

### DIFF
--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -50,6 +50,15 @@ export const NetworkSelector = () => {
       );
     }
 
+    if (activeNetworkId === "mainnet") {
+      return (
+        network.horizonUrl &&
+        network.rpcUrl &&
+        network.passphrase &&
+        mainnetRpc === network.rpcUrl
+      );
+    }
+
     return activeNetworkId === network.id;
   };
 


### PR DESCRIPTION
Summary: Previously, we disabled the switch button if user was trying to switch to the same network that s/he was already on. Now that we support a custom rpc url on mainnet, enable the submit button if the rpc url is different from the previous one.