### PR TITLE
Contract Explorer: Contract info

### DIFF
--- a/src/app/(sidebar)/account/fund/components/SwitchNetwork.tsx
+++ b/src/app/(sidebar)/account/fund/components/SwitchNetwork.tsx
@@ -1,24 +1,11 @@
 "use client";
 
-import { Card, Text, Button } from "@stellar/design-system";
-
-import { NetworkOptions } from "@/constants/settings";
-import { useStore } from "@/store/useStore";
-
-import { NetworkType } from "@/types/types";
+import { Card, Text } from "@stellar/design-system";
+import { SwitchNetworkButtons } from "@/components/SwitchNetworkButtons";
 
 import "../../styles.scss";
 
 export const SwitchNetwork = () => {
-  const { selectNetwork, updateIsDynamicNetworkSelect } = useStore();
-  const onSwitchNetwork = (network: NetworkType) => {
-    const selectedNetwork = NetworkOptions.find((n) => n.id === network);
-    if (selectedNetwork) {
-      updateIsDynamicNetworkSelect(true);
-      selectNetwork(selectedNetwork);
-    }
-  };
-
   return (
     <Card>
       <div className="Account__card">
@@ -33,26 +20,12 @@ export const SwitchNetwork = () => {
             fund an account with 10,000 lumens on the futurenet network.
           </Text>
         </div>
-        <div className="Account__CTA" data-testid="fundAccount-buttons">
-          <Button
-            size="md"
-            variant="tertiary"
-            onClick={() => {
-              onSwitchNetwork("futurenet");
-            }}
-          >
-            Switch to Futurenet
-          </Button>
 
-          <Button
-            size="md"
-            variant="tertiary"
-            onClick={() => {
-              onSwitchNetwork("testnet");
-            }}
-          >
-            Switch to Testnet
-          </Button>
+        <div className="Account__CTA" data-testid="fundAccount-buttons">
+          <SwitchNetworkButtons
+            includedNetworks={["futurenet", "testnet"]}
+            buttonSize="md"
+          />
         </div>
       </div>
     </Card>

--- a/src/app/(sidebar)/account/saved/page.tsx
+++ b/src/app/(sidebar)/account/saved/page.tsx
@@ -16,6 +16,7 @@ import { InputSideElement } from "@/components/InputSideElement";
 import { SavedItemTimestampAndDelete } from "@/components/SavedItemTimestampAndDelete";
 import { PageCard } from "@/components/layout/PageCard";
 import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
+import { SwitchNetworkButtons } from "@/components/SwitchNetworkButtons";
 
 import { localStorageSavedKeypairs } from "@/helpers/localStorageSavedKeypairs";
 import { arrayItem } from "@/helpers/arrayItem";
@@ -131,25 +132,10 @@ export default function SavedKeypairs() {
         </Text>
 
         <Box gap="sm" direction="row" wrap="wrap">
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => {
-              getAndSetNetwork("futurenet");
-            }}
-          >
-            Switch to Futurenet
-          </Button>
-
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => {
-              getAndSetNetwork("testnet");
-            }}
-          >
-            Switch to Testnet
-          </Button>
+          <SwitchNetworkButtons
+            includedNetworks={["futurenet", "testnet"]}
+            buttonSize="md"
+          />
         </Box>
       </Box>
     );

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
@@ -4,13 +4,13 @@ import { SdsLink } from "@/components/SdsLink";
 import { formatEpochToDate } from "@/helpers/formatEpochToDate";
 import { formatNumber } from "@/helpers/formatNumber";
 import { stellarExpertAccountLink } from "@/helpers/stellarExpertAccountLink";
-import { NetworkType } from "@/types/types";
+import { ContractInfoApiResponse, NetworkType } from "@/types/types";
 
 export const ContractInfo = ({
   infoData,
   networkId,
 }: {
-  infoData: any;
+  infoData: ContractInfoApiResponse;
   networkId: NetworkType;
 }) => {
   type ContractExplorerInfoField = {
@@ -85,7 +85,7 @@ export const ContractInfo = ({
             key={field.id}
             label={field.label}
             value={
-              infoData.validation.repository ? (
+              infoData.validation?.repository ? (
                 <SdsLink
                   href={infoData.validation.repository}
                   addlClassName="Link--external"

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
@@ -54,7 +54,7 @@ export const ContractInfo = ({
   }) => {
     return (
       <Box
-        gap="lg"
+        gap="xs"
         direction="row"
         align="center"
         addlClassName="InfoFieldItem"
@@ -165,7 +165,7 @@ export const ContractInfo = ({
 
   return (
     <Card>
-      <Box gap="xs">
+      <Box gap="xs" addlClassName="ContractInfo">
         <>{INFO_FIELDS.map((f) => renderInfoField(f))}</>
       </Box>
     </Card>

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
@@ -165,7 +165,11 @@ export const ContractInfo = ({
 
   return (
     <Card>
-      <Box gap="xs" addlClassName="ContractInfo">
+      <Box
+        gap="xs"
+        addlClassName="ContractInfo"
+        data-testid="contract-info-container"
+      >
         <>{INFO_FIELDS.map((f) => renderInfoField(f))}</>
       </Box>
     </Card>

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
@@ -1,0 +1,173 @@
+import { Avatar, Card, Icon, Logo } from "@stellar/design-system";
+import { Box } from "@/components/layout/Box";
+import { SdsLink } from "@/components/SdsLink";
+import { formatEpochToDate } from "@/helpers/formatEpochToDate";
+import { formatNumber } from "@/helpers/formatNumber";
+import { stellarExpertAccountLink } from "@/helpers/stellarExpertAccountLink";
+import { NetworkType } from "@/types/types";
+
+export const ContractInfo = ({
+  infoData,
+  networkId,
+}: {
+  infoData: any;
+  networkId: NetworkType;
+}) => {
+  type ContractExplorerInfoField = {
+    id: string;
+    label: string;
+  };
+
+  const INFO_FIELDS: ContractExplorerInfoField[] = [
+    {
+      id: "repository",
+      label: "Source Code",
+    },
+    {
+      id: "created",
+      label: "Created",
+    },
+    {
+      id: "wasm",
+      label: "WASM Hash",
+    },
+    {
+      id: "versions",
+      label: "Versions",
+    },
+    {
+      id: "creator",
+      label: "Creator",
+    },
+    {
+      id: "storage_entries",
+      label: "Data Storage",
+    },
+  ];
+
+  const InfoFieldItem = ({
+    label,
+    value,
+  }: {
+    label: string;
+    value: React.ReactNode;
+  }) => {
+    return (
+      <Box
+        gap="lg"
+        direction="row"
+        align="center"
+        addlClassName="InfoFieldItem"
+      >
+        <div className="InfoFieldItem__label">{label}</div>
+        <div className="InfoFieldItem__value">{value ?? "-"}</div>
+      </Box>
+    );
+  };
+
+  const formatEntriesText = (entriesCount: number) => {
+    if (!entriesCount) {
+      return "";
+    }
+
+    if (entriesCount === 1) {
+      return `1 entry`;
+    }
+
+    return `${formatNumber(entriesCount)} entries`;
+  };
+
+  const renderInfoField = (field: ContractExplorerInfoField) => {
+    switch (field.id) {
+      case "repository":
+        return (
+          <InfoFieldItem
+            key={field.id}
+            label={field.label}
+            value={
+              infoData.validation.repository ? (
+                <SdsLink
+                  href={infoData.validation.repository}
+                  addlClassName="Link--external"
+                >
+                  <Logo.Github />
+                  {infoData.validation.repository.replace(
+                    "https://github.com/",
+                    "",
+                  )}
+                  <Icon.LinkExternal01 />
+                </SdsLink>
+              ) : null
+            }
+          />
+        );
+      case "created":
+        return (
+          <InfoFieldItem
+            key={field.id}
+            label={field.label}
+            value={
+              infoData.created ? formatEpochToDate(infoData.created) : null
+            }
+          />
+        );
+      case "wasm":
+        return (
+          <InfoFieldItem
+            key={field.id}
+            label={field.label}
+            value={infoData.wasm}
+          />
+        );
+      case "versions":
+        return (
+          <InfoFieldItem
+            key={field.id}
+            label={field.label}
+            value={infoData.versions}
+          />
+        );
+      case "creator":
+        return (
+          <InfoFieldItem
+            key={field.id}
+            label={field.label}
+            value={
+              infoData.creator ? (
+                <SdsLink
+                  href={stellarExpertAccountLink(infoData.creator, networkId)}
+                >
+                  <Avatar publicAddress={infoData.creator} size="sm" />
+                  {infoData.creator}
+                  <Icon.LinkExternal01 />
+                </SdsLink>
+              ) : null
+            }
+          />
+        );
+      case "storage_entries":
+        return (
+          <InfoFieldItem
+            key={field.id}
+            label={field.label}
+            // TODO: link to Contract Storage tab when ready
+            value={
+              infoData.storage_entries
+                ? formatEntriesText(infoData.storage_entries)
+                : null
+            }
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card>
+      <Box gap="xs">
+        <>{INFO_FIELDS.map((f) => renderInfoField(f))}</>
+      </Box>
+    </Card>
+  );
+};

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -59,7 +59,9 @@ export default function ContractExplorer() {
   const isCurrentNetworkSupported = ["mainnet", "testnet"].includes(network.id);
 
   const renderContractInfoContent = () => {
-    return <ContractInfo infoData={contractInfoData} networkId={network.id} />;
+    return contractInfoData ? (
+      <ContractInfo infoData={contractInfoData} networkId={network.id} />
+    ) : null;
   };
 
   const renderContractInvokeContent = () => {

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -16,9 +16,6 @@ import { SwitchNetworkButtons } from "@/components/SwitchNetworkButtons";
 
 import { ContractInfo } from "./components/ContractInfo";
 
-// TODO: mobile UI
-// TODO: update nav break points
-// TODO: tests
 export default function ContractExplorer() {
   const { network, smartContracts } = useStore();
   const [contractActiveTab, setContractActiveTab] = useState("contract-info");

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button, Card, Icon, Input, Link, Text } from "@stellar/design-system";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useStore } from "@/store/useStore";
+import { useSEContractInfo } from "@/query/external/useSEContractInfo";
+import { validate } from "@/validate";
+
+import { Box } from "@/components/layout/Box";
+import { PageCard } from "@/components/layout/PageCard";
+import { MessageField } from "@/components/MessageField";
+import { TabView } from "@/components/TabView";
+import { SwitchNetworkButtons } from "@/components/SwitchNetworkButtons";
+
+import { ContractInfo } from "./components/ContractInfo";
+
+// TODO: mobile UI
+// TODO: update nav break points
+// TODO: tests
+export default function ContractExplorer() {
+  const { network, smartContracts } = useStore();
+  const [contractActiveTab, setContractActiveTab] = useState("contract-info");
+  const [contractIdInput, setContractIdInput] = useState("");
+  const [contractIdInputError, setContractIdInputError] = useState("");
+
+  const {
+    data: contractInfoData,
+    error: contractInfoError,
+    isLoading: isContractInfoLoading,
+    isFetching: isContractInfoFetching,
+    refetch: fetchContractInfo,
+  } = useSEContractInfo({
+    networkId: network.id,
+    contractId: contractIdInput,
+  });
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (smartContracts.explorer.contractId) {
+      setContractIdInput(smartContracts.explorer.contractId);
+    }
+    // On page load only
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const resetFetchContractInfo = () => {
+    if (contractInfoData) {
+      queryClient.resetQueries({
+        queryKey: ["useSEContractInfo"],
+      });
+      smartContracts.resetExplorerContractId();
+    }
+
+    if (contractIdInputError) {
+      setContractIdInputError("");
+    }
+  };
+
+  const isCurrentNetworkSupported = ["mainnet", "testnet"].includes(network.id);
+
+  const renderContractInfoContent = () => {
+    return <ContractInfo infoData={contractInfoData} networkId={network.id} />;
+  };
+
+  const renderContractInvokeContent = () => {
+    return <Card>Coming soon</Card>;
+  };
+
+  const renderButtons = () => {
+    if (isCurrentNetworkSupported) {
+      return (
+        <Box gap="sm" direction="row">
+          <Button
+            size="md"
+            variant="secondary"
+            type="submit"
+            disabled={
+              !isCurrentNetworkSupported ||
+              !contractIdInput ||
+              Boolean(contractIdInputError)
+            }
+            isLoading={isContractInfoLoading || isContractInfoFetching}
+          >
+            Load contract
+          </Button>
+
+          <>
+            {contractIdInput ? (
+              <Button
+                size="md"
+                variant="error"
+                icon={<Icon.RefreshCw01 />}
+                onClick={() => {
+                  resetFetchContractInfo();
+                  setContractIdInput("");
+                }}
+                disabled={isContractInfoLoading || isContractInfoFetching}
+              >
+                Clear
+              </Button>
+            ) : null}
+          </>
+        </Box>
+      );
+    }
+
+    return (
+      <Box gap="sm" direction="row">
+        <SwitchNetworkButtons
+          includedNetworks={["testnet", "mainnet"]}
+          buttonSize="md"
+        />
+      </Box>
+    );
+  };
+
+  return (
+    <Box gap="lg">
+      <PageCard heading="Contract Explorer">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            fetchContractInfo();
+            smartContracts.updateExplorerContractId(contractIdInput);
+          }}
+          className="ContractExplorer__form"
+        >
+          <Box gap="lg">
+            <Input
+              fieldSize="md"
+              id="contract-id"
+              label="Contract ID"
+              leftElement={<Icon.FileCode02 />}
+              placeholder="Ex: CCBWOUL7XW5XSWD3UKL76VWLLFCSZP4D4GUSCFBHUQCEAW23QVKJZ7ON"
+              error={contractIdInputError}
+              value={contractIdInput}
+              onChange={(e) => {
+                resetFetchContractInfo();
+                setContractIdInput(e.target.value);
+
+                const error = validate.getContractIdError(e.target.value);
+                setContractIdInputError(error || "");
+              }}
+              note={
+                isCurrentNetworkSupported
+                  ? ""
+                  : "You must switch your network to Mainnet or Testnet in order to see contract info."
+              }
+            />
+
+            <>{renderButtons()}</>
+
+            <>
+              {contractInfoError ? (
+                <MessageField
+                  message={contractInfoError.toString()}
+                  isError={true}
+                />
+              ) : null}
+            </>
+          </Box>
+        </form>
+      </PageCard>
+
+      <>
+        {contractInfoData ? (
+          <>
+            <TabView
+              tab1={{
+                id: "contract-info",
+                label: "Contract Info",
+                content: renderContractInfoContent(),
+              }}
+              tab2={{
+                id: "contract-invoke",
+                label: "Invoke Contract",
+                content: renderContractInvokeContent(),
+              }}
+              activeTabId={contractActiveTab}
+              onTabChange={(tabId) => {
+                setContractActiveTab(tabId);
+              }}
+            />
+
+            <Text as="div" size="xs">
+              Powered by{" "}
+              <Link href="https://stellar.expert">Stellar.Expert</Link>
+            </Text>
+          </>
+        ) : null}
+      </>
+    </Box>
+  );
+}

--- a/src/app/(sidebar)/smart-contracts/layout.tsx
+++ b/src/app/(sidebar)/smart-contracts/layout.tsx
@@ -1,20 +1,18 @@
 "use client";
 
 import React from "react";
-
 import { LayoutSidebarContent } from "@/components/layout/LayoutSidebarContent";
+import { SMART_CONTRACTS_NAV_ITEMS } from "@/constants/navItems";
 
-export default function TransactionTemplate({
+import "./styles.scss";
+
+export default function SmartContractsTemplate({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <LayoutSidebarContent
-      sidebar={{
-        navItems: [],
-      }}
-    >
+    <LayoutSidebarContent sidebar={SMART_CONTRACTS_NAV_ITEMS}>
       {children}
     </LayoutSidebarContent>
   );

--- a/src/app/(sidebar)/smart-contracts/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/page.tsx
@@ -1,5 +1,0 @@
-"use client";
-
-export default function SmartContracts() {
-  return <div>Coming soon</div>;
-}

--- a/src/app/(sidebar)/smart-contracts/styles.scss
+++ b/src/app/(sidebar)/smart-contracts/styles.scss
@@ -8,11 +8,32 @@
   }
 }
 
+.ContractInfo {
+  @media screen and (max-width: 500px) {
+    &.Box--xs {
+      gap: pxToRem(12px);
+    }
+  }
+}
+
 .InfoFieldItem {
   font-size: pxToRem(12px);
   line-height: pxToRem(18px);
 
   &__label {
+    flex-shrink: 0;
     width: pxToRem(128px);
+  }
+
+  &__value {
+    word-break: break-all;
+  }
+
+  @media screen and (max-width: 500px) {
+    flex-wrap: wrap;
+
+    &__label {
+      width: 100%;
+    }
   }
 }

--- a/src/app/(sidebar)/smart-contracts/styles.scss
+++ b/src/app/(sidebar)/smart-contracts/styles.scss
@@ -1,0 +1,18 @@
+@use "../../../styles/utils.scss" as *;
+
+.ContractExplorer {
+  &__form {
+    .Button {
+      width: fit-content;
+    }
+  }
+}
+
+.InfoFieldItem {
+  font-size: pxToRem(12px);
+  line-height: pxToRem(18px);
+
+  &__label {
+    width: pxToRem(128px);
+  }
+}

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -35,6 +35,7 @@ import { ViewInXdrButton } from "@/components/ViewInXdrButton";
 import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
 import { LabelHeading } from "@/components/LabelHeading";
 import { PageCard } from "@/components/layout/PageCard";
+import { MessageField } from "@/components/MessageField";
 
 const MIN_LENGTH_FOR_FULL_WIDTH_FIELD = 30;
 
@@ -425,26 +426,6 @@ export const Overview = () => {
   } else if (sign.importTx) {
     mergedFields = [...REQUIRED_FIELDS, ...TX_FIELDS(sign.importTx)];
   }
-
-  const MessageField = ({
-    message,
-    isError,
-  }: {
-    message: string;
-    isError?: boolean;
-  }) => {
-    return (
-      <Box
-        gap="xs"
-        addlClassName={`SignTx__note FieldNote FieldNote--${isError ? "error" : "success"}`}
-        direction="row"
-        align="center"
-      >
-        <span>{message}</span>
-        {isError ? <Icon.XCircle /> : <Icon.CheckCircle />}
-      </Box>
-    );
-  };
 
   const SignTxButton = ({
     label = "Sign transaction",

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -43,7 +43,7 @@ const primaryNavLinks: NavLink[] = [
   },
 ];
 
-export const MainNav = () => {
+export const MainNav = ({ excludeDocs }: { excludeDocs?: boolean }) => {
   const pathname = usePathname();
 
   const isActiveRoute = (link: string) => {
@@ -65,10 +65,14 @@ export const MainNav = () => {
     </NextLink>
   );
 
+  const links = excludeDocs
+    ? primaryNavLinks.filter((l) => l.label !== "View Docs")
+    : primaryNavLinks;
+
   return (
     <nav className="LabLayout__header__nav">
       <div className="LabLayout__header__nav--primary">
-        {primaryNavLinks.map((l) => (
+        {links.map((l) => (
           <NavItem key={l.href} link={l} />
         ))}
       </div>

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -32,11 +32,10 @@ const primaryNavLinks: NavLink[] = [
     href: Routes.ENDPOINTS,
     label: "API Explorer",
   },
-  // TODO: hide until ready
-  // {
-  //   href: Routes.SMART_CONTRACTS,
-  //   label: "Smart Contracts",
-  // },
+  {
+    href: Routes.SMART_CONTRACTS_CONTRACT_EXPLORER,
+    label: "Smart Contracts",
+  },
   {
     href: "https://developers.stellar.org/",
     label: "View Docs",

--- a/src/components/MessageField.tsx
+++ b/src/components/MessageField.tsx
@@ -1,0 +1,22 @@
+import { Icon } from "@stellar/design-system";
+import { Box } from "@/components/layout/Box";
+
+export const MessageField = ({
+  message,
+  isError,
+}: {
+  message: string;
+  isError?: boolean;
+}) => {
+  return (
+    <Box
+      gap="xs"
+      addlClassName={`SignTx__note FieldNote FieldNote--${isError ? "error" : "success"}`}
+      direction="row"
+      align="center"
+    >
+      <span>{message}</span>
+      {isError ? <Icon.XCircle /> : <Icon.CheckCircle />}
+    </Box>
+  );
+};

--- a/src/components/SwitchNetworkButtons.tsx
+++ b/src/components/SwitchNetworkButtons.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@stellar/design-system";
+import { getNetworkById } from "@/helpers/getNetworkById";
+import { useStore } from "@/store/useStore";
+import { NetworkType } from "@/types/types";
+import { capitalizeString } from "@/helpers/capitalizeString";
+
+export const SwitchNetworkButtons = ({
+  includedNetworks,
+  buttonSize,
+}: {
+  includedNetworks: NetworkType[];
+  buttonSize: "sm" | "md" | "lg";
+}) => {
+  const { selectNetwork, updateIsDynamicNetworkSelect } = useStore();
+
+  const getAndSetNetwork = (networkId: NetworkType) => {
+    const newNetwork = getNetworkById(networkId);
+
+    if (newNetwork) {
+      updateIsDynamicNetworkSelect(true);
+      selectNetwork(newNetwork);
+    }
+  };
+
+  return (
+    <>
+      {includedNetworks.map((n) => (
+        <Button
+          key={`switch-${n}`}
+          variant="tertiary"
+          size={buttonSize}
+          onClick={() => {
+            getAndSetNetwork(n);
+          }}
+        >
+          {`Switch to ${capitalizeString(n)}`}
+        </Button>
+      ))}
+    </>
+  );
+};

--- a/src/components/TabView/index.tsx
+++ b/src/components/TabView/index.tsx
@@ -14,7 +14,7 @@ type Tab = {
 };
 
 type TabViewProps = {
-  heading: TabViewHeadingProps;
+  heading?: TabViewHeadingProps;
   tab1: Tab;
   tab2: Tab;
   tab3?: Tab;
@@ -42,9 +42,9 @@ export const TabView = ({
   }));
 
   return (
-    <Box gap="md" addlClassName="TabView">
+    <Box gap="lg" addlClassName="TabView">
       <div className="TabView__heading">
-        <TabViewHeading {...heading} />
+        {heading ? <TabViewHeading {...heading} /> : null}
 
         <div className="TabView__tabContainer">
           <Tabs
@@ -55,15 +55,13 @@ export const TabView = ({
         </div>
       </div>
 
-      <Box gap="md">
-        <div className="TabView__content">
-          {tabContent.map((tc) => (
-            <div key={tc.id} data-is-active={activeTabId === tc.id}>
-              {tc.content}
-            </div>
-          ))}
-        </div>
-      </Box>
+      <div className="TabView__content">
+        {tabContent.map((tc) => (
+          <div key={tc.id} data-is-active={activeTabId === tc.id}>
+            {tc.content}
+          </div>
+        ))}
+      </div>
     </Box>
   );
 };

--- a/src/components/layout/LayoutContextProvider.tsx
+++ b/src/components/layout/LayoutContextProvider.tsx
@@ -7,10 +7,12 @@ type LayoutMode = "desktop" | "mobile";
 
 type WindowContextProps = {
   layoutMode?: LayoutMode;
+  windowWidth?: number;
 };
 
 export const WindowContext = createContext<WindowContextProps>({
   layoutMode: undefined,
+  windowWidth: undefined,
 });
 
 export const LayoutContextProvider = ({
@@ -21,16 +23,22 @@ export const LayoutContextProvider = ({
   const MAX_WIDTH = 1040;
 
   const [layoutMode, setLayoutMode] = useState<LayoutMode>();
+  const [windowWidth, setWindowWidth] = useState<number>();
 
   const getLayoutMode = (windowWidth: number) => {
     return windowWidth < MAX_WIDTH ? "mobile" : "desktop";
   };
 
   useEffect(() => {
-    setLayoutMode(getLayoutMode(document.documentElement.clientWidth));
+    const setState = () => {
+      setLayoutMode(getLayoutMode(document.documentElement.clientWidth));
+      setWindowWidth(document.documentElement.clientWidth);
+    };
+
+    setState();
 
     const handleResize = throttle(() => {
-      setLayoutMode(getLayoutMode(document.documentElement.clientWidth));
+      setState();
     }, 500);
 
     window.addEventListener("resize", handleResize);
@@ -41,7 +49,7 @@ export const LayoutContextProvider = ({
   }, []);
 
   return (
-    <WindowContext.Provider value={{ layoutMode }}>
+    <WindowContext.Provider value={{ layoutMode, windowWidth }}>
       {children}
     </WindowContext.Provider>
   );

--- a/src/components/layout/LayoutHeader.tsx
+++ b/src/components/layout/LayoutHeader.tsx
@@ -48,7 +48,7 @@ const NAV = [
 ];
 
 export const LayoutHeader = () => {
-  const { layoutMode } = useContext(WindowContext);
+  const { windowWidth } = useContext(WindowContext);
   const { setTheme } = useStore();
   const route = useRouter();
   const pathname = usePathname();
@@ -143,10 +143,10 @@ export const LayoutHeader = () => {
       <>
         <option value={Routes.ROOT}>Introduction</option>
 
-        {flattenFormattedNav.map((fn) => (
-          <optgroup key={fn.groupTitle} label={fn.groupTitle}>
+        {flattenFormattedNav.map((fn, groupIdx) => (
+          <optgroup key={`${fn.groupTitle}-${groupIdx}`} label={fn.groupTitle}>
             {fn.options.map((op) => (
-              <option key={op.value} value={op.value}>
+              <option key={`${fn.groupTitle}-${op.value}`} value={op.value}>
                 {op.label}
               </option>
             ))}
@@ -161,34 +161,53 @@ export const LayoutHeader = () => {
     setTheme(theme);
   };
 
-  if (layoutMode === "desktop") {
+  const renderSettingsDropdown = () => {
     return (
-      <div className="LabLayout__header">
-        <header className="LabLayout__header__main">
-          <ProjectLogo
-            title="Lab"
-            link="/"
-            customAnchor={<Link href="/" prefetch={true} />}
-          />
+      <FloaterDropdown
+        triggerEl={<IconButton icon={<Icon.Menu01 />} altText="Menu" />}
+        offset={14}
+      >
+        <>
+          <div className="LabLayout__header__dropdown__item">
+            <div className="LabLayout__header__dropdown__item__label">
+              <ConnectWallet />
+            </div>
+          </div>
 
-          <MainNav />
-
-          <div className="LabLayout__header__settings">
+          <DropdownItem label="Theme">
             <Hydration>
               <ThemeSwitch
                 storageKeyId={LOCAL_STORAGE_SAVED_THEME}
                 onActionEnd={renderTheme}
               />
             </Hydration>
-            <NetworkSelector />
-            <ConnectWallet />
-          </div>
-        </header>
-      </div>
+          </DropdownItem>
+
+          <DropdownItem
+            label="View documentation"
+            href="https://developers.stellar.org/"
+          />
+
+          <DropdownItem
+            label="Got product feedback?"
+            href="https://github.com/stellar/laboratory/issues"
+          />
+
+          <DropdownItem
+            label="GitHub"
+            href="https://github.com/stellar/laboratory"
+          />
+        </>
+      </FloaterDropdown>
     );
+  };
+
+  if (!windowWidth) {
+    return null;
   }
 
-  if (layoutMode === "mobile") {
+  // Mobile
+  if (windowWidth < 940) {
     return (
       <div className="LabLayout__header">
         <header className="LabLayout__header__main">
@@ -203,50 +222,62 @@ export const LayoutHeader = () => {
 
           <Box gap="md" direction="row" align="center">
             <NetworkSelector />
-
-            <FloaterDropdown
-              triggerEl={<IconButton icon={<Icon.Menu01 />} altText="Menu" />}
-              offset={14}
-            >
-              <>
-                <div className="LabLayout__header__dropdown__item">
-                  <div className="LabLayout__header__dropdown__item__label">
-                    <ConnectWallet />
-                  </div>
-                </div>
-
-                <DropdownItem label="Theme">
-                  <Hydration>
-                    <ThemeSwitch
-                      storageKeyId={LOCAL_STORAGE_SAVED_THEME}
-                      onActionEnd={renderTheme}
-                    />
-                  </Hydration>
-                </DropdownItem>
-
-                <DropdownItem
-                  label="View documentation"
-                  href="https://developers.stellar.org/"
-                />
-
-                <DropdownItem
-                  label="Got product feedback?"
-                  href="https://github.com/stellar/laboratory/issues"
-                />
-
-                <DropdownItem
-                  label="GitHub"
-                  href="https://github.com/stellar/laboratory"
-                />
-              </>
-            </FloaterDropdown>
+            {renderSettingsDropdown()}
           </Box>
         </header>
       </div>
     );
   }
 
-  return null;
+  // Show hamburger menu
+  if (windowWidth < 1230) {
+    return (
+      <div className="LabLayout__header">
+        <header className="LabLayout__header__main">
+          <ProjectLogo
+            title="Lab"
+            link="/"
+            customAnchor={<Link href="/" prefetch={true} />}
+          />
+
+          <MainNav excludeDocs={true} />
+
+          <div className="LabLayout__header__settings">
+            <Box gap="md" direction="row" align="center">
+              <NetworkSelector />
+              {renderSettingsDropdown()}
+            </Box>
+          </div>
+        </header>
+      </div>
+    );
+  }
+
+  // Desktop
+  return (
+    <div className="LabLayout__header">
+      <header className="LabLayout__header__main">
+        <ProjectLogo
+          title="Lab"
+          link="/"
+          customAnchor={<Link href="/" prefetch={true} />}
+        />
+
+        <MainNav />
+
+        <div className="LabLayout__header__settings">
+          <Hydration>
+            <ThemeSwitch
+              storageKeyId={LOCAL_STORAGE_SAVED_THEME}
+              onActionEnd={renderTheme}
+            />
+          </Hydration>
+          <NetworkSelector />
+          <ConnectWallet />
+        </div>
+      </header>
+    </div>
+  );
 };
 
 const DropdownItem = ({

--- a/src/constants/navItems.tsx
+++ b/src/constants/navItems.tsx
@@ -117,3 +117,15 @@ export const XDR_NAV_ITEMS = [
     ],
   },
 ];
+
+export const SMART_CONTRACTS_NAV_ITEMS = [
+  {
+    instruction: "Smart Contract Tools",
+    navItems: [
+      {
+        route: Routes.SMART_CONTRACTS_CONTRACT_EXPLORER,
+        label: "Contract Explorer",
+      },
+    ],
+  },
+];

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -83,4 +83,5 @@ export enum Routes {
   TO_XDR = "/xdr/to",
   // Smart Contracts
   SMART_CONTRACTS = "/smart-contracts",
+  SMART_CONTRACTS_CONTRACT_EXPLORER = "/smart-contracts/contract-explorer",
 }

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -120,3 +120,5 @@ export const OPERATION_TRUSTLINE_CLEAR_FLAGS = [
 ];
 
 export const GITHUB_URL = "https://github.com/stellar/laboratory";
+export const STELLAR_EXPERT = "https://stellar.expert/explorer";
+export const STELLAR_EXPERT_API = "https://api.stellar.expert/explorer";

--- a/src/helpers/formatNumber.ts
+++ b/src/helpers/formatNumber.ts
@@ -1,0 +1,2 @@
+export const formatNumber = (num: number) =>
+  new Intl.NumberFormat("en-US").format(num);

--- a/src/helpers/getBlockExplorerLink.ts
+++ b/src/helpers/getBlockExplorerLink.ts
@@ -1,15 +1,9 @@
+import { STELLAR_EXPERT } from "@/constants/settings";
+
 export type BlockExplorer = "stellar.expert" | "stellarchain.io";
 
 export const getBlockExplorerLink = (explorer: BlockExplorer) => {
   switch (explorer) {
-    case "stellar.expert": {
-      return {
-        mainnet: "https://stellar.expert/explorer/public",
-        testnet: "https://stellar.expert/explorer/testnet",
-        futurenet: "",
-        custom: "",
-      };
-    }
     case "stellarchain.io":
       return {
         mainnet: "https://stellarchain.io",
@@ -18,10 +12,11 @@ export const getBlockExplorerLink = (explorer: BlockExplorer) => {
         custom: "",
       };
     // defaults to stellar.expert
+    case "stellar.expert":
     default:
       return {
-        mainnet: "https://stellar.expert/explorer/public",
-        testnet: "https://stellar.expert/explorer/testnet",
+        mainnet: `${STELLAR_EXPERT}/public`,
+        testnet: `${STELLAR_EXPERT}/testnet`,
         futurenet: "",
         custom: "",
       };

--- a/src/helpers/stellarExpertAccountLink.ts
+++ b/src/helpers/stellarExpertAccountLink.ts
@@ -1,0 +1,16 @@
+import { STELLAR_EXPERT } from "@/constants/settings";
+import { NetworkType } from "@/types/types";
+
+export const stellarExpertAccountLink = (
+  accountAddress: string,
+  networkId: NetworkType,
+) => {
+  // Not supported networks
+  if (["futurenet", "custom"].includes(networkId)) {
+    return "";
+  }
+
+  const network = networkId === "mainnet" ? "public" : "testnet";
+
+  return `${STELLAR_EXPERT}/${network}/account/${accountAddress}`;
+};

--- a/src/query/external/useSEContractInfo.ts
+++ b/src/query/external/useSEContractInfo.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { STELLAR_EXPERT_API } from "@/constants/settings";
+import { ContractInfoApiResponse, NetworkType } from "@/types/types";
+
+export const useSEContractInfo = ({
+  networkId,
+  contractId,
+}: {
+  networkId: NetworkType;
+  contractId: string;
+}) => {
+  const query = useQuery<ContractInfoApiResponse>({
+    queryKey: ["useSEContractInfo", networkId, contractId],
+    queryFn: async () => {
+      // Not supported networks
+      if (["futurenet", "custom"].includes(networkId)) {
+        return null;
+      }
+
+      const network = networkId === "mainnet" ? "public" : "testnet";
+
+      try {
+        const response = await fetch(
+          `${STELLAR_EXPERT_API}/${network}/contract/${contractId}`,
+        );
+
+        return await response.json();
+      } catch (e: any) {
+        throw `Something went wrong. ${e}`;
+      }
+    },
+    enabled: false,
+  });
+
+  return query;
+};

--- a/src/query/external/useSEContractInfo.ts
+++ b/src/query/external/useSEContractInfo.ts
@@ -24,7 +24,13 @@ export const useSEContractInfo = ({
           `${STELLAR_EXPERT_API}/${network}/contract/${contractId}`,
         );
 
-        return await response.json();
+        const responseJson = await response.json();
+
+        if (responseJson.error) {
+          throw responseJson.error;
+        }
+
+        return responseJson;
       } catch (e: any) {
         throw `Something went wrong. ${e}`;
       }

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -178,6 +178,15 @@ export interface Store {
     resetXdr: () => void;
     resetJsonString: () => void;
   };
+
+  // Smart Contracts
+  smartContracts: {
+    explorer: {
+      contractId: string;
+    };
+    updateExplorerContractId: (contractId: string) => void;
+    resetExplorerContractId: () => void;
+  };
 }
 
 interface CreateStoreOptions {
@@ -253,6 +262,12 @@ const initXdrState = {
   blob: "",
   jsonString: "",
   type: XDR_TYPE_TRANSACTION_ENVELOPE,
+};
+
+const initSmartContractsState = {
+  explorer: {
+    contractId: "",
+  },
 };
 
 // Store
@@ -480,6 +495,7 @@ export const createStore = (options: CreateStoreOptions) =>
               state.transaction.feeBump = initTransactionState.feeBump;
             }),
         },
+        // XDR
         xdr: {
           ...initXdrState,
           updateXdrBlob: (blob: string) =>
@@ -503,6 +519,18 @@ export const createStore = (options: CreateStoreOptions) =>
             set((state) => {
               state.xdr.jsonString = initXdrState.jsonString;
               state.xdr.type = initXdrState.type;
+            }),
+        },
+        // Smart Contracts
+        smartContracts: {
+          ...initSmartContractsState,
+          updateExplorerContractId: (contractId) =>
+            set((state) => {
+              state.smartContracts.explorer.contractId = contractId;
+            }),
+          resetExplorerContractId: () =>
+            set((state) => {
+              state.smartContracts.explorer.contractId = "";
             }),
         },
       })),
@@ -548,6 +576,11 @@ export const createStore = (options: CreateStoreOptions) =>
               blob: true,
               jsonString: true,
               type: true,
+            },
+            smartContracts: {
+              explorer: {
+                contractId: true,
+              },
             },
           };
         },

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -69,6 +69,18 @@
     }
   }
 
+  .Link--external {
+    gap: pxToRem(4px);
+    align-items: center;
+
+    svg {
+      // GitHub icon
+      g[clip-path="url(#github_svg__a)"] path {
+        fill: currentColor !important;
+      }
+    }
+  }
+
   // ===========================================================================
   // Layout
   // ===========================================================================

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -351,3 +351,35 @@ export interface SavedRpcMethod extends LocalStorageSavedItem {
   shareableUrl: string | undefined;
   payload: AnyObject;
 }
+
+// =============================================================================
+// Smart Contract Explorer
+// =============================================================================
+export type ContractInfoApiResponse = {
+  contract: string;
+  created: number;
+  creator: string;
+  account?: string;
+  payments?: number;
+  trades?: number;
+  wasm?: string;
+  storage_entries?: number;
+  validation?: {
+    status?: "verified" | "unverified";
+    repository?: string;
+    commit?: string;
+    package?: string;
+    make?: string;
+    ts?: number;
+  };
+  versions?: number;
+  salt?: string;
+  asset?: string;
+  code?: string;
+  issuer?: string;
+  functions?: {
+    invocations: number;
+    subinvocations: number;
+    function: string;
+  }[];
+};

--- a/tests/contractInfo.test.ts
+++ b/tests/contractInfo.test.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "@playwright/test";
+import { STELLAR_EXPERT_API } from "@/constants/settings";
+import { SAVED_ACCOUNT_1 } from "./mock/localStorage";
+
+test.describe("Contract Info", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("http://localhost:3000/smart-contracts/contract-explorer");
+  });
+
+  test("Loads", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText("Contract Explorer");
+    await expect(page.getByLabel("Contract ID")).toHaveValue("");
+    await expect(
+      page.getByRole("button", { name: "Load contract" }),
+    ).toBeDisabled();
+  });
+
+  test("Response success", async ({ page }) => {
+    // Mock the API call
+    await page.route(
+      `${STELLAR_EXPERT_API}/testnet/contract/${MOCK_CONTRACT_ID}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(MOCK_RESPONSE_SUCCESS),
+        });
+      },
+    );
+
+    const contractIdInput = page.getByLabel("Contract ID");
+
+    // Input validation
+    await contractIdInput.fill("aaa");
+    await expect(
+      page.getByText("The string must start with 'C'."),
+    ).toBeVisible();
+
+    // Valid input
+    await contractIdInput.fill(MOCK_CONTRACT_ID);
+    await expect(
+      page.getByText("The string must start with 'C'."),
+    ).toBeHidden();
+
+    // Fetch info
+    const loadButton = page.getByRole("button", { name: "Load contract" });
+
+    await expect(loadButton).toBeEnabled();
+    await loadButton.click();
+
+    // Show info
+    await expect(
+      page.getByText("Contract Info", { exact: true }),
+    ).toHaveAttribute("data-is-active", "true");
+
+    const contractInfoContainer = page.getByTestId("contract-info-container");
+
+    const getInfoItem = (label: string) => {
+      return contractInfoContainer.getByText(label).locator("+ div");
+    };
+
+    await expect(getInfoItem("Source Code")).toHaveText("test-org/test-repo");
+    await expect(getInfoItem("Created")).toHaveText(
+      "Tue, Nov 12, 2024, 09:12:56 UTC",
+    );
+    await expect(getInfoItem("WASM Hash")).toHaveText(
+      "df88820e231ad8f3027871e5dd3cf45491d7b7735e785731466bfc2946008608",
+    );
+    await expect(getInfoItem("Versions")).toHaveText("-");
+    await expect(getInfoItem("Creator")).toHaveText(SAVED_ACCOUNT_1);
+    await expect(getInfoItem("Data Storage")).toHaveText("10 entries");
+
+    // Clear
+    await page.getByRole("button", { name: "Clear", exact: true }).click();
+    await expect(contractIdInput).toHaveValue("");
+    await expect(loadButton).toBeDisabled();
+    await expect(contractInfoContainer).toBeHidden();
+  });
+
+  test("Response error", async ({ page }) => {
+    // Mock the API call
+    await page.route(
+      `${STELLAR_EXPERT_API}/testnet/contract/${MOCK_CONTRACT_ID}`,
+      async (route) => {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify(MOCK_RESPONSE_ERROR),
+        });
+      },
+    );
+
+    // Input
+    await page.getByLabel("Contract ID").fill(MOCK_CONTRACT_ID);
+    const loadButton = page.getByRole("button", { name: "Load contract" });
+
+    await expect(loadButton).toBeEnabled();
+    await loadButton.click();
+
+    await expect(
+      page.getByText(
+        "Something went wrong. Not found. Contract was not found on the ledger. Check if you specified contract address correctly.",
+      ),
+    ).toBeVisible();
+  });
+});
+
+// =============================================================================
+// Mock data
+// =============================================================================
+const MOCK_CONTRACT_ID =
+  "CBP7NO6F7FRDHSOFQBT2L2UWYIZ2PU76JKVRYAQTG3KZSQLYAOKIF2WB";
+const MOCK_RESPONSE_SUCCESS = {
+  contract: MOCK_CONTRACT_ID,
+  account: MOCK_CONTRACT_ID,
+  created: 1731402776,
+  creator: SAVED_ACCOUNT_1,
+  payments: 300,
+  trades: 0,
+  wasm: "df88820e231ad8f3027871e5dd3cf45491d7b7735e785731466bfc2946008608",
+  storage_entries: 10,
+  validation: {
+    status: "verified",
+    repository: "https://github.com/test-org/test-repo",
+    commit: "391f37e39a849ddf7543a5d7f1488e055811cb68",
+    ts: 1731402776,
+  },
+};
+const MOCK_RESPONSE_ERROR = {
+  error:
+    "Not found. Contract was not found on the ledger. Check if you specified contract address correctly.",
+  status: 404,
+};

--- a/tests/feeBumpPage.test.ts
+++ b/tests/feeBumpPage.test.ts
@@ -35,18 +35,15 @@ test.describe("Fee Bump Page", () => {
 
       await page.getByLabel("Base Fee").fill(BASE_FEE);
 
+      await expect(successCard).toBeVisible();
       await expect(
         successCard.getByText("Network Passphrase:").locator("+ div"),
       ).toHaveText("Test SDF Network ; September 2015");
       await expect(successCard.getByText("XDR:").locator("+ div")).toHaveText(
         MOCK_XDR,
       );
-    });
 
-    test("Clear", async ({ page }) => {
-      await page.getByLabel("Base Fee").fill(BASE_FEE);
-      await expect(successCard).toBeVisible();
-
+      // Clear
       await page.getByText("Clear and import new").click();
       await expect(successCard).toBeHidden();
     });
@@ -54,7 +51,8 @@ test.describe("Fee Bump Page", () => {
     test("Sign in Transaction Signer", async ({ page }) => {
       await page.getByLabel("Base Fee").fill(BASE_FEE);
 
-      const signButton = page.getByText("Sign in Transaction Signer", {
+      const signButton = page.getByRole("button", {
+        name: "Sign in Transaction Signer",
         exact: true,
       });
 
@@ -70,7 +68,10 @@ test.describe("Fee Bump Page", () => {
     test("View in XDR viewer", async ({ page }) => {
       await page.getByLabel("Base Fee").fill(BASE_FEE);
 
-      const viewButton = page.getByText("View in XDR viewer", { exact: true });
+      const viewButton = page.getByRole("button", {
+        name: "View in XDR viewer",
+        exact: true,
+      });
 
       await expect(viewButton).toBeVisible();
       await viewButton.click();

--- a/tests/feeBumpPage.test.ts
+++ b/tests/feeBumpPage.test.ts
@@ -53,12 +53,15 @@ test.describe("Fee Bump Page", () => {
 
     test("Sign in Transaction Signer", async ({ page }) => {
       await page.getByLabel("Base Fee").fill(BASE_FEE);
-      await page.getByText("Sign in Transaction Signer").click();
 
-      // Adding extra delay because sometimes it takes longer to load the next page
-      await expect(page.locator("h1")).toHaveText("Transaction Overview", {
-        timeout: 5000,
+      const signButton = page.getByText("Sign in Transaction Signer", {
+        exact: true,
       });
+
+      await expect(signButton).toBeVisible();
+      await signButton.click();
+
+      await expect(page.locator("h1")).toHaveText("Transaction Overview");
       await expect(page.getByLabel("Transaction Envelope XDR")).toHaveText(
         MOCK_XDR,
       );
@@ -66,12 +69,13 @@ test.describe("Fee Bump Page", () => {
 
     test("View in XDR viewer", async ({ page }) => {
       await page.getByLabel("Base Fee").fill(BASE_FEE);
-      await page.getByText("View in XDR Viewer").click();
 
-      // Adding extra delay because sometimes it takes longer to load the next page
-      await expect(page.locator("h1")).toHaveText("View XDR", {
-        timeout: 5000,
-      });
+      const viewButton = page.getByText("View in XDR viewer", { exact: true });
+
+      await expect(viewButton).toBeVisible();
+      await viewButton.click();
+
+      await expect(page.locator("h1")).toHaveText("View XDR");
       await expect(page.getByLabel("Base-64 encoded XDR")).toHaveText(MOCK_XDR);
     });
   });

--- a/tests/feeBumpPage.test.ts
+++ b/tests/feeBumpPage.test.ts
@@ -55,7 +55,10 @@ test.describe("Fee Bump Page", () => {
       await page.getByLabel("Base Fee").fill(BASE_FEE);
       await page.getByText("Sign in Transaction Signer").click();
 
-      await expect(page.locator("h1")).toHaveText("Transaction Overview");
+      // Adding extra delay because sometimes it takes longer to load the next page
+      await expect(page.locator("h1")).toHaveText("Transaction Overview", {
+        timeout: 5000,
+      });
       await expect(page.getByLabel("Transaction Envelope XDR")).toHaveText(
         MOCK_XDR,
       );
@@ -65,7 +68,10 @@ test.describe("Fee Bump Page", () => {
       await page.getByLabel("Base Fee").fill(BASE_FEE);
       await page.getByText("View in XDR Viewer").click();
 
-      await expect(page.locator("h1")).toHaveText("View XDR");
+      // Adding extra delay because sometimes it takes longer to load the next page
+      await expect(page.locator("h1")).toHaveText("View XDR", {
+        timeout: 5000,
+      });
       await expect(page.getByLabel("Base-64 encoded XDR")).toHaveText(MOCK_XDR);
     });
   });

--- a/tests/submitTransactionPage.test.ts
+++ b/tests/submitTransactionPage.test.ts
@@ -1,3 +1,4 @@
+import { STELLAR_EXPERT } from "@/constants/settings";
 import { test, expect, Page } from "@playwright/test";
 
 test.describe("Submit Transaction Page", () => {
@@ -493,7 +494,7 @@ const testBlockExplorerLink = async ({
 
   // Assert the StellarExpert URL
   expect(newTabUrl).toBe(
-    `https://stellar.expert/explorer/${network?.toLowerCase()}/tx/${hash}`,
+    `${STELLAR_EXPERT}/${network?.toLowerCase()}/tx/${hash}`,
   );
 
   const [stellarChainPage] = await Promise.all([


### PR DESCRIPTION
- Smart Contracts page and main navigation link
- Contract Info section
- Top header: add another breakpoint for resizing
- Created `SwitchNetworkButtons` component to be used where we have buttons to switch the network
- Also created `MessageField` component
- Updated Fee Bump test to make it less flaky (it was failing for me locally once in a while)

You can use `CBP7NO6F7FRDHSOFQBT2L2UWYIZ2PU76JKVRYAQTG3KZSQLYAOKIF2WB` contract ID to test the response on Mainnet.

<details>
<summary>Screenshots</summary>
<hr />

![image](https://github.com/user-attachments/assets/d7aef278-8d30-4e42-bdf0-cd827c054c55)

![image](https://github.com/user-attachments/assets/88e83f6f-c204-4741-9047-eeb06f6fd314)

![image](https://github.com/user-attachments/assets/104fccd5-26b3-497d-8335-be15b7438658)
</details>

