### PR TITLE
add copy button for the json payload for RPC

### DIFF
--- a/src/app/(sidebar)/endpoints/[[...pages]]/page.tsx
+++ b/src/app/(sidebar)/endpoints/[[...pages]]/page.tsx
@@ -610,9 +610,27 @@ export default function Endpoints() {
 
     if (renderedProps) {
       return (
-        <div className="Endpoints__txTextarea">
-          <PrettyJsonTextarea json={renderedProps} label="Payload" />
-        </div>
+        <>
+          <div className="Endpoints__txTextarea">
+            <PrettyJsonTextarea json={renderedProps} label="Payload" />
+          </div>
+          <Box gap="md" direction="row" justify="end">
+            <CopyText textToCopy={stringify(renderedProps, null, 2) || ""}>
+              <Button
+                size="md"
+                variant="tertiary"
+                icon={<Icon.Copy01 />}
+                iconPosition="left"
+                // needed this to prevent the form from submitting
+                onClick={(e) => {
+                  e.preventDefault();
+                }}
+              >
+                Copy JSON
+              </Button>
+            </CopyText>
+          </Box>
+        </>
       );
     }
     return null;

--- a/src/app/(sidebar)/endpoints/components/SavedEndpointsPage.tsx
+++ b/src/app/(sidebar)/endpoints/components/SavedEndpointsPage.tsx
@@ -5,6 +5,7 @@ import {
   Badge,
   Button,
   Card,
+  CopyText,
   Icon,
   Input,
   Modal,
@@ -23,6 +24,7 @@ import { localStorageSavedEndpointsHorizon } from "@/helpers/localStorageSavedEn
 import { localStorageSavedRpcMethods } from "@/helpers/localStorageSavedRpcMethods";
 import { arrayItem } from "@/helpers/arrayItem";
 import { formatTimestamp } from "@/helpers/formatTimestamp";
+import { stringify } from "lossless-json";
 import { useStore } from "@/store/useStore";
 import {
   Network,
@@ -323,9 +325,23 @@ export const SavedEndpointsPage = () => {
                 </Box>
               </Box>
               {expandedPayloadIndex[idx] ? (
-                <div className="Endpoints__txTextarea">
-                  <PrettyJsonTextarea json={e.payload} label="Payload" />
-                </div>
+                <>
+                  <div className="Endpoints__txTextarea">
+                    <PrettyJsonTextarea json={e.payload} label="Payload" />
+                  </div>
+                  <Box gap="md" direction="row" justify="end">
+                    <CopyText textToCopy={stringify(e.payload, null, 2) || ""}>
+                      <Button
+                        size="md"
+                        variant="tertiary"
+                        icon={<Icon.Copy01 />}
+                        iconPosition="left"
+                      >
+                        Copy JSON
+                      </Button>
+                    </CopyText>
+                  </Box>
+                </>
               ) : (
                 <></>
               )}


### PR DESCRIPTION
**Summary:**
- Add a copy button for the json payload for RPC on **saved requests** and **rpc method**
- Added `e.preventDefault();` for `Copy JSON` button. Without it, it'd submit the form

![saved-requests-rpc](https://github.com/user-attachments/assets/4fe9ba77-3789-4d48-81a2-537fc68cc45d)

<img width="995" alt="rpc-method" src="https://github.com/user-attachments/assets/40996e84-dba7-41ee-a285-2bd971b50194">
