### PR TITLE
display 'transaction hash' only if the xdr type is tx

### DIFF
--- a/src/app/(sidebar)/xdr/view/page.tsx
+++ b/src/app/(sidebar)/xdr/view/page.tsx
@@ -54,6 +54,23 @@ export default function ViewXdr() {
     }
   }, [isLatestTxnSuccess, latestTxn, updateXdrBlob, updateXdrType]);
 
+  useEffect(() => {
+    if (isXdrInit && xdr.blob) {
+      try {
+        const guessed = StellarXdr.guess(xdr.blob);
+
+        // enable xdr type selector to use the guessed type as default
+        if (guessed.includes("TransactionEnvelope")) {
+          xdr.updateXdrType("TransactionEnvelope");
+        } else {
+          xdr.updateXdrType(guessed[0]);
+        }
+      } catch (e) {
+        // do nothing
+      }
+    }
+  }, [xdr.blob, isXdrInit]);
+
   const isFetchingLatestTxn = isLatestTxnFetching || isLatestTxnLoading;
 
   const xdrDecodeJson = () => {
@@ -137,10 +154,14 @@ export default function ViewXdr() {
             disabled={isFetchingLatestTxn}
           />
 
-          <TransactionHashReadOnlyField
-            xdr={xdr.blob}
-            networkPassphrase={network.passphrase}
-          />
+          {xdr.type?.includes("Transaction") ? (
+            <TransactionHashReadOnlyField
+              xdr={xdr.blob}
+              networkPassphrase={network.passphrase}
+            />
+          ) : (
+            <></>
+          )}
 
           <XdrTypeSelect error={xdrJsonDecoded?.error} />
 

--- a/src/helpers/transactionHashFromXdr.ts
+++ b/src/helpers/transactionHashFromXdr.ts
@@ -3,4 +3,15 @@ import { TransactionBuilder } from "@stellar/stellar-sdk";
 export const transactionHashFromXdr = (
   xdr: string,
   networkPassphrase: string,
-) => TransactionBuilder.fromXDR(xdr, networkPassphrase).hash().toString("hex");
+) => {
+  try {
+    // Code to read XDR data
+    return TransactionBuilder?.fromXDR(xdr, networkPassphrase)
+      .hash()
+      .toString("hex");
+  } catch (e) {
+    // @TODO Do nothing for now
+    // add amplitude error tracking
+    return;
+  }
+};


### PR DESCRIPTION

https://github.com/user-attachments/assets/dbd1d442-b026-4fdc-aedc-dd92abf3c761

**Summary:**
- `Transaction Hash` component threw an error when a non transaction xdr was inputted
- Added a `try catch` and enable the tx hash component only when its xdr type is `transaction`
- Also added a function to select the default guessed value for the xdr type dropdown. I found it useful when I was testing `ScVal` xdr
- Shout out to gleb and jayrome for reporting this bug

- `LedgerKey` xdr example: `AAAABgAAAAGWNEXLrjMwpL/B5VAx7PowbQ8QM/gG0tSbhaHxqESvswAAAA8AAAAITUVUQURBVEEAAAAB`
- `ScVal` xdr example: `AAAAEQAAAAEAAAAGAAAADwAAAAZhbW91bnQAAAAAAAoAAAAAAAAAAAAACRhOcqAAAAAADwAAAAxib290c3RyYXBwZXIAAAASAAAAARssFqxD/prgmYc9vGkaqslWrGlPINzMYTLc4yqRfO3AAAAADwAAAAxjbG9zZV9sZWRnZXIAAAADAz6ilAAAAA8AAAAIcGFpcl9taW4AAAAKAAAAAAAAAAAAAAARdlkuAAAAAA8AAAAEcG9vbAAAABIAAAABX/a7xfliM8nFgGel6pbCM6fT/kqrHAITNtWZQXgDlIIAAAAPAAAAC3Rva2VuX2luZGV4AAAAAAMAAAAA`
- `TransactionEnvelope` xdr example: `AAAAAgAAAADJrq4b4AopDZibkeBWpDxuWKUcY4FUUNQdIEF3Nm9dkQAAAGQAAAIiAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAACXlGN76T6NQcaUJxbEkH3mi1HHWsHnLqMDdlLl9NlJgQAAAAAAAAAABfXhAAAAAAAAAAAA`