### PR TITLE
Add a muxed account doc to muxed account page

### DIFF
--- a/src/app/(sidebar)/account/muxed-create/page.tsx
+++ b/src/app/(sidebar)/account/muxed-create/page.tsx
@@ -169,7 +169,10 @@ export default function CreateMuxedAccount() {
       >
         Don’t use in a production environment unless you know what you’re doing.
         Read more about Muxed accounts{" "}
-        <Link href="https://developers.stellar.org/">here</Link>.
+        <Link href="https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/pooled-accounts-muxed-accounts-memos#muxed-accounts">
+          here
+        </Link>
+        .
       </Alert>
 
       {Boolean(sdkError) && (

--- a/src/app/(sidebar)/account/muxed-create/page.tsx
+++ b/src/app/(sidebar)/account/muxed-create/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Alert, Button, Card, Input, Text } from "@stellar/design-system";
+import { Alert, Button, Card, Input, Link, Text } from "@stellar/design-system";
 
 import { useStore } from "@/store/useStore";
 
@@ -9,6 +9,7 @@ import { ExpandBox } from "@/components/ExpandBox";
 import { MuxedAccountResult } from "@/components/MuxedAccountResult";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
 import { SdsLink } from "@/components/SdsLink";
+import { WithInfoText } from "@/components/WithInfoText";
 
 import { muxedAccount } from "@/helpers/muxedAccount";
 
@@ -68,9 +69,11 @@ export default function CreateMuxedAccount() {
       <Card>
         <div className="Account__card">
           <div className="CardText">
-            <Text size="lg" as="h1" weight="medium">
-              Create Multiplexed Account
-            </Text>
+            <WithInfoText href="https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/pooled-accounts-muxed-accounts-memos">
+              <Text size="lg" as="h1" weight="medium">
+                Create Multiplexed Account
+              </Text>
+            </WithInfoText>
 
             <Text size="sm" as="p">
               A muxed (or multiplexed) account (defined in{" "}
@@ -165,6 +168,8 @@ export default function CreateMuxedAccount() {
         title="Muxed accounts are uncommon"
       >
         Don’t use in a production environment unless you know what you’re doing.
+        Read more about Muxed accounts{" "}
+        <Link href="https://developers.stellar.org/">here</Link>.
       </Alert>
 
       {Boolean(sdkError) && (

--- a/src/app/(sidebar)/account/muxed-parse/page.tsx
+++ b/src/app/(sidebar)/account/muxed-parse/page.tsx
@@ -130,7 +130,10 @@ export default function ParseMuxedAccount() {
       >
         Don’t use in a production environment unless you know what you’re doing.
         Read more about Muxed accounts{" "}
-        <Link href="https://developers.stellar.org/">here</Link>.
+        <Link href="https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/pooled-accounts-muxed-accounts-memos#muxed-accounts">
+          here
+        </Link>
+        .
       </Alert>
 
       {Boolean(sdkError) && (

--- a/src/app/(sidebar)/account/muxed-parse/page.tsx
+++ b/src/app/(sidebar)/account/muxed-parse/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Alert, Card, Text, Button } from "@stellar/design-system";
+import { Alert, Card, Link, Text, Button } from "@stellar/design-system";
 
 import { useStore } from "@/store/useStore";
 
 import { ExpandBox } from "@/components/ExpandBox";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
 import { MuxedAccountResult } from "@/components/MuxedAccountResult";
+import { WithInfoText } from "@/components/WithInfoText";
 
 import { muxedAccount } from "@/helpers/muxedAccount";
 
@@ -59,9 +60,11 @@ export default function ParseMuxedAccount() {
       <Card>
         <div className="Account__card">
           <div className="CardText">
-            <Text size="lg" as="h1" weight="medium">
-              Get Muxed Account from M address
-            </Text>
+            <WithInfoText href="https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/pooled-accounts-muxed-accounts-memos">
+              <Text size="lg" as="h1" weight="medium">
+                Get Muxed Account from M address
+              </Text>
+            </WithInfoText>
           </div>
 
           <PubKeyPicker
@@ -126,6 +129,8 @@ export default function ParseMuxedAccount() {
         title="Muxed accounts are uncommon"
       >
         Don’t use in a production environment unless you know what you’re doing.
+        Read more about Muxed accounts{" "}
+        <Link href="https://developers.stellar.org/">here</Link>.
       </Alert>
 
       {Boolean(sdkError) && (

--- a/src/components/WithInfoText/index.tsx
+++ b/src/components/WithInfoText/index.tsx
@@ -34,7 +34,7 @@ export const WithInfoText = ({
         {children}
 
         <NextLink {...buttonBaseProps} href={href}>
-          <Icon.BookOpen01 />
+          <Icon.InfoCircle />
         </NextLink>
       </div>
     );

--- a/src/components/WithInfoText/index.tsx
+++ b/src/components/WithInfoText/index.tsx
@@ -34,7 +34,7 @@ export const WithInfoText = ({
         {children}
 
         <NextLink {...buttonBaseProps} href={href}>
-          <Icon.InfoCircle />
+          <Icon.BookOpen01 />
         </NextLink>
       </div>
     );


### PR DESCRIPTION
- Added by placing an icon next to the title and in the description box below

![create-muxed](https://github.com/user-attachments/assets/54e8552a-559a-409d-98ee-aff325fd075b)
![parse-muxed](https://github.com/user-attachments/assets/092994fe-5e5d-4378-88e6-e2beb253cf23)

@sdfcharles : I noticed that in some areas, we use a book icon for the external link (like in build transaction), for the info icon in the title, should I use `info icon` or `book icon`

- what we have on `build tx`
![build-tx](https://github.com/user-attachments/assets/4be422f2-9730-4010-b2d3-17b4ddb17a8f)

- muxed account title
![title-muxed](https://github.com/user-attachments/assets/967e1b0d-5bb6-428c-9eb5-db7e7edd6b57)
