### PR TITLE
[stellar-wallets-kit] disable 'allowAllModules' to prevent window error

### DIFF
--- a/src/components/WalletKitContextProvider.tsx
+++ b/src/components/WalletKitContextProvider.tsx
@@ -5,7 +5,9 @@ import { useStore } from "@/store/useStore";
 
 import {
   StellarWalletsKit,
-  allowAllModules,
+  FreighterModule,
+  xBullModule,
+  AlbedoModule,
   XBULL_ID,
 } from "@creit.tech/stellar-wallets-kit";
 
@@ -76,7 +78,7 @@ export const WalletKitContextProvider = ({
     return new StellarWalletsKit({
       network: networkType,
       selectedWalletId: XBULL_ID,
-      modules: allowAllModules(),
+      modules: [new xBullModule(), new FreighterModule(), new AlbedoModule()],
       ...(theme && {
         buttonTheme: isDarkTheme
           ? {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f07f24e0-c486-4f3d-b713-1c70b250f170)
- disabled `rabet` which uses `windows` that caused error on test by directly importing wallet modules instead of using `allowAllModules()`
- notified stellar wallets kit team