### PR TITLE
PrettyJson: getLedgerEntries XDR links + formatted manage_data

### DIFF
--- a/src/app/(sidebar)/endpoints/components/EndpointsJsonResponse.tsx
+++ b/src/app/(sidebar)/endpoints/components/EndpointsJsonResponse.tsx
@@ -63,6 +63,12 @@ export const EndpointsJsonResponse = ({ json }: { json: AnyObject }) => {
       case "header_xdr":
         xdrType = "LedgerHeader";
         break;
+      case "key":
+        xdrType = "LedgerKey";
+        break;
+      case "xdr":
+        xdrType = "LedgerEntryData";
+        break;
       default:
       // Do nothing
     }
@@ -370,6 +376,26 @@ export const EndpointsJsonResponse = ({ json }: { json: AnyObject }) => {
     },
     header_xdr: {
       getHref: handleLinkXdr,
+    },
+    key: {
+      getHref: handleLinkXdr,
+      condition: (_: string, parentKey?: string, isRpcResponse?: boolean) => {
+        if (isRpcResponse && parentKey === "entries") {
+          return true;
+        }
+
+        return false;
+      },
+    },
+    xdr: {
+      getHref: handleLinkXdr,
+      condition: (_: string, parentKey?: string, isRpcResponse?: boolean) => {
+        if (isRpcResponse && parentKey === "entries") {
+          return true;
+        }
+
+        return false;
+      },
     },
     // Link
     href: {

--- a/src/components/PrettyJson/index.tsx
+++ b/src/components/PrettyJson/index.tsx
@@ -13,7 +13,11 @@ export type CustomKeyValueLinkMap = {
   [key: string]: {
     text?: string;
     getHref: (value: string, key?: string) => string;
-    condition?: (val: string) => boolean;
+    condition?: (
+      val: string,
+      parentKey?: string,
+      isRpcResponse?: boolean,
+    ) => boolean;
   };
 };
 
@@ -41,6 +45,8 @@ export const PrettyJson = ({
   if (typeof json !== "object") {
     return null;
   }
+
+  const isRpcResponse = Object.keys(json)[0] === "jsonrpc";
 
   const ItemCount = ({ itemList }: { itemList: any[] }) => (
     <div className="PrettyJson__expandSize">{getItemSizeLabel(itemList)}</div>
@@ -102,7 +108,10 @@ export const PrettyJson = ({
       const custom = customKeyValueLinkMap?.[key];
 
       if (custom) {
-        if (custom.condition && !custom.condition(item)) {
+        if (
+          custom.condition &&
+          !custom.condition(item, parentKey, isRpcResponse)
+        ) {
           return render(item, key);
         }
 

--- a/src/components/PrettyJsonTransaction.tsx
+++ b/src/components/PrettyJsonTransaction.tsx
@@ -91,6 +91,21 @@ export const PrettyJsonTransaction = ({
       return PrettyJson.renderStringValue({ item });
     }
 
+    // Manage data
+    if (parentKey === "manage_data") {
+      if (key === "data_name") {
+        return PrettyJson.renderStringValue({
+          item: `${item} (hex: ${Buffer.from(item).toString("base64")})`,
+        });
+      }
+
+      if (key === "data_value") {
+        return PrettyJson.renderStringValue({
+          item: `${Buffer.from(item, "hex").toString()} (hex: ${Buffer.from(item, "hex").toString("base64")})`,
+        });
+      }
+    }
+
     return null;
   };
 


### PR DESCRIPTION
- `getLedgerEntries` XDR [example](https://laboratory-pr1049.previews.kube001.services.stellar-ops.com/endpoints/rpc/get-ledger-entries?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&endpoints$params$ledgerKeyEntries=%5B%22AAAAAAAAAABgPRp+w+RwYpg9G+jj33c2OUXbZV3QzAo2L3Vw7VeDHQ==%22%5D;;)
- Format `manage-data`

![image](https://github.com/user-attachments/assets/61f81fe5-0a72-40ca-aa92-50fe2bec6dd0)
