### PR TITLE
Remove leading zeros for inputs with validate.getAmountError

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/Params.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Params.tsx
@@ -19,6 +19,7 @@ import { TimeBoundsPicker } from "@/components/FormElements/TimeBoundsPicker";
 
 import { sanitizeObject } from "@/helpers/sanitizeObject";
 import { isEmptyObject } from "@/helpers/isEmptyObject";
+import { removeLeadingZeroes } from "@/helpers/removeLeadingZeroes";
 
 import { TransactionBuildParams } from "@/store/createStore";
 import { useStore } from "@/store/useStore";
@@ -335,7 +336,7 @@ export const Params = () => {
           <PositiveIntPicker
             id="fee"
             label="Base Fee"
-            value={txnParams.fee}
+            value={removeLeadingZeroes(txnParams.fee)}
             error={paramsError.fee}
             onChange={(e) => {
               const id = "fee";

--- a/src/app/(sidebar)/transaction/fee-bump/page.tsx
+++ b/src/app/(sidebar)/transaction/fee-bump/page.tsx
@@ -12,6 +12,7 @@ import { validate } from "@/validate";
 
 import { sanitizeObject } from "@/helpers/sanitizeObject";
 import { txHelper, FeeBumpedTxResponse } from "@/helpers/txHelper";
+import { removeLeadingZeroes } from "@/helpers/removeLeadingZeroes";
 
 import { Box } from "@/components/layout/Box";
 import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
@@ -202,7 +203,7 @@ export default function FeeBumpTransaction() {
           <PositiveIntPicker
             id="fee"
             label="Base Fee"
-            value={fee}
+            value={removeLeadingZeroes(fee)}
             error={paramsError.fee}
             onChange={(e) => {
               const id = "fee";

--- a/src/components/formComponentTemplateEndpoints.tsx
+++ b/src/components/formComponentTemplateEndpoints.tsx
@@ -17,6 +17,8 @@ import { MultiLedgerEntriesPicker } from "@/components/FormElements/XdrLedgerKey
 import { ConfigSettingIdPicker } from "@/components/FormElements/ConfigSettingIdPicker";
 
 import { parseJsonString } from "@/helpers/parseJsonString";
+import { removeLeadingZeroes } from "@/helpers/removeLeadingZeroes";
+
 import { validate } from "@/validate";
 import {
   AnyObject,
@@ -349,7 +351,7 @@ export const formComponentTemplateEndpoints = (
             id={id}
             label="Destination Amount"
             labelSuffix={!templ.isRequired ? "optional" : undefined}
-            value={templ.value || ""}
+            value={templ.value ? removeLeadingZeroes(templ.value) : ""}
             error={templ.error}
             onChange={templ.onChange}
           />
@@ -698,7 +700,7 @@ export const formComponentTemplateEndpoints = (
             id={id}
             label="Source Amount"
             labelSuffix={!templ.isRequired ? "optional" : undefined}
-            value={templ.value || ""}
+            value={templ.value ? removeLeadingZeroes(templ.value) : ""}
             error={templ.error}
             onChange={templ.onChange}
           />
@@ -761,7 +763,7 @@ export const formComponentTemplateEndpoints = (
             id={id}
             label="Starting Balance"
             labelSuffix={!templ.isRequired ? "optional" : undefined}
-            value={templ.value || ""}
+            value={templ.value ? removeLeadingZeroes(templ.value) : ""}
             error={templ.error}
             onChange={templ.onChange}
           />

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -15,6 +15,8 @@ import { NumberFractionPicker } from "@/components/FormElements/NumberFractionPi
 import { RevokeSponsorshipPicker } from "@/components/FormElements/RevokeSponsorshipPicker";
 import { ClaimantsPicker } from "@/components/FormElements/ClaimantsPicker";
 
+import { removeLeadingZeroes } from "@/helpers/removeLeadingZeroes";
+
 import { validate } from "@/validate";
 import {
   AnyObject,
@@ -124,7 +126,7 @@ export const formComponentTemplateTxnOps = ({
             id={id}
             label={custom?.label || "Amount"}
             labelSuffix={!templ.isRequired ? "optional" : undefined}
-            value={templ.value || ""}
+            value={templ.value ? removeLeadingZeroes(templ.value) : ""}
             error={templ.error}
             onChange={templ.onChange}
             note={custom?.note}
@@ -641,7 +643,7 @@ export const formComponentTemplateTxnOps = ({
             id={id}
             label="Starting Balance"
             labelSuffix={!templ.isRequired ? "optional" : undefined}
-            value={templ.value || ""}
+            value={templ.value ? removeLeadingZeroes(templ.value) : ""}
             error={templ.error}
             onChange={templ.onChange}
           />

--- a/src/helpers/removeLeadingZeroes.ts
+++ b/src/helpers/removeLeadingZeroes.ts
@@ -1,0 +1,2 @@
+export const removeLeadingZeroes = (numStr: string) =>
+  numStr.replace(/^0+/, "") || "0";


### PR DESCRIPTION
- Add `removeLeadingZeroes` helper function
- Use the function to sanitize the value that uses either `PositiveIntPicker` component or inputs that use `validate.getAmountError` as a validation