### PR TITLE
Mask secret key inputs + some cleanup

### DIFF
--- a/src/app/(sidebar)/account/create/page.tsx
+++ b/src/app/(sidebar)/account/create/page.tsx
@@ -62,6 +62,8 @@ export default function CreateAccount() {
       networkRef.current = network;
       resetStates();
     }
+    // Not including network and resetStates()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [networkRef.current.id, network.id]);
 
   const generateKeypair = () => {

--- a/src/app/(sidebar)/account/fund/page.tsx
+++ b/src/app/(sidebar)/account/fund/page.tsx
@@ -61,6 +61,8 @@ export default function FundAccount() {
       networkRef.current = network;
       resetStates();
     }
+    // Not including network and resetStates()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [networkRef.current.id, network.id]);
 
   useEffect(() => {

--- a/src/app/(sidebar)/endpoints/[[...pages]]/page.tsx
+++ b/src/app/(sidebar)/endpoints/[[...pages]]/page.tsx
@@ -57,11 +57,11 @@ import { EndpointsJsonResponse } from "../components/EndpointsJsonResponse";
 
 export default function Endpoints() {
   const pathname = usePathname();
-  const isRpcEndpoint = pathname.includes(Routes.ENDPOINTS_RPC);
-  const currentPage = pathname.split(Routes.ENDPOINTS)?.[1];
+  const isRpcEndpoint = pathname?.includes(Routes.ENDPOINTS_RPC);
+  const currentPage = pathname?.split(Routes.ENDPOINTS)?.[1];
 
   const horizonPage = ENDPOINTS_PAGES_HORIZON.navItems
-    .find((page) => pathname.includes(page.route))
+    .find((page) => pathname?.includes(page.route))
     ?.nestedItems?.find((i) => i.route === pathname);
 
   const rpcPage = ENDPOINTS_PAGES_RPC.navItems.find(
@@ -141,7 +141,7 @@ export default function Endpoints() {
     return [
       Routes.ENDPOINTS_TRANSACTIONS_POST.toString(),
       Routes.ENDPOINTS_TRANSACTIONS_POST_ASYNC.toString(),
-    ].includes(pathname);
+    ].includes(pathname || "");
   };
 
   const getRpcPostPayloadProps = (endpoint: string) => {
@@ -261,7 +261,7 @@ export default function Endpoints() {
         payload = { tx: params.tx ?? "" };
       }
 
-      if (isRpcEndpoint) {
+      if (isRpcEndpoint && pathname) {
         payload = getRpcPostPayloadProps(pathname);
       }
     }
@@ -603,7 +603,7 @@ export default function Endpoints() {
         renderedProps = { tx: params.tx ?? "" };
       }
 
-      if (isRpcEndpoint) {
+      if (isRpcEndpoint && pathname) {
         renderedProps = getRpcPostPayloadProps(pathname);
       }
     }

--- a/src/app/(sidebar)/transaction/cli-sign/page.tsx
+++ b/src/app/(sidebar)/transaction/cli-sign/page.tsx
@@ -19,8 +19,8 @@ export default function CliSignTransaction() {
   const router = useRouter();
 
   useEffect(() => {
-    const networkPassphrase = searchParams.get("networkPassphrase");
-    const xdr = searchParams.get("xdr");
+    const networkPassphrase = searchParams?.get("networkPassphrase");
+    const xdr = searchParams?.get("xdr");
 
     if (networkPassphrase) {
       const network = getNetworkByPassphrase(networkPassphrase);
@@ -36,6 +36,8 @@ export default function CliSignTransaction() {
     }
 
     router.push(Routes.SIGN_TRANSACTION);
+    // Not including other deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transaction.sign.importXdr, network.id]);
 
   return <Loader />;

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  Card,
-  Icon,
-  Text,
-  Button,
-  Select,
-  Label,
-} from "@stellar/design-system";
+import { Card, Icon, Text, Button, Select } from "@stellar/design-system";
 import {
   FeeBumpTransaction,
   Transaction,
@@ -40,6 +33,7 @@ import { ValidationResponseCard } from "@/components/ValidationResponseCard";
 import { XdrPicker } from "@/components/FormElements/XdrPicker";
 import { ViewInXdrButton } from "@/components/ViewInXdrButton";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
+import { LabelHeading } from "@/components/LabelHeading";
 
 const MIN_LENGTH_FOR_FULL_WIDTH_FIELD = 30;
 
@@ -769,9 +763,7 @@ export const Overview = () => {
             </Box>
 
             <Box gap="md" addlClassName="PageBody__content">
-              <Label size="md" htmlFor="">
-                Sign with wallet extension
-              </Label>
+              <LabelHeading size="md">Sign with wallet extension</LabelHeading>
 
               <SignTxButton
                 label={`Sign with ${account.walletKitPubKey ? shortenStellarAddress(account.walletKitPubKey) : "wallet"}`}
@@ -790,9 +782,7 @@ export const Overview = () => {
             </Box>
 
             <Box gap="md" addlClassName="PageBody__content">
-              <Label size="md" htmlFor="">
-                Add a signature
-              </Label>
+              <LabelHeading size="md">Add a signature</LabelHeading>
 
               <>
                 {sigInputs.map((_, idx) => (

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -678,6 +678,7 @@ export const Overview = () => {
                 autocomplete="off"
                 useAutoAdd
                 note="Paste a secret key to add an additional signer"
+                isPassword
               />
               <SignTxButton
                 onSign={() => {

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -37,6 +37,8 @@ export const ConnectWallet = () => {
     return () => {
       walletKitInstance.walletKit?.removeButton({ skipDisconnect: true });
     };
+    // Run only when component mounts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return <div className="ConnectWallet" ref={responseSuccessEl}></div>;

--- a/src/components/FormElements/AssetMultiPicker.tsx
+++ b/src/components/FormElements/AssetMultiPicker.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Button, Input, Label } from "@stellar/design-system";
+import { Button, Input } from "@stellar/design-system";
 
 import { ExpandBox } from "@/components/ExpandBox";
 import { RadioPicker } from "@/components/RadioPicker";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
+import { Box } from "@/components/layout/Box";
+import { LabelHeading } from "@/components/LabelHeading";
 
 import { AssetObject, AssetObjectValue } from "@/types/types";
-import { Box } from "../layout/Box";
 
 type AssetMultiPickerProps = {
   id: string;
@@ -95,9 +96,9 @@ export const AssetMultiPicker = ({
   return (
     <Box gap="sm">
       <>
-        <Label htmlFor="" size="md" labelSuffix={labelSuffix}>
+        <LabelHeading size="md" labelSuffix={labelSuffix}>
           {label}
-        </Label>
+        </LabelHeading>
         {values.length ? (
           <Box gap="sm">
             <>

--- a/src/components/FormElements/ClaimantsPicker.tsx
+++ b/src/components/FormElements/ClaimantsPicker.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Icon, Label } from "@stellar/design-system";
+import { Badge, Button, Icon } from "@stellar/design-system";
 import { flatten, isEmpty, set } from "lodash";
 
 import { RadioPicker } from "@/components/RadioPicker";
@@ -7,6 +7,7 @@ import { Box } from "@/components/layout/Box";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
 import { TextPicker } from "@/components/FormElements/TextPicker";
 import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
+import { LabelHeading } from "@/components/LabelHeading";
 
 import { arrayItem } from "@/helpers/arrayItem";
 import { AnyObject } from "@/types/types";
@@ -28,9 +29,7 @@ export const ClaimantsPicker = ({
 
   return (
     <Box gap="md">
-      <Label size="md" htmlFor="">
-        Claimants
-      </Label>
+      <LabelHeading size="md">Claimants</LabelHeading>
 
       <>
         {hasClaimants ? (
@@ -249,9 +248,9 @@ const Predicate = ({
 
   return (
     <Box gap="sm" addlClassName="PredicateWrapper">
-      <Label size="md" htmlFor="">
+      <LabelHeading size="md">
         {`${getParentLabel(parentPath)}${label}`}
-      </Label>
+      </LabelHeading>
 
       <RadioPicker
         id={`${index}-${parentPath}-predicate`}

--- a/src/components/FormElements/FlagFieldPicker.tsx
+++ b/src/components/FormElements/FlagFieldPicker.tsx
@@ -1,6 +1,6 @@
-import { Label } from "@stellar/design-system";
 import { arrayItem } from "@/helpers/arrayItem";
 import { optionsFlagDetails } from "@/helpers/optionsFlagDetails";
+import { LabelHeading } from "@/components/LabelHeading";
 import { OptionFlag } from "@/types/types";
 
 interface FlagFieldProps {
@@ -35,15 +35,14 @@ export const FlagFieldPicker = ({
   return (
     <div className="RadioPicker">
       {label ? (
-        <Label
+        <LabelHeading
           size="md"
-          htmlFor=""
           labelSuffix={labelSuffix}
           infoLink={infoLink}
           infoText={infoText}
         >
           {label}
-        </Label>
+        </LabelHeading>
       ) : null}
       <div className="RadioPicker__options">
         {options.map((o) => {

--- a/src/components/FormElements/MultiPicker.tsx
+++ b/src/components/FormElements/MultiPicker.tsx
@@ -24,6 +24,7 @@ type MultiPickerProps = {
   limit?: number;
   useAutoAdd?: boolean;
   note?: React.ReactNode;
+  isPassword?: boolean;
 };
 
 export const MultiPicker = ({
@@ -39,6 +40,7 @@ export const MultiPicker = ({
   limit,
   useAutoAdd,
   note,
+  isPassword,
 }: MultiPickerProps) => {
   if (!value || !value.length) {
     value = [];
@@ -85,6 +87,7 @@ export const MultiPicker = ({
                       />
                     ) : null
                   }
+                  isPassword={isPassword}
                 />
               );
             })

--- a/src/components/FormElements/MultiPicker.tsx
+++ b/src/components/FormElements/MultiPicker.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 
-import { Button, Icon, Label } from "@stellar/design-system";
+import { Button, Icon } from "@stellar/design-system";
 
 import { arrayItem } from "@/helpers/arrayItem";
 
 import { TextPicker } from "@/components/FormElements/TextPicker";
 import { Box } from "@/components/layout/Box";
 import { InputSideElement } from "@/components/InputSideElement";
+import { LabelHeading } from "@/components/LabelHeading";
 
 type Values = string[];
 
@@ -45,9 +46,9 @@ export const MultiPicker = ({
 
   return (
     <Box gap="sm">
-      <Label htmlFor="" size="md" labelSuffix={labelSuffix}>
+      <LabelHeading size="md" labelSuffix={labelSuffix}>
         {label}
-      </Label>
+      </LabelHeading>
       <>
         {value.length
           ? value.map((singleVal: string, index: number) => {

--- a/src/components/FormElements/NumberFractionPicker.tsx
+++ b/src/components/FormElements/NumberFractionPicker.tsx
@@ -1,8 +1,8 @@
-import { Label } from "@stellar/design-system";
 import { Box } from "@/components/layout/Box";
 import { RadioPicker } from "@/components/RadioPicker";
 import { ExpandBox } from "@/components/ExpandBox";
 import { TextPicker } from "@/components/FormElements/TextPicker";
+import { LabelHeading } from "@/components/LabelHeading";
 
 import { FractionValue, NumberFractionValue } from "@/types/types";
 
@@ -105,9 +105,9 @@ export const NumberFractionPicker = ({
 
   return (
     <Box gap="sm">
-      <Label size="md" labelSuffix={labelSuffix} htmlFor="">
+      <LabelHeading size="md" labelSuffix={labelSuffix}>
         {label}
-      </Label>
+      </LabelHeading>
       <RadioPicker
         id={id}
         selectedOption={value?.type}

--- a/src/components/FormElements/SignerPicker.tsx
+++ b/src/components/FormElements/SignerPicker.tsx
@@ -1,9 +1,10 @@
-import { Label, Select } from "@stellar/design-system";
+import { Select } from "@stellar/design-system";
 import { Box } from "@/components/layout/Box";
 import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
 import { TextPicker } from "@/components/FormElements/TextPicker";
 import { OptionSigner } from "@/types/types";
+import { LabelHeading } from "../LabelHeading";
 
 type SignerPickerProps = {
   id: string;
@@ -71,15 +72,14 @@ export const SignerPicker = ({
     <Box gap="sm">
       <>
         {label ? (
-          <Label
+          <LabelHeading
             size="md"
-            htmlFor=""
             labelSuffix={labelSuffix}
             infoLink={infoLink}
             infoText={infoText}
           >
             {label}
-          </Label>
+          </LabelHeading>
         ) : null}
 
         <Select

--- a/src/components/LabelHeading.tsx
+++ b/src/components/LabelHeading.tsx
@@ -1,0 +1,47 @@
+import { Icon, Tooltip } from "@stellar/design-system";
+
+export const LabelHeading = ({
+  children,
+  size,
+  labelSuffix,
+  infoText,
+  infoLink,
+}: {
+  children: React.ReactNode;
+  size: "sm" | "md" | "lg";
+  labelSuffix?: string | React.ReactNode;
+  infoText?: string | React.ReactNode;
+  infoLink?: string;
+}) => (
+  <div className="Label__wrapper">
+    <div className={`Label Label--${size}`}>
+      {children}
+      {labelSuffix ? (
+        <span className="Label__suffix">({labelSuffix})</span>
+      ) : null}
+    </div>
+
+    {infoLink ? (
+      <a
+        href={infoLink}
+        className="Label__infoButton"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        <Icon.BookOpen01 />
+      </a>
+    ) : null}
+
+    {infoText ? (
+      <Tooltip
+        triggerEl={
+          <div className="Label__infoButton" role="button">
+            <Icon.InfoCircle />
+          </div>
+        }
+      >
+        {infoText}
+      </Tooltip>
+    ) : null}
+  </div>
+);

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -52,7 +52,7 @@ export const MainNav = () => {
       return false;
     }
 
-    return pathname.split("/")[1] === link.split("/")[1];
+    return pathname?.split("/")[1] === link.split("/")[1];
   };
 
   const NavItem = ({ link }: { link: NavLink }) => (

--- a/src/components/PrettyJsonTextarea/index.tsx
+++ b/src/components/PrettyJsonTextarea/index.tsx
@@ -1,6 +1,6 @@
-import { Label } from "@stellar/design-system";
 import { PrettyJson } from "@/components/PrettyJson";
 import { Box } from "@/components/layout/Box";
+import { LabelHeading } from "@/components/LabelHeading";
 import { AnyObject } from "@/types/types";
 import "./styles.scss";
 
@@ -13,9 +13,7 @@ export const PrettyJsonTextarea = ({
 }) => {
   return (
     <Box gap="sm" addlClassName="PrettyJsonTextarea">
-      <Label htmlFor="" size="md">
-        {label}
-      </Label>
+      <LabelHeading size="md">{label}</LabelHeading>
       <div className="PrettyJsonTextarea__json">
         <PrettyJson json={json} isCollapsible={false} />
       </div>

--- a/src/components/RadioPicker/index.tsx
+++ b/src/components/RadioPicker/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Label } from "@stellar/design-system";
+import { LabelHeading } from "@/components/LabelHeading";
 import "./styles.scss";
 
 interface RadioPickerProps<TOptionValue = string> {
@@ -38,15 +38,14 @@ export const RadioPicker = <TOptionValue,>({
   return (
     <div className="RadioPicker" style={customStyle}>
       {label ? (
-        <Label
+        <LabelHeading
           size="md"
-          htmlFor=""
           labelSuffix={labelSuffix}
           infoLink={infoLink}
           infoText={infoText}
         >
           {label}
-        </Label>
+        </LabelHeading>
       ) : null}
       <div className="RadioPicker__options">
         {options.map((o) => {

--- a/src/components/WalletKitContextProvider.tsx
+++ b/src/components/WalletKitContextProvider.tsx
@@ -36,6 +36,8 @@ export const WalletKitContextProvider = ({
     if (savedTheme) {
       setTheme(savedTheme);
     }
+    // Run only when component mounts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const walletKitInstance = useMemo(() => {

--- a/src/components/layout/LayoutHeader.tsx
+++ b/src/components/layout/LayoutHeader.tsx
@@ -196,7 +196,7 @@ export const LayoutHeader = () => {
             id="mobile-nav"
             fieldSize="md"
             onChange={handleNavChange}
-            value={pathname}
+            value={pathname || undefined}
           >
             {renderNav()}
           </Select>

--- a/src/components/layout/LayoutSidebarContent.tsx
+++ b/src/components/layout/LayoutSidebarContent.tsx
@@ -29,7 +29,7 @@ export const LayoutSidebarContent = ({
   children: ReactNode;
   sidebar: Sidebar | Sidebar[];
 }) => {
-  const pathname = usePathname();
+  const pathname = usePathname() || "";
   const { layoutMode } = useContext(WindowContext);
 
   const sidebarArray = Array.isArray(sidebar) ? sidebar : [sidebar];


### PR DESCRIPTION
- Use `LabelHeading` component instead of `Label` in places where it's not associated with an input (`htmlFor` is empty).
- Small Eslint fixes.
- Mask secret key inputs on the Sign Transaction page.

![image](https://github.com/user-attachments/assets/80fd1bba-1b9b-488a-a4c9-2a8a55023f8e)