### PR TITLE
Dependabot: do not notify about patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,14 @@ updates:
       time: "02:00"
     open-pull-requests-limit: 2
     groups:
-      minor-and-patch:
+      minor:
         applies-to: version-updates
         update-types:
-        - "patch"
-        - "minor"
+          - "minor"
       major:
         applies-to: version-updates
         update-types:
-        - "major"
+          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -27,7 +26,7 @@ updates:
     groups:
       all-actions:
         applies-to: version-updates
-        patterns: [ "*" ]
+        patterns: ["*"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -38,4 +37,4 @@ updates:
     groups:
       all-docker:
         applies-to: version-updates
-        patterns: [ "*" ]
+        patterns: ["*"]


### PR DESCRIPTION
Let's see if this reduces the noise that Dependabot PRs create. We probably don't want to update every time a new patch version is released anyway.