### PR TITLE
Submit Transaction: add links to XDR in response

### DIFF
--- a/src/app/(sidebar)/transaction/submit/page.tsx
+++ b/src/app/(sidebar)/transaction/submit/page.tsx
@@ -17,6 +17,7 @@ import { delayedAction } from "@/helpers/delayedAction";
 import { openUrl } from "@/helpers/openUrl";
 import { getBlockExplorerLink } from "@/helpers/getBlockExplorerLink";
 import { localStorageSubmitMethod } from "@/helpers/localStorageSubmitMethod";
+import { buildEndpointHref } from "@/helpers/buildEndpointHref";
 
 import { Routes } from "@/constants/routes";
 import { XDR_TYPE_TRANSACTION_ENVELOPE } from "@/constants/settings";
@@ -33,6 +34,7 @@ import { XdrPicker } from "@/components/FormElements/XdrPicker";
 import { ValidationResponseCard } from "@/components/ValidationResponseCard";
 import { TxResponse } from "@/components/TxResponse";
 import { SaveTransactionModal } from "@/components/SaveTransactionModal";
+import { SdsLink } from "@/components/SdsLink";
 
 import {
   HorizonErrorResponse,
@@ -241,6 +243,20 @@ export default function SubmitTransaction() {
 
   const isSubmitDisabled = !submitMethod || !blob || Boolean(xdrJson?.error);
 
+  const XdrLink = ({ xdr, type }: { xdr: string; type: string }) => (
+    <SdsLink
+      href={buildEndpointHref(Routes.VIEW_XDR, {
+        blob: xdr,
+        type: type,
+      })}
+      target="_blank"
+      isUnderline
+      variant="secondary"
+    >
+      {xdr}
+    </SdsLink>
+  );
+
   const renderSuccess = () => {
     if (isSubmitRpcSuccess && submitRpcResponse) {
       return (
@@ -294,21 +310,36 @@ export default function SubmitTransaction() {
                 />
                 <TxResponse
                   label="Envelope XDR:"
-                  value={submitRpcResponse.result.envelopeXdr
-                    .toXDR("base64")
-                    .toString()}
+                  item={
+                    <XdrLink
+                      xdr={submitRpcResponse.result.envelopeXdr
+                        .toXDR("base64")
+                        .toString()}
+                      type="TransactionEnvelope"
+                    />
+                  }
                 />
                 <TxResponse
                   label="Result XDR:"
-                  value={submitRpcResponse.result.resultXdr
-                    .toXDR("base64")
-                    .toString()}
+                  item={
+                    <XdrLink
+                      xdr={submitRpcResponse.result.resultXdr
+                        .toXDR("base64")
+                        .toString()}
+                      type="TransactionResult"
+                    />
+                  }
                 />
                 <TxResponse
                   label="Result Meta XDR:"
-                  value={submitRpcResponse.result.resultMetaXdr
-                    .toXDR("base64")
-                    .toString()}
+                  item={
+                    <XdrLink
+                      xdr={submitRpcResponse.result.resultMetaXdr
+                        .toXDR("base64")
+                        .toString()}
+                      type="TransactionMeta"
+                    />
+                  }
                 />
                 <TxResponse label="Fee:" value={submitRpcResponse.fee} />
               </Box>
@@ -370,15 +401,30 @@ export default function SubmitTransaction() {
                 />
                 <TxResponse
                   label="Envelope XDR:"
-                  value={submitHorizonResponse.envelope_xdr}
+                  item={
+                    <XdrLink
+                      xdr={submitHorizonResponse.envelope_xdr}
+                      type="TransactionEnvelope"
+                    />
+                  }
                 />
                 <TxResponse
                   label="Result XDR:"
-                  value={submitHorizonResponse.result_xdr}
+                  item={
+                    <XdrLink
+                      xdr={submitHorizonResponse.result_xdr}
+                      type="TransactionResult"
+                    />
+                  }
                 />
                 <TxResponse
                   label="Result Meta XDR:"
-                  value={submitHorizonResponse.result_meta_xdr}
+                  item={
+                    <XdrLink
+                      xdr={submitHorizonResponse.result_meta_xdr}
+                      type="TransactionMeta"
+                    />
+                  }
                 />
                 <TxResponse
                   label="Fee charged:"
@@ -540,12 +586,22 @@ export default function SubmitTransaction() {
 
           <>
             {xdrJson?.jsonString ? (
-              <div className="PageBody__content PageBody__scrollable">
-                <PrettyJsonTransaction
-                  json={JSON.parse(xdrJson.jsonString)}
-                  xdr={blob}
-                />
-              </div>
+              <Box gap="sm">
+                <Text
+                  size="sm"
+                  as="h2"
+                  weight="semi-bold"
+                  addlClassName="PageBody__title"
+                >
+                  TransactionEnvelope
+                </Text>
+                <div className="PageBody__content PageBody__scrollable">
+                  <PrettyJsonTransaction
+                    json={JSON.parse(xdrJson.jsonString)}
+                    xdr={blob}
+                  />
+                </div>
+              </Box>
             ) : null}
           </>
         </Box>

--- a/src/components/TxResponse/styles.scss
+++ b/src/components/TxResponse/styles.scss
@@ -3,5 +3,11 @@
 .TxResponse {
   &__value {
     margin-left: var(--sds-gap-sm);
+
+    .Link {
+      --Link-color-default: var(--sds-clr-gray-12);
+      word-break: break-all;
+      font-weight: var(--sds-fw-regular);
+    }
   }
 }


### PR DESCRIPTION
- Added `TransactionEnvelope` title to JSON block
- Added links to XDR items in transaction response

![image](https://github.com/user-attachments/assets/e24398d2-3f21-4ac0-b829-e0cfd20e4d4d)

![image](https://github.com/user-attachments/assets/1bf1e4e0-1603-435d-b31d-03c4c501e654)
