### PR TITLE
[bugfix] reset the status of previous imported tx and submitted screen

### DIFF
--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -419,7 +419,7 @@ export const Overview = () => {
           </div>
         </Card>
 
-        {sign.signedTx ? (
+        {sign.signedTx && signedTxSuccessMsg ? (
           <ValidationResponseCard
             variant="success"
             title="Transaction signed!"

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -75,22 +75,19 @@ export const Overview = () => {
   });
 
   useEffect(() => {
-    if (!sign.importTx) {
-      if (sign.importXdr) {
-        // used to persist page data when accessed by query string
-        const transaction = TransactionBuilder.fromXDR(
-          sign.importXdr,
-          network.passphrase,
-        );
+    if (sign.importXdr) {
+      // used to persist page data when accessed by query string
+      const transaction = TransactionBuilder.fromXDR(
+        sign.importXdr,
+        network.passphrase,
+      );
 
-        updateSignImportTx(transaction);
-      } else {
-        updateSignActiveView("import");
-      }
+      updateSignImportTx(transaction);
+    } else {
+      updateSignActiveView("import");
     }
   }, [
     network.passphrase,
-    sign.importTx,
     sign.importXdr,
     updateSignActiveView,
     updateSignImportTx,


### PR DESCRIPTION
**Summary:**
- sign transaction was displaying previous imported tx information for hash
- submitted tx to reset when there's a new tx imported

**How to reproduce this bug:**
- build a transaction, go to sign transaction, then submit
- go back to build a transaction, build a new different transaction, go to sign transaction page, you'll see that old hash is showing & previous submitted screen is on display

**Bug flow:**
![Screenshot 2024-09-19 at 4 13 57 PM](https://github.com/user-attachments/assets/1810bb20-a46f-4794-b402-54b84945289c)