### PR TITLE
Rename RPC endpoints + update main nav order

### DIFF
--- a/src/app/(sidebar)/endpoints/[[...pages]]/page.tsx
+++ b/src/app/(sidebar)/endpoints/[[...pages]]/page.tsx
@@ -864,7 +864,7 @@ export default function Endpoints() {
         <>
           This tool can be used to run queries against the{" "}
           <SdsLink href="https://developers.stellar.org/docs/data/rpc">
-            REST API endpoints
+            REST API methods
           </SdsLink>{" "}
           of RPC servers. RPC is one of the developer-facing services for the
           Stellar ecosystem.

--- a/src/app/(sidebar)/endpoints/components/EndpointsLandingPage.tsx
+++ b/src/app/(sidebar)/endpoints/components/EndpointsLandingPage.tsx
@@ -8,8 +8,8 @@ export const EndpointsLandingPage = () => {
   const infoCards = [
     {
       id: "soroban-rpc",
-      title: "Soroban RPC Endpoints",
-      description: "Learn about the RPC endpoints in our Developer Docs.",
+      title: "Soroban RPC Methods",
+      description: "Learn about the RPC methods in our Developer Docs.",
       buttonLabel: "See docs",
       buttonIcon: <Icon.LinkExternal01 />,
       buttonAction: () =>
@@ -31,7 +31,7 @@ export const EndpointsLandingPage = () => {
       <Card>
         <div className="CardText">
           <Text size="lg" as="h1" weight="medium">
-            Endpoints
+            API Explorer
           </Text>
 
           <Text size="sm" as="p">

--- a/src/app/(sidebar)/endpoints/components/SavedEndpointsPage.tsx
+++ b/src/app/(sidebar)/endpoints/components/SavedEndpointsPage.tsx
@@ -195,7 +195,7 @@ export const SavedEndpointsPage = () => {
   return (
     <Box gap="md">
       <TabView
-        heading={{ title: "Saved Endpoints" }}
+        heading={{ title: "Saved Requests" }}
         tab1={{
           id: "rpc",
           label: "RPC Methods",

--- a/src/app/(sidebar)/endpoints/components/SavedEndpointsPage.tsx
+++ b/src/app/(sidebar)/endpoints/components/SavedEndpointsPage.tsx
@@ -198,7 +198,7 @@ export const SavedEndpointsPage = () => {
         heading={{ title: "Saved Endpoints" }}
         tab1={{
           id: "rpc",
-          label: "RPC Endpoints",
+          label: "RPC Methods",
           content: saved.activeTab === "rpc" ? <RpcEndpoints /> : null,
         }}
         tab2={{

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -229,11 +229,11 @@ export default function SavedTransactions() {
 
       <Alert
         variant="primary"
-        title="Looking for your saved endpoints?"
+        title="Looking for your saved requests?"
         placement="inline"
       >
         <NextLink href={`${Routes.ENDPOINTS_SAVED}`} sds-variant="primary">
-          See saved endpoints
+          See saved requests
         </NextLink>
       </Alert>
 

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -25,12 +25,12 @@ const primaryNavLinks: NavLink[] = [
     label: "Account",
   },
   {
-    href: Routes.ENDPOINTS,
-    label: "Endpoints",
-  },
-  {
     href: Routes.BUILD_TRANSACTION,
     label: "Transactions",
+  },
+  {
+    href: Routes.ENDPOINTS,
+    label: "API Explorer",
   },
   // TODO: hide until ready
   // {

--- a/src/components/layout/LayoutHeader.tsx
+++ b/src/components/layout/LayoutHeader.tsx
@@ -35,7 +35,7 @@ const NAV = [
     subNav: ACCOUNT_NAV_ITEMS,
   },
   {
-    label: "Endpoints",
+    label: "API Explorer",
     subNav: ENDPOINTS_NAV_ITEMS,
   },
   {
@@ -49,7 +49,7 @@ export const LayoutHeader = () => {
   const route = useRouter();
   const pathname = usePathname();
 
-  // Adjusting format to remove nested sub-sections (RPC Endpoints, for example)
+  // Adjusting format to remove nested sub-sections (RPC Methods, for example)
   // We cannot have nested optgroup in select
   const formattedNav = NAV.map((mainNav) => {
     type NavItem = {

--- a/src/constants/endpointsPages.ts
+++ b/src/constants/endpointsPages.ts
@@ -30,7 +30,7 @@ export type EndpointsPagesProps = {
 };
 
 export const ENDPOINTS_PAGES_RPC: EndpointsPagesProps = {
-  instruction: "RPC Endpoints",
+  instruction: "RPC Methods",
   navItems: [
     {
       route: Routes.ENDPOINTS_GET_EVENTS,

--- a/src/constants/navItems.tsx
+++ b/src/constants/navItems.tsx
@@ -33,7 +33,7 @@ const ENDPOINTS_PAGES_INTRO: EndpointsPagesProps = {
   navItems: [
     {
       route: Routes.ENDPOINTS,
-      label: "About Endpoints",
+      label: "About API Explorer",
     },
   ],
   hasBottomDivider: false,

--- a/src/constants/navItems.tsx
+++ b/src/constants/navItems.tsx
@@ -42,7 +42,7 @@ const ENDPOINTS_PAGES_SAVED: EndpointsPagesProps = {
   navItems: [
     {
       route: Routes.ENDPOINTS_SAVED,
-      label: "Saved Endpoints",
+      label: "Saved Requests",
       icon: <Icon.Save03 />,
     },
   ],

--- a/tests/endpointsPage.test.ts
+++ b/tests/endpointsPage.test.ts
@@ -1,17 +1,17 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Endpoints page", () => {
+test.describe("API Explorer page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("http://localhost:3000/endpoints");
   });
 
   test("Loads", async ({ page }) => {
-    await expect(page.locator("h1")).toHaveText("Endpoints");
+    await expect(page.locator("h1")).toHaveText("API Explorer");
   });
 
   test("Renders info cards", async ({ page }) => {
     await expect(page.locator("h2")).toHaveText([
-      "Soroban RPC Endpoints",
+      "Soroban RPC Methods",
       "Horizon Endpoints",
     ]);
   });
@@ -22,7 +22,7 @@ test.describe("Endpoints page", () => {
 
       await expect(
         sidebar.getByTestId("endpoints-sidebar-subtitle").nth(0),
-      ).toContainText("RPC Endpoints");
+      ).toContainText("RPC Methods");
 
       await expect(
         sidebar.getByTestId("endpoints-sidebar-subtitle").nth(1),


### PR DESCRIPTION
- Rename main nav "Endpoints" to "API Explorer"
- Rename "RPC Endpoints" to "RPC Methods" (keep "Horizon Endpoints" to match the docs)
- Put "Accounts" and "Transactions" next to each other in the main nav