### PR TITLE
[Navigation] Utilize vertical space and add subnavigation for endpoints

### DIFF
--- a/src/app/(sidebar)/endpoints/layout.tsx
+++ b/src/app/(sidebar)/endpoints/layout.tsx
@@ -15,6 +15,15 @@ export default function EndpointsTemplate({
 }: {
   children: React.ReactNode;
 }) {
+  const ENDPOINTS_PAGES_INTRO: EndpointsPagesProps = {
+    navItems: [
+      {
+        route: Routes.ENDPOINTS,
+        label: "About Endpoints",
+      },
+    ],
+    hasBottomDivider: false,
+  };
   const ENDPOINTS_PAGES_SAVED: EndpointsPagesProps = {
     navItems: [
       {
@@ -29,9 +38,10 @@ export default function EndpointsTemplate({
   return (
     <LayoutSidebarContent
       sidebar={[
-        ENDPOINTS_PAGES_SAVED,
+        ENDPOINTS_PAGES_INTRO,
         ENDPOINTS_PAGES_RPC,
         ENDPOINTS_PAGES_HORIZON,
+        ENDPOINTS_PAGES_SAVED,
       ]}
     >
       {children}

--- a/src/app/(sidebar)/endpoints/layout.tsx
+++ b/src/app/(sidebar)/endpoints/layout.tsx
@@ -38,10 +38,10 @@ export default function EndpointsTemplate({
   return (
     <LayoutSidebarContent
       sidebar={[
+        ENDPOINTS_PAGES_SAVED,
         ENDPOINTS_PAGES_INTRO,
         ENDPOINTS_PAGES_RPC,
         ENDPOINTS_PAGES_HORIZON,
-        ENDPOINTS_PAGES_SAVED,
       ]}
     >
       {children}

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { usePathname } from "next/navigation";
-import { Button, Icon } from "@stellar/design-system";
+import { Icon } from "@stellar/design-system";
 
 import { Routes } from "@/constants/routes";
 import { NextLink } from "@/components/NextLink";
@@ -36,9 +36,6 @@ const primaryNavLinks: NavLink[] = [
     href: Routes.SOROBAN_CONTRACT_EXPLORER,
     label: "Soroban",
   },
-];
-
-const secondaryNavLinks: NavLink[] = [
   {
     href: "https://developers.stellar.org/",
     label: "View Docs",
@@ -70,16 +67,9 @@ export const MainNav = () => {
 
   return (
     <nav className="LabLayout__header__nav">
-      {/* Primary nav links */}
       <div className="LabLayout__header__nav--primary">
         {primaryNavLinks.map((l) => (
           <NavItem key={l.href} link={l} />
-        ))}
-      </div>
-      {/* Secondary nav links */}
-      <div className="LabLayout__header__nav--secondary">
-        {secondaryNavLinks.map((sl) => (
-          <NavItem key={sl.href} link={sl} />
         ))}
       </div>
     </nav>

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -1,4 +1,6 @@
+import { ReactNode } from "react";
 import { usePathname } from "next/navigation";
+import { Button, Icon } from "@stellar/design-system";
 
 import { Routes } from "@/constants/routes";
 import { NextLink } from "@/components/NextLink";
@@ -6,6 +8,7 @@ import { NextLink } from "@/components/NextLink";
 type NavLink = {
   href: Routes | string;
   label: string;
+  icon?: ReactNode;
 };
 
 const primaryNavLinks: NavLink[] = [
@@ -38,7 +41,8 @@ const primaryNavLinks: NavLink[] = [
 const secondaryNavLinks: NavLink[] = [
   {
     href: "https://developers.stellar.org/",
-    label: "View Documentation",
+    label: "View Docs",
+    icon: <Icon.LinkExternal01 />,
   },
 ];
 
@@ -59,6 +63,8 @@ export const MainNav = () => {
       className={`NavLink ${isActiveRoute(link.href) ? "NavLink--active" : ""}`}
     >
       {link.label}
+
+      {link.icon ? <span className="NavLink__icon">{link.icon}</span> : null}
     </NextLink>
   );
 

--- a/src/components/layout/LayoutMain.tsx
+++ b/src/components/layout/LayoutMain.tsx
@@ -18,17 +18,17 @@ export const LayoutMain = ({ children }: { children: ReactNode }) => {
         <div className="LabLayout__header">
           <header className="LabLayout__header__main">
             <ProjectLogo
-              title="Laboratory"
+              title="Lab"
               link="/"
               customAnchor={<Link href="/" prefetch={true} />}
             />
+            <MainNav />
 
             <div className="LabLayout__header__settings">
               <ThemeSwitch storageKeyId="stellarTheme:Laboratory" />
               <NetworkSelector />
             </div>
           </header>
-          <MainNav />
         </div>
       </div>
 

--- a/src/components/layout/LayoutSidebarContent.tsx
+++ b/src/components/layout/LayoutSidebarContent.tsx
@@ -49,25 +49,26 @@ export const LayoutSidebarContent = ({
               data-testid="endpoints-sidebar-section"
             >
               {sidebar.instruction ? (
-                <div
-                  className="LabLayout__sidebar__instruction"
-                  data-testid="endpoints-sidebar-subtitle"
-                >
-                  {sidebar.instruction}
-                </div>
-              ) : null}
-
-              {sidebar.navItems.map((item) => (
-                <Link key={item.route} item={item} pathname={pathname} />
-              ))}
+                <NestedNav
+                  instruction={sidebar.instruction}
+                  sidebar={sidebar}
+                  pathname={pathname}
+                />
+              ) : (
+                // <div
+                //   className="LabLayout__sidebar__instruction"
+                //   data-testid="endpoints-sidebar-subtitle"
+                // >
+                //   {sidebar.instruction}
+                // </div>
+                sidebar.navItems.map((item) => (
+                  <Link key={item.route} item={item} pathname={pathname} />
+                ))
+              )}
             </div>
           ))}
         </div>
-        <div
-          className={`LabLayout__sidebar--bottom ${
-            bottomItems?.length ? "LabLayout__sidebar--bottom--border" : ""
-          }`}
-        >
+        <div className="LabLayout__sidebar--bottom">
           <div className="LabLayout__sidebar__wrapper">
             {bottomItems?.map((bi) => (
               <Link key={bi.route} item={bi} pathname={pathname} />
@@ -87,6 +88,55 @@ export const LayoutSidebarContent = ({
         <div className="LabLayout__content">{children}</div>
       </div>
     </>
+  );
+};
+
+const NestedNav = ({
+  instruction,
+  pathname,
+  sidebar,
+}: {
+  instruction: string;
+  pathname: string;
+  sidebar: Sidebar;
+}) => {
+  // const isSelectedParent = pathname
+  //   ?.split(Routes.ENDPOINTS)?.[1]
+  //   ?.split("/")?.[1];
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  console.log("pathname: ", pathname);
+
+  return (
+    <div
+      className="LabLayout__sidebar__instruction"
+      data-testid="endpoints-sidebar-subtitle"
+    >
+      <div
+        className="SidebarLink SidebarLink__toggle"
+        onClick={() => {
+          setIsExpanded(!isExpanded);
+        }}
+        data-is-expanded={isExpanded}
+        data-testid="endpoints-sidebar-linkToggle"
+      >
+        {sidebar.instruction} <Icon.ChevronRight />
+      </div>
+
+      {sidebar.navItems?.length ? (
+        <div
+          className="SidebarLink__nestedItemsWrapper"
+          data-is-expanded={isExpanded}
+          data-testid="endpoints-sidebar-linksContainer"
+        >
+          <div className="SidebarLink__nestedItems">
+            {sidebar.navItems.map((item) => (
+              <Link key={item.route} item={item} pathname={pathname} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 };
 
@@ -117,7 +167,7 @@ const Link = ({ item, pathname }: { item: SidebarLink; pathname: string }) => {
           }}
           data-testid="endpoints-sidebar-linkToggle"
         >
-          <Icon.ChevronRight /> {item.label}
+          {item.label} <Icon.ChevronRight />
         </div>
 
         {item.nestedItems?.length ? (

--- a/src/components/layout/LayoutSidebarContent.tsx
+++ b/src/components/layout/LayoutSidebarContent.tsx
@@ -49,18 +49,8 @@ export const LayoutSidebarContent = ({
               data-testid="endpoints-sidebar-section"
             >
               {sidebar.instruction ? (
-                <NestedNav
-                  instruction={sidebar.instruction}
-                  sidebar={sidebar}
-                  pathname={pathname}
-                />
+                <NestedNav sidebar={sidebar} pathname={pathname} />
               ) : (
-                // <div
-                //   className="LabLayout__sidebar__instruction"
-                //   data-testid="endpoints-sidebar-subtitle"
-                // >
-                //   {sidebar.instruction}
-                // </div>
                 sidebar.navItems.map((item) => (
                   <Link key={item.route} item={item} pathname={pathname} />
                 ))
@@ -92,20 +82,22 @@ export const LayoutSidebarContent = ({
 };
 
 const NestedNav = ({
-  instruction,
   pathname,
   sidebar,
 }: {
-  instruction: string;
   pathname: string;
   sidebar: Sidebar;
 }) => {
-  // const isSelectedParent = pathname
-  //   ?.split(Routes.ENDPOINTS)?.[1]
-  //   ?.split("/")?.[1];
+  const isSelectedParent = sidebar.navItems.some((item) =>
+    pathname.includes(item.route),
+  );
   const [isExpanded, setIsExpanded] = useState(false);
 
-  console.log("pathname: ", pathname);
+  useEffect(() => {
+    if (isSelectedParent) {
+      setIsExpanded(isSelectedParent);
+    }
+  }, [isSelectedParent]);
 
   return (
     <div

--- a/src/components/layout/LayoutSidebarContent.tsx
+++ b/src/components/layout/LayoutSidebarContent.tsx
@@ -193,7 +193,7 @@ const Link = ({ item, pathname }: { item: SidebarLink; pathname: string }) => {
       className="SidebarLink"
       data-is-active={pathname === item.route}
     >
-      {item.icon ?? null} {item.label}
+      {item.label} {item.icon ?? null}
     </NextLink>
   );
 };

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -159,6 +159,10 @@
       &--divider {
         border-bottom: 1px solid var(--sds-clr-gray-06);
         padding-bottom: pxToRem(16px);
+
+        .SidebarLink {
+          justify-content: space-between;
+        }
       }
     }
 
@@ -226,7 +230,6 @@
 .SidebarLink {
   --SidebarLink-color: var(--sds-clr-gray-11);
 
-  justify-content: space-between;
   font-size: pxToRem(14px);
   line-height: pxToRem(20px);
   font-weight: var(--sds-fw-medium);

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -159,10 +159,6 @@
       &--divider {
         border-bottom: 1px solid var(--sds-clr-gray-06);
         padding-bottom: pxToRem(16px);
-
-        .SidebarLink {
-          justify-content: space-between;
-        }
       }
     }
 
@@ -177,6 +173,10 @@
       padding-bottom: pxToRem(16px);
       padding-left: pxToRem(32px);
       padding-right: pxToRem(32px);
+
+      .SidebarLink {
+        justify-content: flex-start;
+      }
     }
 
     &__wrapper {
@@ -229,6 +229,7 @@
 
 .SidebarLink {
   --SidebarLink-color: var(--sds-clr-gray-11);
+  justify-content: space-between;
 
   font-size: pxToRem(14px);
   line-height: pxToRem(20px);

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -72,8 +72,8 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: pxToRem(16px);
-      padding: pxToRem(32px);
+      gap: pxToRem(24px);
+      padding: pxToRem(8px) pxToRem(32px);
     }
 
     &__settings {
@@ -89,7 +89,6 @@
       align-items: center;
       justify-content: space-between;
       gap: pxToRem(16px);
-      padding: 0 pxToRem(32px);
 
       font-size: pxToRem(14px);
       line-height: pxToRem(20px);
@@ -98,7 +97,7 @@
 
       & > div {
         display: flex;
-        gap: pxToRem(20px);
+        gap: pxToRem(16px);
         flex: 1;
       }
 
@@ -150,7 +149,7 @@
       padding-bottom: pxToRem(16px);
       display: flex;
       flex-direction: column;
-      gap: pxToRem(24px);
+      gap: pxToRem(12px);
       flex: 1;
     }
 
@@ -166,24 +165,18 @@
     }
 
     &--bottom {
-      --Sidebar-bottomItems-border-color: transparent;
-
       flex-grow: 1;
       flex-shrink: 0;
-      border-top: 1px solid var(--Sidebar-bottomItems-border-color);
+      border-top: 1px solid var(--sds-clr-gray-06);
       background-color: var(--sds-clr-gray-01);
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      gap: pxToRem(8px);
-      padding-top: pxToRem(16px);
-      padding-bottom: pxToRem(32px);
-      margin-left: pxToRem(32px);
-      margin-right: pxToRem(32px);
 
-      &--border {
-        --Sidebar-bottomItems-border-color: var(--sds-clr-gray-06);
-      }
+      padding-top: pxToRem(16px);
+      padding-bottom: pxToRem(16px);
+      padding-left: pxToRem(32px);
+      padding-right: pxToRem(32px);
     }
 
     &__wrapper {
@@ -193,7 +186,7 @@
     }
 
     &__instruction {
-      font-size: pxToRem(12px);
+      font-size: pxToRem(14px);
       line-height: pxToRem(18px);
       font-weight: var(--sds-fw-medium);
       margin-bottom: pxToRem(4px);
@@ -214,6 +207,10 @@
   border-bottom: 2px solid var(--Nav-navLink-border-color);
   white-space: nowrap;
 
+  display: flex;
+  align-items: center;
+  gap: pxToRem(4px);
+
   @media (hover: hover) {
     &:hover {
       --Nav-navLink-color: var(--sds-clr-lilac-11);
@@ -227,11 +224,20 @@
     --Nav-navLink-border-color: var(--sds-clr-lilac-09);
     pointer-events: none;
   }
+
+  &__icon {
+    display: flex;
+
+    // to fix Safari only styling bug
+    width: pxToRem(14px);
+    height: pxToRem(14px);
+  }
 }
 
 .SidebarLink {
   --SidebarLink-color: var(--sds-clr-gray-11);
 
+  justify-content: space-between;
   font-size: pxToRem(14px);
   line-height: pxToRem(20px);
   font-weight: var(--sds-fw-medium);
@@ -288,6 +294,10 @@
     &:has(~ [data-is-expanded="true"]) {
       --SidebarLink-rotate: 90deg;
     }
+
+    &[data-is-expanded="true"] {
+      margin-bottom: pxToRem(8);
+    }
   }
 
   &--nested,
@@ -303,8 +313,16 @@
     transition:
       grid-template-rows 100ms ease-out,
       margin-top 100ms ease-out;
-    margin-left: pxToRem(24px);
+    margin-left: pxToRem(16px);
     margin-top: pxToRem(-8px);
+
+    &:has(
+        .SidebarLink__nestedItemsWrapper
+          > .SidebarLink__nestedItems
+          > [data-is-active="true"]
+      ) {
+      background: yellow;
+    }
 
     &[data-is-expanded="true"] {
       grid-template-rows: 1fr;
@@ -338,7 +356,7 @@
     // to fix Safari only styling bug
     .Link__icon {
       width: pxToRem(14px);
-      width: pxToRem(14px);
+      height: pxToRem(14px);
     }
   }
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -65,6 +65,7 @@
 
   // Header
   &__header {
+    display: grid;
     background-color: var(--sds-clr-gray-01);
     border-bottom: 1px solid var(--sds-clr-gray-06);
 
@@ -139,9 +140,7 @@
     border-right: 1px solid var(--sds-clr-gray-06);
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows:
-      minmax(0, max-content)
-      1fr;
+    grid-template-rows: 1fr;
 
     &--top {
       overflow-x: auto;
@@ -150,7 +149,6 @@
       display: flex;
       flex-direction: column;
       gap: pxToRem(12px);
-      flex: 1;
     }
 
     &__section {
@@ -165,8 +163,6 @@
     }
 
     &--bottom {
-      flex-grow: 1;
-      flex-shrink: 0;
       border-top: 1px solid var(--sds-clr-gray-06);
       background-color: var(--sds-clr-gray-01);
       display: flex;
@@ -183,13 +179,6 @@
       display: flex;
       flex-direction: column;
       gap: pxToRem(8px);
-    }
-
-    &__instruction {
-      font-size: pxToRem(14px);
-      line-height: pxToRem(18px);
-      font-weight: var(--sds-fw-medium);
-      margin-bottom: pxToRem(4px);
     }
   }
 }
@@ -269,6 +258,7 @@
     cursor: default;
     font-weight: var(--sds-fw-semi-bold);
     pointer-events: none;
+    position: relative;
   }
 
   &__toggle {
@@ -296,7 +286,7 @@
     }
 
     &[data-is-expanded="true"] {
-      margin-bottom: pxToRem(8);
+      margin-bottom: pxToRem(12px);
     }
   }
 
@@ -304,7 +294,21 @@
   &__nestedItems {
     display: flex;
     flex-direction: column;
-    gap: pxToRem(8px);
+
+    .SidebarLink__nestedItemsWrapper {
+      margin-left: pxToRem(8px);
+    }
+  }
+
+  &--nested {
+    &:has(> [data-is-expanded="true"]) {
+      gap: pxToRem(12px);
+    }
+  }
+
+  &__nestedItems {
+    overflow: hidden;
+    gap: pxToRem(12px);
   }
 
   &__nestedItemsWrapper {
@@ -314,24 +318,11 @@
       grid-template-rows 100ms ease-out,
       margin-top 100ms ease-out;
     margin-left: pxToRem(16px);
-    margin-top: pxToRem(-8px);
-
-    &:has(
-        .SidebarLink__nestedItemsWrapper
-          > .SidebarLink__nestedItems
-          > [data-is-active="true"]
-      ) {
-      background: yellow;
-    }
 
     &[data-is-expanded="true"] {
       grid-template-rows: 1fr;
       margin-top: pxToRem(0);
     }
-  }
-
-  &__nestedItems {
-    overflow: hidden;
   }
 }
 

--- a/tests/endpointsPage.test.ts
+++ b/tests/endpointsPage.test.ts
@@ -30,7 +30,7 @@ test.describe("Endpoints page", () => {
 
       const linkToggles = sidebar.getByTestId("endpoints-sidebar-linkToggle");
 
-      await expect(linkToggles).toHaveCount(15);
+      await expect(linkToggles).toHaveCount(17);
 
       await expect(linkToggles).toContainText([
         "Accounts",
@@ -53,6 +53,12 @@ test.describe("Endpoints page", () => {
 
     test("Expands dropdown on click with correct links", async ({ page }) => {
       const sidebar = page.getByTestId("endpoints-sidebar-section");
+      const horizonDropdown = sidebar
+        .getByTestId("endpoints-sidebar-linkToggle")
+        .filter({ hasText: "Horizon Endpoints" });
+
+      await horizonDropdown.click();
+
       const accountsLink = sidebar
         .getByTestId("endpoints-sidebar-linkToggle")
         .filter({ hasText: "Accounts" });


### PR DESCRIPTION
- [Figma Link](https://www.figma.com/design/yuikaFOPmJifyAfS90ER6T/Laboratory?node-id=3902-18565&t=fDBaHLHd09pDE1CZ-0)
- Subnavigation added for `RPC Endpoints` and `Horizon Endpoints`
- Navigation State to be remembered based on `pathname`

<img width="292" alt="Screenshot 2024-07-26 at 1 23 31 PM" src="https://github.com/user-attachments/assets/08216491-8aff-4a00-8501-acce2a3bca49">

