### PR TITLE
[Build Tx] Add a Soroban Operation - Extend TTL

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -886,6 +886,7 @@ export const Operations = () => {
           <option value="end_sponsoring_future_reserves">
             End Sponsoring Future Reserves
           </option>
+          <option value="restore_footprint">Restore Footprint</option>
           <option value="revoke_sponsorship">Revoke Sponsorship</option>
           <option value="clawback">Clawback</option>
           <option value="clawback_claimable_balance">
@@ -1187,6 +1188,7 @@ export const Operations = () => {
               <Button
                 size="md"
                 variant="tertiary"
+                disabled={true}
                 icon={<Icon.PlusCircle />}
                 onClick={() => {
                   updateOptionParamAndError({

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -1098,6 +1098,20 @@ export const Operations = () => {
                   operationType={sorobanOperation.operation_type}
                 />
 
+                <>
+                  {!network.rpcUrl ? (
+                    <Box gap="sm" direction="row" align="center">
+                      <Notification
+                        variant="error"
+                        title="Network Configuration Required"
+                      >
+                        An RPC URL must be configured in the network settings to
+                        proceed with a Soroban operation.
+                      </Notification>
+                    </Box>
+                  ) : null}
+                </>
+
                 {/* Operation params */}
                 <>
                   {TRANSACTION_OPERATIONS[
@@ -1121,6 +1135,7 @@ export const Operations = () => {
                         TRANSACTION_OPERATIONS[
                           sorobanOperation.operation_type
                         ].requiredParams.includes(input),
+                      isDisabled: Boolean(!network.rpcUrl),
                     };
 
                     if (component) {
@@ -1217,11 +1232,11 @@ export const Operations = () => {
           type="save"
           itemTitle="Transaction"
           itemProps={{
-            xdr: txnXdr,
+            xdr: sorobanTxnXdr,
             page: "build",
             shareableUrl: shareableUrl("transactions-build"),
             params: transaction.build.params,
-            operations: transaction.build.operations,
+            operations: [transaction.build.soroban.operation],
           }}
           allSavedItems={localStorageSavedTransactions.get()}
           isVisible={isSaveTxnModalVisible}

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -27,7 +27,10 @@ import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransa
 import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
 import { OP_SET_TRUST_LINE_FLAGS } from "@/constants/settings";
-import { TRANSACTION_OPERATIONS } from "@/constants/transactionOperations";
+import {
+  TRANSACTION_OPERATIONS,
+  INITIAL_OPERATION,
+} from "@/constants/transactionOperations";
 import { useStore } from "@/store/useStore";
 import {
   AnyObject,
@@ -38,12 +41,11 @@ import {
   OpBuildingError,
   OptionSigner,
   RevokeSponsorshipValue,
-  TxnOperation,
 } from "@/types/types";
 
 export const Operations = () => {
   const { transaction, network } = useStore();
-  const { operations: txnOperations, xdr: txnXdr, soroban } = transaction.build;
+  const { classic, soroban } = transaction.build;
   const {
     // Classic
     updateBuildOperations,
@@ -55,11 +57,10 @@ export const Operations = () => {
     setBuildOperationsError,
   } = transaction;
 
-  const {
-    // Soroban
-    operation: sorobanOperation,
-    xdr: sorobanTxnXdr,
-  } = soroban;
+  // Classic Operations
+  const { operations: txnOperations, xdr: txnXdr } = classic;
+  // Soroban Operation
+  const { operation: sorobanOperation, xdr: sorobanTxnXdr } = soroban;
 
   // Types
   type OperationError = {
@@ -71,11 +72,6 @@ export const Operations = () => {
 
   const [operationsError, setOperationsError] = useState<OperationError[]>([]);
   const [isSaveTxnModalVisible, setIsSaveTxnModalVisible] = useState(false);
-
-  const INITIAL_OPERATION: TxnOperation = {
-    operation_type: "",
-    params: [],
-  };
 
   const EMPTY_OPERATION_ERROR: OperationError = {
     operationType: "",
@@ -1576,7 +1572,7 @@ export const Operations = () => {
           page: "build",
           shareableUrl: shareableUrl("transactions-build"),
           params: transaction.build.params,
-          operations: transaction.build.operations,
+          operations: transaction.build.classic.operations,
         }}
         allSavedItems={localStorageSavedTransactions.get()}
         isVisible={isSaveTxnModalVisible}

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -1073,7 +1073,7 @@ export const Operations = () => {
                 key={`op`}
                 gap="lg"
                 addlClassName="PageBody__content"
-                data-testid={`build-soroban-transaction-operation`}
+                data-testid="build-soroban-transaction-operation"
               >
                 {/* Operation label and action buttons */}
                 <Box
@@ -1213,6 +1213,7 @@ export const Operations = () => {
                 variant="error"
                 icon={<Icon.RefreshCw01 />}
                 onClick={() => {
+                  updateOptionParamAndError({ type: "reset" });
                   updateSorobanBuildOperation(INITIAL_OPERATION);
                 }}
               >

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -24,6 +24,7 @@ import { sanitizeObject } from "@/helpers/sanitizeObject";
 import { shareableUrl } from "@/helpers/shareableUrl";
 import { getClaimableBalanceIdFromXdr } from "@/helpers/getClaimableBalanceIdFromXdr";
 import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
+import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
 import { OP_SET_TRUST_LINE_FLAGS } from "@/constants/settings";
 import { TRANSACTION_OPERATIONS } from "@/constants/transactionOperations";
@@ -924,13 +925,6 @@ export const Operations = () => {
               TRANSACTION_OPERATIONS[e.target.value]?.defaultParams || {};
             const defaultParamKeys = Object.keys(defaultParams);
 
-            const isSorobanOperationType = (operationType: string) => {
-              return [
-                "extend_footprint_ttl",
-                "restore_footprint",
-                "invoke_host_function",
-              ].includes(operationType);
-            };
             if (isSorobanOperationType(e.target.value)) {
               updateSorobanBuildOperation({
                 operation_type: e.target.value,

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -153,7 +153,7 @@ export const Operations = () => {
   // Preserve values and validate inputs when components mounts
   useEffect(() => {
     // If no operations to preserve, add inital operation and error template
-    if (txnOperations.length === 0) {
+    if (txnOperations.length === 0 && !soroban.operation.operation_type) {
       updateOptionParamAndError({ type: "add", item: INITIAL_OPERATION });
     } else {
       // Validate all params in all operations
@@ -799,6 +799,10 @@ export const Operations = () => {
   };
 
   const renderSourceAccount = (opType: string, index: number) => {
+    const currentOperation = isSorobanOperationType(opType)
+      ? sorobanOperation
+      : txnOperations[index];
+
     const sourceAccountComponent = formComponentTemplateTxnOps({
       param: "source_account",
       opType,
@@ -807,7 +811,7 @@ export const Operations = () => {
 
     return opType && sourceAccountComponent
       ? sourceAccountComponent.render({
-          value: txnOperations[index].source_account,
+          value: currentOperation.source_account,
           error: operationsError[index]?.error?.["source_account"],
           isRequired: false,
           onChange: (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -872,6 +872,9 @@ export const Operations = () => {
         >
           <option value="">Select operation type</option>
           <option value="create_account">Create Account</option>
+          <option value="extend_footprint_ttl">
+            Extend Footprint TTL (Soroban)
+          </option>
           <option value="payment">Payment</option>
           <option value="path_payment_strict_send">
             Path Payment Strict Send
@@ -1216,8 +1219,6 @@ export const Operations = () => {
                     type: "add",
                     item: INITIAL_OPERATION,
                   });
-
-                  // todo: soroban operation
                 }}
               >
                 Add Operation

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -60,6 +60,7 @@ export const Operations = () => {
 
   const [operationsError, setOperationsError] = useState<OperationError[]>([]);
   const [isSaveTxnModalVisible, setIsSaveTxnModalVisible] = useState(false);
+  const [isSorobanOperation, setIsSorobanOperation] = useState(false);
 
   const INITIAL_OPERATION: TxnOperation = {
     operation_type: "",
@@ -217,6 +218,14 @@ export const Operations = () => {
     // Not including getOperationsError()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [txnOperations, operationsError, setBuildOperationsError]);
+
+  useEffect(() => {
+    const isSorobanOp = txnOperations.some((op) =>
+      op.operation_type.includes("restore_footprint"),
+    );
+
+    setIsSorobanOperation(isSorobanOp);
+  }, [txnOperations]);
 
   const missingSelectedAssetFields = (
     param: string,
@@ -784,6 +793,13 @@ export const Operations = () => {
     return null;
   };
 
+  const renderSorobanNote = () => (
+    <Notification variant="warning" title="Only One Operation Allowed">
+      Note that Soroban transactions can only contain one operation per
+      transaction.
+    </Notification>
+  );
+
   const OperationTypeSelector = ({
     index,
     operationType,
@@ -886,7 +902,7 @@ export const Operations = () => {
           <option value="end_sponsoring_future_reserves">
             End Sponsoring Future Reserves
           </option>
-          <option value="restore_footprint">Restore Footprint</option>
+          <option value="restore_footprint">Restore Footprint (Soroban)</option>
           <option value="revoke_sponsorship">Revoke Sponsorship</option>
           <option value="clawback">Clawback</option>
           <option value="clawback_claimable_balance">
@@ -1176,6 +1192,10 @@ export const Operations = () => {
             ))}
           </>
 
+          <Box gap="sm" direction="row" align="center">
+            {isSorobanOperation ? renderSorobanNote() : null}
+          </Box>
+
           {/* Operations bottom buttons */}
           <Box
             gap="lg"
@@ -1188,13 +1208,16 @@ export const Operations = () => {
               <Button
                 size="md"
                 variant="tertiary"
-                disabled={true}
+                disabled={isSorobanOperation}
                 icon={<Icon.PlusCircle />}
                 onClick={() => {
+                  // classic operation
                   updateOptionParamAndError({
                     type: "add",
                     item: INITIAL_OPERATION,
                   });
+
+                  // todo: soroban operation
                 }}
               >
                 Add Operation

--- a/src/app/(sidebar)/transaction/build/components/SorobanTransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanTransactionXdr.tsx
@@ -50,7 +50,7 @@ export const SorobanTransactionXdr = () => {
         const builtXdr = buildSorobanTx({
           sorobanData,
           params: txnParams,
-          sorobanParams: operation.params,
+          sorobanOp: operation,
           networkPassphrase: network.passphrase,
         });
 

--- a/src/app/(sidebar)/transaction/build/components/SorobanTransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanTransactionXdr.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useStore } from "@/store/useStore";
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { useRouter } from "next/navigation";
+import { Button } from "@stellar/design-system";
+
+import {
+  buildSorobanData,
+  buildSorobanTx,
+  getContractDataXDR,
+} from "@/helpers/sorobanUtils";
+
+import { Routes } from "@/constants/routes";
+
+import { SdsLink } from "@/components/SdsLink";
+import { ValidationResponseCard } from "@/components/ValidationResponseCard";
+import { Box } from "@/components/layout/Box";
+import { ViewInXdrButton } from "@/components/ViewInXdrButton";
+
+export const SorobanTransactionXdr = () => {
+  const { network, transaction } = useStore();
+  const { updateSignActiveView, updateSignImportXdr } = transaction;
+  const { soroban, isValid, params: txnParams } = transaction.build;
+  const { operation } = soroban;
+  const router = useRouter();
+
+  const sorobanTxData = () => {
+    try {
+      if (!isValid.operations || !isValid.params) {
+        return "";
+      }
+
+      let sorobanData;
+
+      const operationtype = operation.operation_type;
+
+      const contractDataXDR = getContractDataXDR({
+        contractAddress: operation.params.contract,
+        dataKey: operation.params.key_xdr,
+        durability: operation.params.durability,
+      });
+
+      switch (operationtype) {
+        case "extend_footprint_ttl":
+          sorobanData = buildSorobanData({
+            readOnlyXdrLedgerKey: [contractDataXDR],
+            resourceFee: operation.params.resource_fee,
+          });
+      }
+
+      if (sorobanData) {
+        const builtXdr = buildSorobanTx({
+          sorobanData,
+          params: txnParams,
+          sorobanParams: operation.params,
+          networkPassphrase: network.passphrase,
+        });
+        return builtXdr.toXDR();
+      }
+      return "";
+    } catch (e) {
+      console.log("error: ", e);
+      return "";
+    }
+  };
+
+  const sorobanData = sorobanTxData();
+
+  if (sorobanData) {
+    try {
+      const txnHash = TransactionBuilder.fromXDR(
+        sorobanData,
+        network.passphrase,
+      )
+        .hash()
+        .toString("hex");
+
+      return (
+        <ValidationResponseCard
+          variant="success"
+          title="Success! Transaction Envelope XDR:"
+          response={
+            <Box gap="xs" data-testid="build-transaction-envelope-xdr">
+              <div>
+                <div>Network Passphrase:</div>
+                <div>{network.passphrase}</div>
+              </div>
+              <div>
+                <div>Hash:</div>
+                <div>{txnHash}</div>
+              </div>
+              <div>
+                <div>XDR:</div>
+                <div>{sorobanData}</div>
+              </div>
+            </Box>
+          }
+          note={
+            <>
+              In order for the transaction to make it into the ledger, a
+              transaction must be successfully signed and submitted to the
+              network. The Lab provides the{" "}
+              <SdsLink href={Routes.SIGN_TRANSACTION}>
+                Transaction Signer
+              </SdsLink>{" "}
+              for signing a transaction, and the{" "}
+              <SdsLink href={Routes.SUBMIT_TRANSACTION}>
+                Post Transaction endpoint
+              </SdsLink>{" "}
+              for submitting one to the network.
+            </>
+          }
+          footerLeftEl={
+            <>
+              <Button
+                size="md"
+                variant="secondary"
+                onClick={() => {
+                  updateSignImportXdr(sorobanData);
+                  updateSignActiveView("overview");
+
+                  router.push(Routes.SIGN_TRANSACTION);
+                }}
+              >
+                Sign in Transaction Signer
+              </Button>
+
+              <ViewInXdrButton xdrBlob={sorobanData} />
+            </>
+          }
+        />
+      );
+    } catch (e: any) {
+      return (
+        <ValidationResponseCard
+          variant="error"
+          title="Transaction Error:"
+          response={e.toString()}
+        />
+      );
+    }
+  }
+
+  return null;
+};

--- a/src/app/(sidebar)/transaction/build/components/SorobanTransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanTransactionXdr.tsx
@@ -83,7 +83,7 @@ export const SorobanTransactionXdr = () => {
           variant="success"
           title="Success! Transaction Envelope XDR:"
           response={
-            <Box gap="xs" data-testid="build-transaction-envelope-xdr">
+            <Box gap="xs" data-testid="build-soroban-transaction-envelope-xdr">
               <div>
                 <div>Network Passphrase:</div>
                 <div>{network.passphrase}</div>

--- a/src/app/(sidebar)/transaction/build/components/TransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/TransactionXdr.tsx
@@ -45,13 +45,10 @@ const MAX_INT64 = "9223372036854775807";
 export const TransactionXdr = () => {
   const { transaction, network } = useStore();
   const router = useRouter();
-  const {
-    params: txnParams,
-    operations: txnOperations,
-    isValid,
-  } = transaction.build;
+  const { classic, params: txnParams, isValid } = transaction.build;
   const { updateSignActiveView, updateSignImportXdr, updateBuildXdr } =
     transaction;
+  const { operations: txnOperations } = classic;
 
   const isXdrInit = useIsXdrInit();
 

--- a/src/app/(sidebar)/transaction/build/components/TransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/TransactionXdr.tsx
@@ -72,6 +72,7 @@ export const TransactionXdr = () => {
     try {
       // TODO: remove this formatter once Stellar XDR supports strings for numbers.
       // Format values to meet XDR requirements
+      console.log("txnParams: ", txnParams);
       const prepTxnParams = Object.entries(txnParams).reduce((res, param) => {
         const key = param[0] as KeysOfUnion<typeof txnParams>;
         // Casting to any type for simplicity
@@ -490,6 +491,9 @@ export const TransactionXdr = () => {
         body: renderTxnBody(op),
       }));
 
+      console.log("prepTxnParams: ", prepTxnParams);
+      console.log("prepTxnOps: ", prepTxnOps);
+
       const txnJson = {
         tx: {
           tx: {
@@ -522,6 +526,8 @@ export const TransactionXdr = () => {
   };
 
   const txnXdr = txnJsonToXdr();
+
+  console.log("txnXdr :", txnXdr);
 
   if (txnXdr.error) {
     return (

--- a/src/app/(sidebar)/transaction/build/components/TransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/TransactionXdr.tsx
@@ -72,7 +72,7 @@ export const TransactionXdr = () => {
     try {
       // TODO: remove this formatter once Stellar XDR supports strings for numbers.
       // Format values to meet XDR requirements
-      console.log("txnParams: ", txnParams);
+
       const prepTxnParams = Object.entries(txnParams).reduce((res, param) => {
         const key = param[0] as KeysOfUnion<typeof txnParams>;
         // Casting to any type for simplicity
@@ -491,9 +491,6 @@ export const TransactionXdr = () => {
         body: renderTxnBody(op),
       }));
 
-      console.log("prepTxnParams: ", prepTxnParams);
-      console.log("prepTxnOps: ", prepTxnOps);
-
       const txnJson = {
         tx: {
           tx: {
@@ -526,8 +523,6 @@ export const TransactionXdr = () => {
   };
 
   const txnXdr = txnJsonToXdr();
-
-  console.log("txnXdr :", txnXdr);
 
   if (txnXdr.error) {
     return (

--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -9,11 +9,18 @@ import { ValidationResponseCard } from "@/components/ValidationResponseCard";
 import { Params } from "./components/Params";
 import { Operations } from "./components/Operations";
 import { TransactionXdr } from "./components/TransactionXdr";
+import { SorobanTransactionXdr } from "./components/SorobanTransactionXdr";
 
 export default function BuildTransaction() {
   const { transaction } = useStore();
+
+  // For Classic
   const { params: paramsError, operations: operationsError } =
     transaction.build.error;
+
+  // For Soroban
+  const { soroban } = transaction.build;
+  const IS_SOROBAN_TX = Boolean(soroban.operation.operation_type);
 
   const renderError = () => {
     if (paramsError.length > 0 || operationsError.length > 0) {
@@ -80,7 +87,7 @@ export default function BuildTransaction() {
 
       <>{renderError()}</>
 
-      <TransactionXdr />
+      {IS_SOROBAN_TX ? <SorobanTransactionXdr /> : <TransactionXdr />}
     </Box>
   );
 }

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -22,16 +22,7 @@ import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransa
 import { arrayItem } from "@/helpers/arrayItem";
 import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
-import {
-  SavedTransaction,
-  SavedTransactionPage,
-  TxnOperation,
-} from "@/types/types";
-
-const INITIAL_OPERATION: TxnOperation = {
-  operation_type: "",
-  params: [],
-};
+import { SavedTransaction, SavedTransactionPage } from "@/types/types";
 
 export default function SavedTransactions() {
   const { network, transaction, xdr } = useStore();

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -107,89 +107,87 @@ export default function SavedTransactions() {
     }
   };
 
-  const SavedTxn = ({ txn }: { txn: SavedTransaction }) => {
-    return (
-      <Box
-        gap="sm"
-        addlClassName="PageBody__content"
-        data-testid="saved-transactions-item"
-      >
-        <Input
-          id={`saved-txn-${txn.timestamp}`}
-          data-testid="saved-transactions-name"
-          fieldSize="md"
-          value={txn.name}
-          readOnly
-          rightElement={
-            <InputSideElement
-              variant="button"
-              placement="right"
-              onClick={() => {
-                setCurrentTxnTimestamp(txn.timestamp);
-              }}
-              icon={<Icon.Edit05 />}
-              data-testid="saved-transactions-edit"
-            />
-          }
-        />
+  const SavedTxn = ({ txn }: { txn: SavedTransaction }) => (
+    <Box
+      gap="sm"
+      addlClassName="PageBody__content"
+      data-testid="saved-transactions-item"
+    >
+      <Input
+        id={`saved-txn-${txn.timestamp}`}
+        data-testid="saved-transactions-name"
+        fieldSize="md"
+        value={txn.name}
+        readOnly
+        rightElement={
+          <InputSideElement
+            variant="button"
+            placement="right"
+            onClick={() => {
+              setCurrentTxnTimestamp(txn.timestamp);
+            }}
+            icon={<Icon.Edit05 />}
+            data-testid="saved-transactions-edit"
+          />
+        }
+      />
 
-        <>
-          {!txn.operations || txn.operations.length === 0
-            ? null
-            : txn.operations.map((o, idx) => (
-                <Input
-                  key={`saved-txn-${txn.timestamp}-op-${idx}`}
-                  id={`saved-txn-${txn.timestamp}-op-${idx}`}
-                  data-testid="saved-transactions-op"
-                  fieldSize="md"
-                  value={
-                    TRANSACTION_OPERATIONS[o.operation_type]?.label ||
-                    "Operation type not selected"
-                  }
-                  readOnly
-                  leftElement={idx + 1}
-                />
-              ))}
-        </>
-
-        <Box
-          gap="lg"
-          direction="row"
-          align="center"
-          justify="space-between"
-          addlClassName="Endpoints__urlBar__footer"
-        >
-          <Box gap="sm" direction="row">
-            <>
-              {renderActionButton(txn.timestamp, txn.page)}
-              {txn.shareableUrl ? (
-                <ShareUrlButton shareableUrl={txn.shareableUrl} />
-              ) : null}
-            </>
-          </Box>
-
-          <Box gap="sm" direction="row" align="center" justify="end">
-            <SavedItemTimestampAndDelete
-              timestamp={txn.timestamp}
-              onDelete={() => {
-                const allTxns = localStorageSavedTransactions.get();
-                const indexToUpdate = allTxns.findIndex(
-                  (t) => t.timestamp === txn.timestamp,
-                );
-
-                if (indexToUpdate >= 0) {
-                  const updatedList = arrayItem.delete(allTxns, indexToUpdate);
-
-                  localStorageSavedTransactions.set(updatedList);
-                  updateSavedTxns();
+      <>
+        {!txn.operations || txn.operations.length === 0
+          ? null
+          : txn.operations.map((o, idx) => (
+              <Input
+                key={`saved-txn-${txn.timestamp}-op-${idx}`}
+                id={`saved-txn-${txn.timestamp}-op-${idx}`}
+                data-testid="saved-transactions-op"
+                fieldSize="md"
+                value={
+                  TRANSACTION_OPERATIONS[o.operation_type]?.label ||
+                  "Operation type not selected"
                 }
-              }}
-            />
-          </Box>
+                readOnly
+                leftElement={idx + 1}
+              />
+            ))}
+      </>
+
+      <Box
+        gap="lg"
+        direction="row"
+        align="center"
+        justify="space-between"
+        addlClassName="Endpoints__urlBar__footer"
+      >
+        <Box gap="sm" direction="row">
+          <>
+            {renderActionButton(txn.timestamp, txn.page)}
+            {txn.shareableUrl ? (
+              <ShareUrlButton shareableUrl={txn.shareableUrl} />
+            ) : null}
+          </>
+        </Box>
+
+        <Box gap="sm" direction="row" align="center" justify="end">
+          <SavedItemTimestampAndDelete
+            timestamp={txn.timestamp}
+            onDelete={() => {
+              const allTxns = localStorageSavedTransactions.get();
+              const indexToUpdate = allTxns.findIndex(
+                (t) => t.timestamp === txn.timestamp,
+              );
+
+              if (indexToUpdate >= 0) {
+                const updatedList = arrayItem.delete(allTxns, indexToUpdate);
+
+                localStorageSavedTransactions.set(updatedList);
+                updateSavedTxns();
+              }
+            }}
+          />
         </Box>
       </Box>
-    );
-  };
+    </Box>
+  );
 
   return (
     <Box gap="md" data-testid="saved-transactions-container">

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -66,6 +66,7 @@ export default function SavedTransactions() {
         if (isSorobanTx) {
           transaction.updateSorobanBuildOperation(found.operations[0]);
         } else {
+          transaction.resetSorobanBuildOperation();
           transaction.updateBuildOperations(found.operations);
         }
       }

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -13,7 +13,10 @@ import { SavedItemTimestampAndDelete } from "@/components/SavedItemTimestampAndD
 import { PageCard } from "@/components/layout/PageCard";
 import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
 
-import { TRANSACTION_OPERATIONS } from "@/constants/transactionOperations";
+import {
+  TRANSACTION_OPERATIONS,
+  INITIAL_OPERATION,
+} from "@/constants/transactionOperations";
 import { useStore } from "@/store/useStore";
 import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
 import { arrayItem } from "@/helpers/arrayItem";
@@ -55,6 +58,12 @@ export default function SavedTransactions() {
 
       router.push(Routes.BUILD_TRANSACTION);
 
+      // reset both the classic and soroban related states
+      transaction.updateBuildOperations([INITIAL_OPERATION]);
+      transaction.updateBuildXdr("");
+      transaction.updateSorobanBuildOperation(INITIAL_OPERATION);
+      transaction.updateSorobanBuildXdr("");
+
       if (found.params) {
         transaction.setBuildParams(found.params);
       }
@@ -64,9 +73,10 @@ export default function SavedTransactions() {
           found?.operations?.[0]?.operation_type,
         );
         if (isSorobanTx) {
+          // update the soroban operation
           transaction.updateSorobanBuildOperation(found.operations[0]);
         } else {
-          transaction.resetSorobanBuildOperation();
+          // reset the soroban operations
           transaction.updateBuildOperations(found.operations);
         }
       }

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -22,7 +22,16 @@ import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransa
 import { arrayItem } from "@/helpers/arrayItem";
 import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
-import { SavedTransaction, SavedTransactionPage } from "@/types/types";
+import {
+  SavedTransaction,
+  SavedTransactionPage,
+  TxnOperation,
+} from "@/types/types";
+
+const INITIAL_OPERATION: TxnOperation = {
+  operation_type: "",
+  params: [],
+};
 
 export default function SavedTransactions() {
   const { network, transaction, xdr } = useStore();
@@ -73,10 +82,12 @@ export default function SavedTransactions() {
           found?.operations?.[0]?.operation_type,
         );
         if (isSorobanTx) {
-          // update the soroban operation
+          // reset the classic operation
+          transaction.updateBuildOperations([INITIAL_OPERATION]);
           transaction.updateSorobanBuildOperation(found.operations[0]);
         } else {
-          // reset the soroban operations
+          // reset the soroban operation
+          transaction.updateSorobanBuildOperation(INITIAL_OPERATION);
           transaction.updateBuildOperations(found.operations);
         }
       }

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -17,6 +17,7 @@ import { TRANSACTION_OPERATIONS } from "@/constants/transactionOperations";
 import { useStore } from "@/store/useStore";
 import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
 import { arrayItem } from "@/helpers/arrayItem";
+import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
 import { SavedTransaction, SavedTransactionPage } from "@/types/types";
 
@@ -50,6 +51,8 @@ export default function SavedTransactions() {
     const found = findLocalStorageTx(timestamp);
 
     if (found) {
+      let isSorobanTx = false;
+
       router.push(Routes.BUILD_TRANSACTION);
 
       if (found.params) {
@@ -57,11 +60,22 @@ export default function SavedTransactions() {
       }
 
       if (found.operations) {
-        transaction.updateBuildOperations(found.operations);
+        isSorobanTx = isSorobanOperationType(
+          found?.operations?.[0]?.operation_type,
+        );
+        if (isSorobanTx) {
+          transaction.updateSorobanBuildOperation(found.operations[0]);
+        } else {
+          transaction.updateBuildOperations(found.operations);
+        }
       }
 
       if (found.xdr) {
-        transaction.updateBuildXdr(found.xdr);
+        if (isSorobanTx) {
+          transaction.updateSorobanBuildXdr(found.xdr);
+        } else {
+          transaction.updateBuildXdr(found.xdr);
+        }
       }
     }
   };

--- a/src/app/(sidebar)/transaction/submit/page.tsx
+++ b/src/app/(sidebar)/transaction/submit/page.tsx
@@ -70,7 +70,6 @@ const SUBMIT_OPTIONS = [
 // Define operation types for better type safety
 interface DecodedOperationBody {
   extend_footprint_ttl?: { ext: string };
-  restore_footprint?: { ext: string };
   invoke_host_function?: { ext: string };
 }
 

--- a/src/app/(sidebar)/transaction/submit/page.tsx
+++ b/src/app/(sidebar)/transaction/submit/page.tsx
@@ -93,11 +93,7 @@ const isSorobanXdr = (jsonString: string): boolean => {
         return false;
       }
 
-      const sorobanOps = [
-        body.extend_footprint_ttl,
-        body.restore_footprint,
-        body.invoke_host_function,
-      ];
+      const sorobanOps = [body.extend_footprint_ttl, body.invoke_host_function];
 
       return sorobanOps.some((op) => op?.ext === "v0");
     });

--- a/src/components/FormElements/ResourceFeePicker.tsx
+++ b/src/components/FormElements/ResourceFeePicker.tsx
@@ -102,9 +102,12 @@ export const ResourceFeePicker = ({
         builtXdr = buildSorobanTx({
           sorobanData,
           params: txnParams,
-          sorobanParams: {
-            ...operation.params,
-            resource_fee: BOGUS_RESOURCE_FEE,
+          sorobanOp: {
+            ...operation,
+            params: {
+              ...operation.params,
+              resource_fee: BOGUS_RESOURCE_FEE,
+            },
           },
           networkPassphrase: network.passphrase,
         }).toXDR();

--- a/src/components/FormElements/ResourceFeePicker.tsx
+++ b/src/components/FormElements/ResourceFeePicker.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import React, { useEffect } from "react";
+
+import { useSimulateTx } from "@/query/useSimulateTx";
+
+import { useStore } from "@/store/useStore";
+import { SorobanOpType } from "@/types/types";
+import { getNetworkHeaders } from "@/helpers/getNetworkHeaders";
+import {
+  buildSorobanTx,
+  getContractDataXDR,
+  getSorobanDataResult,
+} from "@/helpers/sorobanUtils";
+
+import { InputSideElement } from "@/components/InputSideElement";
+import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
+
+interface ResourceFeePickerProps {
+  id: string;
+  labelSuffix?: string | React.ReactNode;
+  label: string;
+  value: string;
+  placeholder?: string;
+  error: string | undefined;
+  note?: React.ReactNode;
+  infoLink?: string;
+  disabled?: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+// only for Soroban Operation
+// includes a simulate transaction to fetch the minimum resource fee
+export const ResourceFeePicker = ({
+  id,
+  labelSuffix,
+  label,
+  value,
+  error,
+  onChange,
+  placeholder,
+  note,
+  infoLink,
+  disabled,
+  ...props
+}: ResourceFeePickerProps) => {
+  const { network, transaction } = useStore();
+  const { params: txnParams, soroban, isValid } = transaction.build;
+  const { operation } = soroban;
+  const {
+    mutateAsync: simulateTx,
+    data: simulateTxData,
+    isPending: isSimulateTxPending,
+  } = useSimulateTx();
+
+  useEffect(() => {
+    if (simulateTxData?.result?.minResourceFee) {
+      const syntheticEvent = {
+        target: {
+          value: simulateTxData.result.minResourceFee.toString(),
+        },
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      onChange(syntheticEvent);
+    }
+  }, [simulateTxData?.result?.minResourceFee]);
+
+  // Create a sample transaction (txn) to simulate to get the min resource fee
+  const buildTxToSimulate = () => {
+    try {
+      // we don't check for operation.params.resource_fee here
+      // in case user doesn't have one and we still want to simulate
+      const isOperationValid = Boolean(
+        operation.params.contract &&
+          operation.params.key_xdr &&
+          operation.params.durability,
+      );
+
+      const BOGUS_RESOURCE_FEE = "100";
+
+      if (!isValid.params || !isOperationValid) {
+        return;
+      }
+
+      let sorobanData, builtXdr;
+
+      const contractDataXDR = getContractDataXDR({
+        contractAddress: operation.params.contract,
+        dataKey: operation.params.key_xdr,
+        durability: operation.params.durability,
+      });
+
+      if (contractDataXDR) {
+        sorobanData = getSorobanDataResult({
+          contractDataXDR,
+          operationType: operation.operation_type as SorobanOpType,
+          fee: BOGUS_RESOURCE_FEE, // simulate purpose only
+        });
+      }
+
+      if (sorobanData) {
+        builtXdr = buildSorobanTx({
+          sorobanData,
+          params: txnParams,
+          sorobanParams: {
+            ...operation.params,
+            resource_fee: BOGUS_RESOURCE_FEE,
+          },
+          networkPassphrase: network.passphrase,
+        }).toXDR();
+      }
+      return builtXdr;
+    } catch (e) {
+      return;
+    }
+  };
+
+  return (
+    <PositiveIntPicker
+      key={id}
+      id={id}
+      label={label}
+      placeholder={placeholder}
+      labelSuffix={labelSuffix}
+      value={value}
+      error={error}
+      onChange={onChange}
+      infoLink={infoLink}
+      note={note}
+      disabled={disabled}
+      rightElement={
+        <InputSideElement
+          variant="button"
+          onClick={async () => {
+            const sampleTxnXdr = buildTxToSimulate();
+
+            if (!sampleTxnXdr) {
+              return;
+            }
+
+            await simulateTx({
+              rpcUrl: network.rpcUrl,
+              transactionXdr: sampleTxnXdr,
+              headers: getNetworkHeaders(network, "rpc"),
+            });
+          }}
+          placement="right"
+          disabled={!network.rpcUrl}
+          isLoading={isSimulateTxPending}
+        >
+          Fetch minimum resource fee from RPC
+        </InputSideElement>
+      }
+      {...props}
+    />
+  );
+};

--- a/src/components/FormElements/ResourceFeePickerWithQuery.tsx
+++ b/src/components/FormElements/ResourceFeePickerWithQuery.tsx
@@ -10,13 +10,13 @@ import { getNetworkHeaders } from "@/helpers/getNetworkHeaders";
 import {
   buildSorobanTx,
   getContractDataXDR,
-  getSorobanDataResult,
+  getSorobanTxData,
 } from "@/helpers/sorobanUtils";
 
 import { InputSideElement } from "@/components/InputSideElement";
 import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
 
-interface ResourceFeePickerProps {
+interface ResourceFeePickerWithQueryProps {
   id: string;
   labelSuffix?: string | React.ReactNode;
   label: string;
@@ -29,9 +29,10 @@ interface ResourceFeePickerProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-// only for Soroban Operation
-// includes a simulate transaction to fetch the minimum resource fee
-export const ResourceFeePicker = ({
+// Used only for a Soroban operation
+// Includes a simulate transaction function to fetch
+// the minimum resource fee
+export const ResourceFeePickerWithQuery = ({
   id,
   labelSuffix,
   label,
@@ -43,7 +44,7 @@ export const ResourceFeePicker = ({
   infoLink,
   disabled,
   ...props
-}: ResourceFeePickerProps) => {
+}: ResourceFeePickerWithQueryProps) => {
   const { network, transaction } = useStore();
   const { params: txnParams, soroban, isValid } = transaction.build;
   const { operation } = soroban;
@@ -91,7 +92,7 @@ export const ResourceFeePicker = ({
       });
 
       if (contractDataXDR) {
-        sorobanData = getSorobanDataResult({
+        sorobanData = getSorobanTxData({
           contractDataXDR,
           operationType: operation.operation_type as SorobanOpType,
           fee: BOGUS_RESOURCE_FEE, // simulate purpose only
@@ -148,7 +149,8 @@ export const ResourceFeePicker = ({
             });
           }}
           placement="right"
-          disabled={!network.rpcUrl}
+          // if we can't build a txn to simulate, we can't fetch the min resource fee
+          disabled={!buildTxToSimulate()}
           isLoading={isSimulateTxPending}
         >
           Fetch minimum resource fee from RPC

--- a/src/components/FormElements/XdrLedgerKeyPicker.tsx
+++ b/src/components/FormElements/XdrLedgerKeyPicker.tsx
@@ -82,7 +82,7 @@ const ledgerKeyFields: {
   {
     id: "contract_data",
     label: "Contract Data",
-    templates: "contract,storageKey,durability",
+    templates: "contract,entryKey,durability",
   },
   {
     id: "contract_code",

--- a/src/components/FormElements/XdrLedgerKeyPicker.tsx
+++ b/src/components/FormElements/XdrLedgerKeyPicker.tsx
@@ -82,7 +82,7 @@ const ledgerKeyFields: {
   {
     id: "contract_data",
     label: "Contract Data",
-    templates: "contract,key,durability",
+    templates: "contract,storageKey,durability",
   },
   {
     id: "contract_code",

--- a/src/components/FormElements/XdrLedgerKeyPicker.tsx
+++ b/src/components/FormElements/XdrLedgerKeyPicker.tsx
@@ -82,7 +82,7 @@ const ledgerKeyFields: {
   {
     id: "contract_data",
     label: "Contract Data",
-    templates: "contract,entryKey,durability",
+    templates: "contract,key,durability",
   },
   {
     id: "contract_code",

--- a/src/components/formComponentTemplateEndpoints.tsx
+++ b/src/components/formComponentTemplateEndpoints.tsx
@@ -462,7 +462,7 @@ export const formComponentTemplateEndpoints = (
         validate: null,
       };
     // contract data key
-    case "storageKey":
+    case "entryKey":
       return {
         render: (templ: {
           value: string | undefined;
@@ -474,8 +474,8 @@ export const formComponentTemplateEndpoints = (
               fieldSize="md"
               key={id}
               id={id}
-              label="Key (Storage Key)"
-              placeholder='ex: {"string":"Counter"}'
+              label="Entry Key"
+              placeholder='ex: {"symbol":"Counter"}'
               // @TODO we should display an input for each value
               // hotfix: sanitizing value from backlashes and extra quotes
               value={

--- a/src/components/formComponentTemplateEndpoints.tsx
+++ b/src/components/formComponentTemplateEndpoints.tsx
@@ -462,32 +462,30 @@ export const formComponentTemplateEndpoints = (
         validate: null,
       };
     // contract data key
-    case "entryKey":
+    case "key":
       return {
         render: (templ: {
           value: string | undefined;
           error: string | undefined;
           onChange: (val: any) => void;
-        }) => {
-          return (
-            <Textarea
-              fieldSize="md"
-              key={id}
-              id={id}
-              label="Entry Key"
-              placeholder='ex: {"symbol":"Counter"}'
-              // @TODO we should display an input for each value
-              // hotfix: sanitizing value from backlashes and extra quotes
-              value={
-                JSON.stringify(templ.value)
-                  .replace(/\\/g, "")
-                  .replace(/^"+|"+$/g, "") || ""
-              }
-              error={templ.error}
-              onChange={templ.onChange}
-            />
-          );
-        },
+        }) => (
+          <Textarea
+            fieldSize="md"
+            key={id}
+            id={id}
+            label="Key"
+            placeholder="Ex: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9"
+            // @TODO we should display an input for each value
+            // hotfix: sanitizing value from backlashes and extra quotes
+            value={
+              JSON.stringify(templ.value)
+                .replace(/\\/g, "")
+                .replace(/^"+|"+$/g, "") || ""
+            }
+            error={templ.error}
+            onChange={templ.onChange}
+          />
+        ),
         validate: null,
       };
     case "ledger":

--- a/src/components/formComponentTemplateEndpoints.tsx
+++ b/src/components/formComponentTemplateEndpoints.tsx
@@ -264,7 +264,7 @@ export const formComponentTemplateEndpoints = (
           <TextPicker
             key={id}
             id={id}
-            label="Contract"
+            label="Contract ID"
             placeholder="Ex: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
             value={templ.value || ""}
             error={templ.error}
@@ -461,33 +461,33 @@ export const formComponentTemplateEndpoints = (
         ),
         validate: null,
       };
-    // contract key
-    case "key":
+    // contract data key
+    case "storageKey":
       return {
         render: (templ: {
           value: string | undefined;
           error: string | undefined;
           onChange: (val: any) => void;
-          disabled?: boolean;
-        }) => (
-          <Textarea
-            fieldSize="md"
-            key={id}
-            id={id}
-            label="Key"
-            placeholder="Ex: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9"
-            // @TODO we should display an input for each value
-            // hotfix: sanitizing value from backlashes and extra quotes
-            value={
-              JSON.stringify(templ.value)
-                .replace(/\\/g, "")
-                .replace(/^"+|"+$/g, "") || ""
-            }
-            error={templ.error}
-            onChange={templ.onChange}
-            disabled={templ.disabled}
-          />
-        ),
+        }) => {
+          return (
+            <Textarea
+              fieldSize="md"
+              key={id}
+              id={id}
+              label="Key (Storage Key)"
+              placeholder='ex: {"string":"Counter"}'
+              // @TODO we should display an input for each value
+              // hotfix: sanitizing value from backlashes and extra quotes
+              value={
+                JSON.stringify(templ.value)
+                  .replace(/\\/g, "")
+                  .replace(/^"+|"+$/g, "") || ""
+              }
+              error={templ.error}
+              onChange={templ.onChange}
+            />
+          );
+        },
         validate: null,
       };
     case "ledger":

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -366,7 +366,10 @@ export const formComponentTemplateTxnOps = ({
             {/* @todo also add a temporary but disabled 
             https://github.com/stellar/js-stellar-base/blob/master/src/generated/curr_generated.js#L1887-L1891 */}
             <option value="">Select a durability</option>
-            {[{ id: "persistent", label: "Persistent" }].map((f) => (
+            {[
+              { id: "persistent", label: "Persistent" },
+              { id: "temporary", label: "Temporary" },
+            ].map((f) => (
               <option key={f.id} value={f.id}>
                 {f.label}
               </option>
@@ -457,6 +460,31 @@ export const formComponentTemplateTxnOps = ({
           />
         ),
         validate: null,
+      };
+    case "resource_fee":
+      return {
+        render: (templ: TemplateRenderProps) => (
+          <PositiveIntPicker
+            id={id}
+            label="Resource Fee (in stroops)"
+            value={removeLeadingZeroes(templ.value || "")}
+            error={templ.error}
+            onChange={templ.onChange}
+            note={
+              <>
+                The best way to find the required resource fee for any smart
+                contract transaction is to use the{" "}
+                <SdsLink href="https://developers.stellar.org/docs/learn/encyclopedia/contract-development/contract-interactions/transaction-simulation">
+                  simulateTransaction endpoint
+                </SdsLink>{" "}
+                from the RPC, which enables you to send a preflight transaction
+                that will return the necessary resource values and resource fee.
+              </>
+            }
+            infoLink="https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering#resource-fee"
+          />
+        ),
+        validate: validate.getPositiveNumberError,
       };
     case "limit":
       return {

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -15,6 +15,7 @@ import { AuthorizePicker } from "@/components/FormElements/AuthorizePicker";
 import { NumberFractionPicker } from "@/components/FormElements/NumberFractionPicker";
 import { RevokeSponsorshipPicker } from "@/components/FormElements/RevokeSponsorshipPicker";
 import { ClaimantsPicker } from "@/components/FormElements/ClaimantsPicker";
+import { ResourceFeePicker } from "@/components/FormElements/ResourceFeePicker";
 
 import { removeLeadingZeroes } from "@/helpers/removeLeadingZeroes";
 
@@ -35,6 +36,15 @@ type TemplateRenderProps = {
   error: string | undefined;
   onChange: (val: any) => void;
   isRequired?: boolean;
+};
+
+// Types
+type SorobanTemplateRenderProps = {
+  value: string | undefined;
+  error: string | undefined;
+  onChange: (val: any) => void;
+  isRequired?: boolean;
+  isDisabled?: boolean;
 };
 
 type TemplateRenderAssetProps = {
@@ -278,6 +288,7 @@ export const formComponentTemplateTxnOps = ({
           value: string | undefined;
           error: string | undefined;
           onChange: (val: any) => void;
+          isDisabled?: boolean;
         }) => (
           <TextPicker
             key={id}
@@ -287,6 +298,7 @@ export const formComponentTemplateTxnOps = ({
             value={templ.value || ""}
             error={templ.error}
             onChange={templ.onChange}
+            disabled={templ.isDisabled}
           />
         ),
         validate: validate.getContractIdError,
@@ -352,6 +364,7 @@ export const formComponentTemplateTxnOps = ({
         render: (templ: {
           value: string | undefined;
           error: string | undefined;
+          isDisabled?: boolean;
           onChange: (val: any) => void;
         }) => (
           <Select
@@ -361,6 +374,7 @@ export const formComponentTemplateTxnOps = ({
             label="Durability"
             value={templ.value || ""}
             onChange={templ.onChange}
+            disabled={templ.isDisabled}
             note="Only persistent and instance entries can be restored."
           >
             {/* @todo also add a temporary but disabled 
@@ -380,7 +394,7 @@ export const formComponentTemplateTxnOps = ({
       };
     case "extend_ttl_to": {
       return {
-        render: (templ: TemplateRenderProps) => (
+        render: (templ: SorobanTemplateRenderProps) => (
           <PositiveIntPicker
             key={id}
             id={id}
@@ -389,6 +403,7 @@ export const formComponentTemplateTxnOps = ({
             value={templ.value || ""}
             error={templ.error}
             onChange={templ.onChange}
+            disabled={templ.isDisabled}
             note={custom?.note}
           />
         ),
@@ -445,7 +460,7 @@ export const formComponentTemplateTxnOps = ({
       };
     case "key_xdr":
       return {
-        render: (templ: TemplateRenderProps) => (
+        render: (templ: SorobanTemplateRenderProps) => (
           <TextPicker
             key={id}
             id={id}
@@ -455,6 +470,7 @@ export const formComponentTemplateTxnOps = ({
             value={templ.value || ""}
             error={templ.error}
             onChange={templ.onChange}
+            disabled={templ.isDisabled}
             // @TODO add a link of doc that describes how to convert ScVal to XDR
             // infoLink=""
           />
@@ -463,13 +479,14 @@ export const formComponentTemplateTxnOps = ({
       };
     case "resource_fee":
       return {
-        render: (templ: TemplateRenderProps) => (
-          <PositiveIntPicker
+        render: (templ: SorobanTemplateRenderProps) => (
+          <ResourceFeePicker
             id={id}
             label="Resource Fee (in stroops)"
             value={removeLeadingZeroes(templ.value || "")}
             error={templ.error}
             onChange={templ.onChange}
+            disabled={templ.isDisabled}
             note={
               <>
                 The best way to find the required resource fee for any smart

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -271,6 +271,25 @@ export const formComponentTemplateTxnOps = ({
         ),
         validate: null,
       };
+    case "contract":
+      return {
+        render: (templ: {
+          value: string | undefined;
+          error: string | undefined;
+          onChange: (val: any) => void;
+        }) => (
+          <TextPicker
+            key={id}
+            id={id}
+            label="Contract ID"
+            placeholder="Ex: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+            value={templ.value || ""}
+            error={templ.error}
+            onChange={templ.onChange}
+          />
+        ),
+        validate: validate.getContractIdError,
+      };
     case "data_name":
       return {
         render: (templ: TemplateRenderProps) => (
@@ -373,6 +392,23 @@ export const formComponentTemplateTxnOps = ({
             infoLink="https://developers.stellar.org/docs/learn/encyclopedia/inflation"
           />
         ),
+        validate: validate.getPublicKeyError,
+      };
+    case "key_xdr":
+      return {
+        render: (templ: TemplateRenderProps) => (
+          <TextPicker
+            key={id}
+            id={id}
+            label="(Storage) Key in ScVal XDR Type"
+            placeholder="Ex: AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAHkOSeQVxNP4zqcstl6AA+PwtKrnRwrp7+LGt4xqEnTC"
+            labelSuffix={!templ.isRequired ? "optional" : undefined}
+            value={templ.value || ""}
+            error={templ.error}
+            onChange={templ.onChange}
+          />
+        ),
+        // validate: validate.getXdrError,
         validate: validate.getPublicKeyError,
       };
     case "limit":

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -375,7 +375,7 @@ export const formComponentTemplateTxnOps = ({
             value={templ.value || ""}
             onChange={templ.onChange}
             disabled={templ.isDisabled}
-            note="Only persistent and instance entries can be restored."
+            note={custom?.note}
           >
             {/* @todo also add a temporary but disabled 
             https://github.com/stellar/js-stellar-base/blob/master/src/generated/curr_generated.js#L1887-L1891 */}

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -1,4 +1,5 @@
 import { JSX } from "react";
+import { Select } from "@stellar/design-system";
 
 import { Box } from "@/components/layout/Box";
 import { SdsLink } from "@/components/SdsLink";
@@ -346,6 +347,51 @@ export const formComponentTemplateTxnOps = ({
         ),
         validate: validate.getPublicKeyError,
       };
+    case "durability":
+      return {
+        render: (templ: {
+          value: string | undefined;
+          error: string | undefined;
+          onChange: (val: any) => void;
+        }) => (
+          <Select
+            key={id}
+            id={`${id}-type`}
+            fieldSize="md"
+            label="Durability"
+            value={templ.value || ""}
+            onChange={templ.onChange}
+            note="Only persistent and instance entries can be restored."
+          >
+            {/* @todo also add a temporary but disabled 
+            https://github.com/stellar/js-stellar-base/blob/master/src/generated/curr_generated.js#L1887-L1891 */}
+            <option value="">Select a durability</option>
+            {[{ id: "persistent", label: "Persistent" }].map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.label}
+              </option>
+            ))}
+          </Select>
+        ),
+        validate: null,
+      };
+    case "extend_ttl_to": {
+      return {
+        render: (templ: TemplateRenderProps) => (
+          <PositiveIntPicker
+            key={id}
+            id={id}
+            label={custom?.label || "Extend To"}
+            labelSuffix={!templ.isRequired ? "optional" : undefined}
+            value={templ.value || ""}
+            error={templ.error}
+            onChange={templ.onChange}
+            note={custom?.note}
+          />
+        ),
+        validate: validate.getPositiveIntError,
+      };
+    }
     case "from":
       return {
         render: (templ: TemplateRenderProps) => (
@@ -400,16 +446,17 @@ export const formComponentTemplateTxnOps = ({
           <TextPicker
             key={id}
             id={id}
-            label="(Storage) Key in ScVal XDR Type"
+            label="Key ScVal in XDR"
             placeholder="Ex: AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAHkOSeQVxNP4zqcstl6AA+PwtKrnRwrp7+LGt4xqEnTC"
             labelSuffix={!templ.isRequired ? "optional" : undefined}
             value={templ.value || ""}
             error={templ.error}
             onChange={templ.onChange}
+            // @TODO add a link of doc that describes how to convert ScVal to XDR
+            // infoLink=""
           />
         ),
-        // validate: validate.getXdrError,
-        validate: validate.getPublicKeyError,
+        validate: null,
       };
     case "limit":
       return {

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -15,7 +15,7 @@ import { AuthorizePicker } from "@/components/FormElements/AuthorizePicker";
 import { NumberFractionPicker } from "@/components/FormElements/NumberFractionPicker";
 import { RevokeSponsorshipPicker } from "@/components/FormElements/RevokeSponsorshipPicker";
 import { ClaimantsPicker } from "@/components/FormElements/ClaimantsPicker";
-import { ResourceFeePicker } from "@/components/FormElements/ResourceFeePicker";
+import { ResourceFeePickerWithQuery } from "@/components/FormElements/ResourceFeePickerWithQuery";
 
 import { removeLeadingZeroes } from "@/helpers/removeLeadingZeroes";
 
@@ -480,7 +480,7 @@ export const formComponentTemplateTxnOps = ({
     case "resource_fee":
       return {
         render: (templ: SorobanTemplateRenderProps) => (
-          <ResourceFeePicker
+          <ResourceFeePickerWithQuery
             id={id}
             label="Resource Fee (in stroops)"
             value={removeLeadingZeroes(templ.value || "")}

--- a/src/constants/transactionOperations.tsx
+++ b/src/constants/transactionOperations.tsx
@@ -338,10 +338,17 @@ export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {
       "https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#clawback",
     params: ["asset", "from", "amount"],
     requiredParams: ["asset", "from", "amount"],
+  },
+  restore_footprint: {
+    label: "Restore Footprint",
+    description:
+      "Make archived Soroban smart contract entries accessible again by restoring them.",
+    docsUrl:
+      "https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#restore-footprint",
+    params: ["contract", "key_xdr"],
+    requiredParams: ["contract", "key_xdr"],
     custom: {
-      asset: {
-        includeNative: false,
-      },
+      isSorobanTx: true,
     },
   },
   revoke_sponsorship: {

--- a/src/constants/transactionOperations.tsx
+++ b/src/constants/transactionOperations.tsx
@@ -5,7 +5,7 @@ import {
   OPERATION_TRUSTLINE_CLEAR_FLAGS,
   OPERATION_TRUSTLINE_SET_FLAGS,
 } from "@/constants/settings";
-import { AnyObject } from "@/types/types";
+import { AnyObject, TxnOperation } from "@/types/types";
 
 type TransactionOperation = {
   label: string;
@@ -17,6 +17,11 @@ type TransactionOperation = {
     [key: string]: string;
   };
   custom?: AnyObject;
+};
+
+export const INITIAL_OPERATION: TxnOperation = {
+  operation_type: "",
+  params: [],
 };
 
 export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {

--- a/src/constants/transactionOperations.tsx
+++ b/src/constants/transactionOperations.tsx
@@ -339,16 +339,45 @@ export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {
     params: ["asset", "from", "amount"],
     requiredParams: ["asset", "from", "amount"],
   },
+  extend_footprint_ttl: {
+    label: "Extend Footprint TTL",
+    description:
+      "Extend the time to live (TTL) of entries for Soroban smart contracts. This operation extends the TTL of the entries specified in the readOnly footprint of the transaction so that they will live at least until the extendTo ledger sequence number is reached.",
+    docsUrl:
+      "https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#extend-footprint-ttl",
+    params: [
+      "contract",
+      "key_xdr",
+      "extend_ttl_to",
+      "durability",
+      "resource_fee",
+    ],
+    requiredParams: [
+      "contract",
+      "key_xdr",
+      "extend_ttl_to",
+      "durability",
+      "resource_fee",
+    ],
+    defaultParams: {
+      durability: "persistent",
+    },
+    custom: {
+      extend_ttl_to: {
+        note: "The ledger sequence number the entries will live until.",
+      },
+    },
+  },
   restore_footprint: {
     label: "Restore Footprint",
     description:
       "Make archived Soroban smart contract entries accessible again by restoring them.",
     docsUrl:
       "https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#restore-footprint",
-    params: ["contract", "key_xdr"],
-    requiredParams: ["contract", "key_xdr"],
-    custom: {
-      isSorobanTx: true,
+    params: ["contract", "key_xdr", "durability", "resource_fee"],
+    requiredParams: ["contract", "key_xdr", "durability", "resource_fee"],
+    defaultParams: {
+      durability: "persistent",
     },
   },
   revoke_sponsorship: {

--- a/src/constants/transactionOperations.tsx
+++ b/src/constants/transactionOperations.tsx
@@ -376,26 +376,6 @@ export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {
       },
     },
   },
-  restore_footprint: {
-    label: "Restore Footprint",
-    description:
-      "Make archived Soroban smart contract entries accessible again by restoring them.",
-    docsUrl:
-      "https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#restore-footprint",
-    params: ["contract", "key_xdr", "durability", "resource_fee"],
-    requiredParams: ["contract", "key_xdr", "durability", "resource_fee"],
-    defaultParams: {
-      durability: "persistent",
-    },
-    custom: {
-      durability: {
-        note: "Only persistent and instance entries can be restored.",
-      },
-      extend_ttl_to: {
-        note: "The ledger sequence number the entries will live until.",
-      },
-    },
-  },
   revoke_sponsorship: {
     label: "Revoke Sponsorship",
     description: "Revoke sponsorship of a ledger entry.",

--- a/src/constants/transactionOperations.tsx
+++ b/src/constants/transactionOperations.tsx
@@ -366,6 +366,9 @@ export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {
       extend_ttl_to: {
         note: "The ledger sequence number the entries will live until.",
       },
+      durability: {
+        note: "TTL for the temporary data can be extended; however, it is unsafe to rely on the extensions to preserve data since there is always a risk of losing temporary data",
+      },
     },
   },
   restore_footprint: {
@@ -378,6 +381,14 @@ export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {
     requiredParams: ["contract", "key_xdr", "durability", "resource_fee"],
     defaultParams: {
       durability: "persistent",
+    },
+    custom: {
+      durability: {
+        note: "Only persistent and instance entries can be restored.",
+      },
+      extend_ttl_to: {
+        note: "The ledger sequence number the entries will live until.",
+      },
     },
   },
   revoke_sponsorship: {

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -10,7 +10,7 @@ import {
 } from "@stellar/stellar-sdk";
 
 import { TransactionBuildParams } from "@/store/createStore";
-import { SorobanOpType } from "@/types/types";
+import { SorobanOpType, TxnOperation } from "@/types/types";
 
 export const isSorobanOperationType = (operationType: string) => {
   return [
@@ -87,12 +87,12 @@ export const getSorobanDataResult = ({
 export const buildSorobanTx = ({
   sorobanData,
   params,
-  sorobanParams,
+  sorobanOp,
   networkPassphrase,
 }: {
   sorobanData: xdr.SorobanTransactionData;
   params: TransactionBuildParams;
-  sorobanParams: any;
+  sorobanOp: TxnOperation;
   networkPassphrase: string;
 }) => {
   // decrement seq number by 1 because TransactionBuilder.build()
@@ -101,7 +101,7 @@ export const buildSorobanTx = ({
   const account = new Account(params.source_account, txSeq);
 
   // https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering
-  const totalTxFee = BigInt(params.fee) + BigInt(sorobanParams.resource_fee);
+  const totalTxFee = BigInt(params.fee) + BigInt(sorobanOp.params.resource_fee);
 
   const getMemoValue = (memoType: string, memoValue: string) => {
     switch (memoType) {
@@ -143,7 +143,8 @@ export const buildSorobanTx = ({
     .setSorobanData(sorobanData)
     .addOperation(
       Operation.extendFootprintTtl({
-        extendTo: Number(sorobanParams.extend_ttl_to),
+        extendTo: Number(sorobanOp.params.extend_ttl_to),
+        source: sorobanOp.source_account,
       }),
     )
     .build();

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -1,0 +1,150 @@
+import {
+  Address,
+  Contract,
+  Operation,
+  TransactionBuilder,
+  xdr,
+  Account,
+  Memo,
+  SorobanDataBuilder,
+} from "@stellar/stellar-sdk";
+
+import { TransactionBuildParams } from "@/store/createStore";
+
+export const transactionHashFromXdr = (
+  xdr: string,
+  networkPassphrase: string,
+) => {
+  try {
+    // Code to read XDR data
+    return TransactionBuilder?.fromXDR(xdr, networkPassphrase)
+      .hash()
+      .toString("hex");
+  } catch (e) {
+    // @TODO Do nothing for now
+    // add amplitude error tracking
+    return;
+  }
+};
+
+// https://developers.stellar.org/docs/learn/glossary#ledgerkey
+// https://developers.stellar.org/docs/build/guides/archival/restore-data-js
+export const getContractDataXDR = ({
+  contractAddress,
+  dataKey,
+  durability,
+}: {
+  contractAddress: string;
+  dataKey: string;
+  durability: string;
+}) => {
+  const contract: Contract = new Contract(contractAddress);
+  const address: Address = Address.fromString(contract.contractId());
+  const xdrBinary = Buffer.from(dataKey, "base64");
+
+  const getXdrDurability = (durability: string) => {
+    switch (durability) {
+      case "persistent":
+        return xdr.ContractDataDurability.persistent();
+      // https://developers.stellar.org/docs/build/guides/storage/choosing-the-right-storage#temporary-storage
+      // TTL for the temporary data can be extended; however,
+      // it is unsafe to rely on the extensions to preserve data since
+      // there is always a risk of losing temporary data
+      case "temporary":
+        return xdr.ContractDataDurability.temporary();
+      default:
+        return xdr.ContractDataDurability.persistent();
+    }
+  };
+
+  return xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: address.toScAddress(),
+      key: xdr.ScVal.fromXDR(xdrBinary),
+      durability: getXdrDurability(durability),
+    }),
+  );
+};
+
+export const buildSorobanData = ({
+  readOnlyXdrLedgerKey = [],
+  readWrieXdrLedgerKey = [],
+  resourceFee,
+  //   instructionsm
+  //   ReadableByteStreamController,
+}: {
+  readOnlyXdrLedgerKey?: xdr.LedgerKey[];
+  readWrieXdrLedgerKey?: xdr.LedgerKey[];
+  resourceFee: string;
+}) => {
+  return new SorobanDataBuilder()
+    .setReadOnly(readOnlyXdrLedgerKey)
+    .setReadWrite(readWrieXdrLedgerKey)
+    .setResourceFee(resourceFee)
+    .build();
+};
+
+export const buildSorobanTx = ({
+  sorobanData,
+  params,
+  sorobanParams,
+  networkPassphrase,
+}: {
+  sorobanData: xdr.SorobanTransactionData;
+  params: TransactionBuildParams;
+  sorobanParams: any;
+  networkPassphrase: string;
+}) => {
+  // decrement seq number by 1 because TransactionBuilder.build()
+  // will increment the seq number by 1 automatically
+  const txSeq = (BigInt(params.seq_num) - BigInt(1)).toString();
+  const account = new Account(params.source_account, txSeq);
+
+  // https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering
+  const totalTxFee = BigInt(params.fee) + BigInt(sorobanParams.resource_fee);
+
+  const getMemoValue = (memoType: string, memoValue: string) => {
+    switch (memoType) {
+      case "text":
+        return Memo.text(memoValue);
+      case "id":
+        return Memo.id(memoValue);
+      case "hash":
+        return Memo.hash(memoValue);
+      case "return":
+        return Memo.return(memoValue);
+      default:
+        return Memo.none();
+    }
+  };
+
+  const getTimeboundsValue = (timebounds: {
+    min_time: string;
+    max_time: string;
+  }) => {
+    return {
+      minTime: timebounds.min_time,
+      maxTime: timebounds.max_time,
+    };
+  };
+
+  const transaction = new TransactionBuilder(account, {
+    fee: totalTxFee.toString(),
+    timebounds: getTimeboundsValue(params.cond.time),
+  });
+
+  if (Object.keys(params.memo).length > 0) {
+    const [type, val] = Object.entries(params.memo)[0];
+    transaction.addMemo(getMemoValue(type, val));
+  }
+
+  return transaction
+    .setNetworkPassphrase(networkPassphrase)
+    .setSorobanData(sorobanData)
+    .addOperation(
+      Operation.extendFootprintTtl({
+        extendTo: Number(sorobanParams.extend_ttl_to),
+      }),
+    )
+    .build();
+};

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -12,20 +12,12 @@ import {
 import { TransactionBuildParams } from "@/store/createStore";
 import { SorobanOpType } from "@/types/types";
 
-export const transactionHashFromXdr = (
-  xdr: string,
-  networkPassphrase: string,
-) => {
-  try {
-    // Code to read XDR data
-    return TransactionBuilder?.fromXDR(xdr, networkPassphrase)
-      .hash()
-      .toString("hex");
-  } catch (e) {
-    // @TODO Do nothing for now
-    // add amplitude error tracking
-    return;
-  }
+export const isSorobanOperationType = (operationType: string) => {
+  return [
+    "extend_footprint_ttl",
+    "restore_footprint",
+    "invoke_host_function",
+  ].includes(operationType);
 };
 
 // https://developers.stellar.org/docs/learn/glossary#ledgerkey
@@ -92,29 +84,6 @@ export const getSorobanDataResult = ({
   }
 };
 
-const buildSorobanData = ({
-  readOnlyXdrLedgerKey = [],
-  readWriteXdrLedgerKey = [],
-  resourceFee,
-  //   instructionsm
-  //   ReadableByteStreamController,
-}: {
-  readOnlyXdrLedgerKey?: xdr.LedgerKey[];
-  readWriteXdrLedgerKey?: xdr.LedgerKey[];
-  resourceFee: string;
-}) => {
-  // one of the two must be provided
-  if (!readOnlyXdrLedgerKey && !readWriteXdrLedgerKey) {
-    return;
-  }
-
-  return new SorobanDataBuilder()
-    .setReadOnly(readOnlyXdrLedgerKey)
-    .setReadWrite(readWriteXdrLedgerKey)
-    .setResourceFee(resourceFee)
-    .build();
-};
-
 export const buildSorobanTx = ({
   sorobanData,
   params,
@@ -177,5 +146,28 @@ export const buildSorobanTx = ({
         extendTo: Number(sorobanParams.extend_ttl_to),
       }),
     )
+    .build();
+};
+
+const buildSorobanData = ({
+  readOnlyXdrLedgerKey = [],
+  readWriteXdrLedgerKey = [],
+  resourceFee,
+  //   instructionsm
+  //   ReadableByteStreamController,
+}: {
+  readOnlyXdrLedgerKey?: xdr.LedgerKey[];
+  readWriteXdrLedgerKey?: xdr.LedgerKey[];
+  resourceFee: string;
+}) => {
+  // one of the two must be provided
+  if (!readOnlyXdrLedgerKey && !readWriteXdrLedgerKey) {
+    return;
+  }
+
+  return new SorobanDataBuilder()
+    .setReadOnly(readOnlyXdrLedgerKey)
+    .setReadWrite(readWriteXdrLedgerKey)
+    .setResourceFee(resourceFee)
     .build();
 };

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -10,6 +10,7 @@ import {
 } from "@stellar/stellar-sdk";
 
 import { TransactionBuildParams } from "@/store/createStore";
+import { SorobanOpType } from "@/types/types";
 
 export const transactionHashFromXdr = (
   xdr: string,
@@ -66,20 +67,50 @@ export const getContractDataXDR = ({
   );
 };
 
-export const buildSorobanData = ({
+export const getSorobanDataResult = ({
+  contractDataXDR,
+  operationType,
+  fee,
+}: {
+  contractDataXDR: xdr.LedgerKey;
+  operationType: SorobanOpType;
+  fee: string;
+}) => {
+  switch (operationType) {
+    case "extend_footprint_ttl":
+      return buildSorobanData({
+        readOnlyXdrLedgerKey: [contractDataXDR],
+        resourceFee: fee,
+      });
+    // case "restore_footprint":
+    // return buildSorobanData({
+    //   readWriteXdrLedgerKey: [contractDataXDR],
+    //   resourceFee: operation.params.resource_fee,
+    // });
+    default:
+      return undefined;
+  }
+};
+
+const buildSorobanData = ({
   readOnlyXdrLedgerKey = [],
-  readWrieXdrLedgerKey = [],
+  readWriteXdrLedgerKey = [],
   resourceFee,
   //   instructionsm
   //   ReadableByteStreamController,
 }: {
   readOnlyXdrLedgerKey?: xdr.LedgerKey[];
-  readWrieXdrLedgerKey?: xdr.LedgerKey[];
+  readWriteXdrLedgerKey?: xdr.LedgerKey[];
   resourceFee: string;
 }) => {
+  // one of the two must be provided
+  if (!readOnlyXdrLedgerKey && !readWriteXdrLedgerKey) {
+    return;
+  }
+
   return new SorobanDataBuilder()
     .setReadOnly(readOnlyXdrLedgerKey)
-    .setReadWrite(readWrieXdrLedgerKey)
+    .setReadWrite(readWriteXdrLedgerKey)
     .setResourceFee(resourceFee)
     .build();
 };

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -595,9 +595,6 @@ export const createStore = (options: CreateStoreOptions) =>
             },
             transaction: {
               build: {
-                error: false,
-                isValid: true,
-                xdr: false,
                 classic: {
                   operations: true,
                   xdr: false,
@@ -606,6 +603,9 @@ export const createStore = (options: CreateStoreOptions) =>
                   operation: true,
                   xdr: false,
                 },
+                params: true,
+                error: false,
+                isValid: true,
               },
               sign: {
                 activeView: true,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -229,6 +229,12 @@ const initTransactionParamsState = {
   memo: {},
 };
 
+const initTransactionOperationState = {
+  operation_type: "",
+  params: {},
+  source_account: "",
+};
+
 const initTransactionState = {
   build: {
     classic: {
@@ -236,7 +242,7 @@ const initTransactionState = {
       xdr: "",
     },
     soroban: {
-      operation: {},
+      operation: initTransactionOperationState,
       xdr: "",
     },
     params: initTransactionParamsState,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -110,21 +110,22 @@ export interface Store {
   transaction: {
     build: {
       // @TODO wrap it within classic object
-      params: TransactionBuildParams;
       operations: TxnOperation[];
-      error: {
-        params: string[];
-        operations: OpBuildingError[];
-      };
       xdr: string;
-      isValid: {
-        params: boolean;
-        operations: boolean;
-      };
       // soroban
       soroban: {
         operation: TxnOperation;
         xdr: string;
+      };
+      // used for both classic and soroban
+      params: TransactionBuildParams;
+      error: {
+        params: string[];
+        operations: OpBuildingError[];
+      };
+      isValid: {
+        params: boolean;
+        operations: boolean;
       };
     };
     sign: {
@@ -230,7 +231,7 @@ const initTransactionParamsState = {
 const initSorobanState = {
   operation: {
     operation_type: "",
-    params: {},
+    params: [],
     source_account: "",
   },
   xdr: "",

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -15,7 +15,6 @@ import {
   Network,
   MuxedAccount,
   TxnOperation,
-  TxnSorobanOperation,
   OpBuildingError,
   ThemeColorType,
 } from "@/types/types";
@@ -124,7 +123,7 @@ export interface Store {
       };
       // soroban
       soroban: {
-        operation: TxnSorobanOperation;
+        operation: TxnOperation;
         xdr: string;
       };
     };
@@ -160,7 +159,7 @@ export interface Store {
     setBuildOperationsError: (error: OpBuildingError[]) => void;
     resetBuildParams: () => void;
     // [Transaction] Build Soroban Transaction actions
-    updateSorobanBuildOperation: (operation: TxnSorobanOperation) => void;
+    updateSorobanBuildOperation: (operation: TxnOperation) => void;
     updateSorobanBuildXdr: (xdr: string) => void;
     // [Transaction] Both Classic & Soroban Transaction actions
     resetBuild: () => void;

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -109,9 +109,11 @@ export interface Store {
   // Transaction
   transaction: {
     build: {
-      // @TODO wrap it within classic object
-      operations: TxnOperation[];
-      xdr: string;
+      // classic
+      classic: {
+        operations: TxnOperation[];
+        xdr: string;
+      };
       // soroban
       soroban: {
         operation: TxnOperation;
@@ -162,7 +164,6 @@ export interface Store {
     // [Transaction] Build Soroban Transaction actions
     updateSorobanBuildOperation: (operation: TxnOperation) => void;
     updateSorobanBuildXdr: (xdr: string) => void;
-    resetSorobanBuildOperation: () => void;
     // [Transaction] Both Classic & Soroban Transaction actions
     resetBuild: () => void;
     // [Transaction] Sign Transaction actions
@@ -228,29 +229,25 @@ const initTransactionParamsState = {
   memo: {},
 };
 
-const initSorobanState = {
-  operation: {
-    operation_type: "",
-    params: [],
-    source_account: "",
-  },
-  xdr: "",
-};
-
 const initTransactionState = {
   build: {
+    classic: {
+      operations: [],
+      xdr: "",
+    },
+    soroban: {
+      operation: {},
+      xdr: "",
+    },
     params: initTransactionParamsState,
-    operations: [],
     error: {
       params: [],
       operations: [],
     },
-    xdr: "",
     isValid: {
       params: false,
       operations: false,
     },
-    soroban: initSorobanState,
   },
   sign: {
     activeView: "import" as SignTxActiveView,
@@ -426,15 +423,15 @@ export const createStore = (options: CreateStoreOptions) =>
             }),
           updateBuildOperations: (operations) =>
             set((state) => {
-              state.transaction.build.operations = operations;
+              state.transaction.build.classic.operations = operations;
             }),
           updateBuildXdr: (xdr) =>
             set((state) => {
-              state.transaction.build.xdr = xdr;
+              state.transaction.build.classic.xdr = xdr;
             }),
           updateBuildSingleOperation: (index, operation) =>
             set((state) => {
-              state.transaction.build.operations[index] = operation;
+              state.transaction.build.classic.operations[index] = operation;
             }),
           updateBuildIsValid: ({
             params,
@@ -478,10 +475,6 @@ export const createStore = (options: CreateStoreOptions) =>
           updateSorobanBuildXdr: (xdr: string) =>
             set((state) => {
               state.transaction.build.soroban.xdr = xdr;
-            }),
-          resetSorobanBuildOperation: () =>
-            set((state) => {
-              state.transaction.build.soroban = initSorobanState;
             }),
           // Classic & Soroban
           resetBuild: () =>
@@ -596,11 +589,13 @@ export const createStore = (options: CreateStoreOptions) =>
             },
             transaction: {
               build: {
-                params: true,
-                operations: true,
                 error: false,
                 isValid: true,
                 xdr: false,
+                classic: {
+                  operations: true,
+                  xdr: false,
+                },
                 soroban: {
                   operation: true,
                   xdr: false,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -15,6 +15,7 @@ import {
   Network,
   MuxedAccount,
   TxnOperation,
+  TxnSorobanOperation,
   OpBuildingError,
   ThemeColorType,
 } from "@/types/types";
@@ -109,6 +110,7 @@ export interface Store {
   // Transaction
   transaction: {
     build: {
+      // @TODO wrap it within classic object
       params: TransactionBuildParams;
       operations: TxnOperation[];
       error: {
@@ -119,6 +121,11 @@ export interface Store {
       isValid: {
         params: boolean;
         operations: boolean;
+      };
+      // soroban
+      soroban: {
+        operation: TxnSorobanOperation;
+        xdr: string;
       };
     };
     sign: {
@@ -133,7 +140,7 @@ export interface Store {
       triggerOnLaunch?: boolean;
     };
     feeBump: FeeBumpParams;
-    // [Transaction] Build Transaction actions
+    // [Transaction] Build Classic Transaction actions
     updateBuildParams: (params: TransactionBuildParamsObj) => void;
     updateBuildOperations: (operations: TxnOperation[]) => void;
     updateBuildXdr: (xdr: string) => void;
@@ -152,6 +159,10 @@ export interface Store {
     setBuildParamsError: (error: string[]) => void;
     setBuildOperationsError: (error: OpBuildingError[]) => void;
     resetBuildParams: () => void;
+    // [Transaction] Build Soroban Transaction actions
+    updateSorobanBuildOperation: (operation: TxnOperation) => void;
+    updateSorobanBuildXdr: (xdr: string) => void;
+    // [Transaction] Both Classic & Soroban Transaction actions
     resetBuild: () => void;
     // [Transaction] Sign Transaction actions
     updateSignActiveView: (viewId: SignTxActiveView) => void;
@@ -228,6 +239,23 @@ const initTransactionState = {
     isValid: {
       params: false,
       operations: false,
+    },
+    soroban: {
+      params: initTransactionParamsState,
+      operation: {
+        operation_type: "",
+        params: {},
+        source_account: "",
+      },
+      error: {
+        params: [],
+        operations: [],
+      },
+      xdr: "",
+      isValid: {
+        params: false,
+        operations: false,
+      },
     },
   },
   sign: {
@@ -394,6 +422,7 @@ export const createStore = (options: CreateStoreOptions) =>
         // Transaction
         transaction: {
           ...initTransactionState,
+          // Classic Build
           updateBuildParams: (params: TransactionBuildParamsObj) =>
             set((state) => {
               state.transaction.build.params = {
@@ -447,10 +476,21 @@ export const createStore = (options: CreateStoreOptions) =>
             set((state) => {
               state.transaction.build.params = initTransactionParamsState;
             }),
+          // Soroban Build
+          updateSorobanBuildOperation: (operation: TxnOperation) =>
+            set((state) => {
+              state.transaction.build.soroban.operation = operation;
+            }),
+          updateSorobanBuildXdr: (xdr: string) =>
+            set((state) => {
+              state.transaction.build.soroban.xdr = xdr;
+            }),
+          // Classic & Soroban
           resetBuild: () =>
             set((state) => {
               state.transaction.build = initTransactionState.build;
             }),
+          // Sign
           updateSignActiveView: (viewId: SignTxActiveView) =>
             set((state) => {
               state.transaction.sign.activeView = viewId;
@@ -563,6 +603,10 @@ export const createStore = (options: CreateStoreOptions) =>
                 error: false,
                 isValid: true,
                 xdr: false,
+                soroban: {
+                  operation: true,
+                  xdr: false,
+                },
               },
               sign: {
                 activeView: true,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -161,6 +161,7 @@ export interface Store {
     // [Transaction] Build Soroban Transaction actions
     updateSorobanBuildOperation: (operation: TxnOperation) => void;
     updateSorobanBuildXdr: (xdr: string) => void;
+    resetSorobanBuildOperation: () => void;
     // [Transaction] Both Classic & Soroban Transaction actions
     resetBuild: () => void;
     // [Transaction] Sign Transaction actions
@@ -226,6 +227,15 @@ const initTransactionParamsState = {
   memo: {},
 };
 
+const initSorobanState = {
+  operation: {
+    operation_type: "",
+    params: {},
+    source_account: "",
+  },
+  xdr: "",
+};
+
 const initTransactionState = {
   build: {
     params: initTransactionParamsState,
@@ -239,14 +249,7 @@ const initTransactionState = {
       params: false,
       operations: false,
     },
-    soroban: {
-      operation: {
-        operation_type: "",
-        params: {},
-        source_account: "",
-      },
-      xdr: "",
-    },
+    soroban: initSorobanState,
   },
   sign: {
     activeView: "import" as SignTxActiveView,
@@ -474,6 +477,10 @@ export const createStore = (options: CreateStoreOptions) =>
           updateSorobanBuildXdr: (xdr: string) =>
             set((state) => {
               state.transaction.build.soroban.xdr = xdr;
+            }),
+          resetSorobanBuildOperation: () =>
+            set((state) => {
+              state.transaction.build.soroban = initSorobanState;
             }),
           // Classic & Soroban
           resetBuild: () =>

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -160,7 +160,7 @@ export interface Store {
     setBuildOperationsError: (error: OpBuildingError[]) => void;
     resetBuildParams: () => void;
     // [Transaction] Build Soroban Transaction actions
-    updateSorobanBuildOperation: (operation: TxnOperation) => void;
+    updateSorobanBuildOperation: (operation: TxnSorobanOperation) => void;
     updateSorobanBuildXdr: (xdr: string) => void;
     // [Transaction] Both Classic & Soroban Transaction actions
     resetBuild: () => void;
@@ -241,21 +241,12 @@ const initTransactionState = {
       operations: false,
     },
     soroban: {
-      params: initTransactionParamsState,
       operation: {
         operation_type: "",
         params: {},
         source_account: "",
       },
-      error: {
-        params: [],
-        operations: [],
-      },
       xdr: "",
-      isValid: {
-        params: false,
-        operations: false,
-      },
     },
   },
   sign: {
@@ -564,7 +555,7 @@ export const createStore = (options: CreateStoreOptions) =>
         // Smart Contracts
         smartContracts: {
           ...initSmartContractsState,
-          updateExplorerContractId: (contractId) =>
+          updateExplorerContractId: (contractId: string) =>
             set((state) => {
               state.smartContracts.explorer.contractId = contractId;
             }),

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  Address,
-  NetworkError,
-  rpc as StellarRpc,
-  xdr,
-} from "@stellar/stellar-sdk";
+import { NetworkError, rpc as StellarRpc, xdr } from "@stellar/stellar-sdk";
 import { TransactionBuildParams } from "@/store/createStore";
 
 // =============================================================================
@@ -231,13 +226,6 @@ export type FractionValue = {
   d: string | undefined;
 };
 
-// https://github.com/stellar/js-stellar-base/blob/master/src/generated/curr_generated.js#L1887-L1891
-export type LedgerKeyContractDataType = {
-  contract: xdr.ScAddress;
-  key: xdr.ScVal;
-  durability: xdr.ContractDataDurability;
-};
-
 export type RevokeSponsorshipValue = {
   type: SponsorshipType | string;
   data: AnyObject;
@@ -251,6 +239,9 @@ export type SponsorshipType =
   | "claimable_balance"
   | "signer";
 
+// =============================================================================
+// Soroban Operations
+// =============================================================================
 export type SorobanOpType = "restore_footprint" | "extend_footprint_ttl";
 
 // =============================================================================

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -138,6 +138,12 @@ export type TxnOperation = {
   source_account?: string;
 };
 
+export type TxnSorobanOperation = {
+  operation_type: SorobanOpType;
+  params: AnyObject;
+  source_account?: string;
+};
+
 export type OpBuildingError = { label?: string; errorList?: string[] };
 
 export type LedgerErrorResponse = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -138,12 +138,6 @@ export type TxnOperation = {
   source_account?: string;
 };
 
-export type TxnSorobanOperation = {
-  operation_type: SorobanOpType;
-  params: AnyObject;
-  source_account?: string;
-};
-
 export type OpBuildingError = { label?: string; errorList?: string[] };
 
 export type LedgerErrorResponse = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -242,7 +242,7 @@ export type SponsorshipType =
 // =============================================================================
 // Soroban Operations
 // =============================================================================
-export type SorobanOpType = "restore_footprint" | "extend_footprint_ttl";
+export type SorobanOpType = "extend_footprint_ttl";
 
 // =============================================================================
 // RPC

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,8 +1,8 @@
 import React from "react";
 import {
+  Address,
   NetworkError,
   rpc as StellarRpc,
-  Transaction,
   xdr,
 } from "@stellar/stellar-sdk";
 import { TransactionBuildParams } from "@/store/createStore";
@@ -231,8 +231,11 @@ export type FractionValue = {
   d: string | undefined;
 };
 
-export type RestoreFootprintValue = {
-  tx: Transaction;
+// https://github.com/stellar/js-stellar-base/blob/master/src/generated/curr_generated.js#L1887-L1891
+export type LedgerKeyContractDataType = {
+  contract: xdr.ScAddress;
+  key: xdr.ScVal;
+  durability: xdr.ContractDataDurability;
 };
 
 export type RevokeSponsorshipValue = {
@@ -247,6 +250,8 @@ export type SponsorshipType =
   | "data"
   | "claimable_balance"
   | "signer";
+
+export type SorobanOpType = "restore_footprint" | "extend_footprint_ttl";
 
 // =============================================================================
 // RPC

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,10 @@
 import React from "react";
-import { NetworkError, rpc as StellarRpc, xdr } from "@stellar/stellar-sdk";
+import {
+  NetworkError,
+  rpc as StellarRpc,
+  Transaction,
+  xdr,
+} from "@stellar/stellar-sdk";
 import { TransactionBuildParams } from "@/store/createStore";
 
 // =============================================================================
@@ -224,6 +229,10 @@ export type NumberFractionValue = {
 export type FractionValue = {
   n: string | undefined;
   d: string | undefined;
+};
+
+export type RestoreFootprintValue = {
+  tx: Transaction;
 };
 
 export type RevokeSponsorshipValue = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -259,7 +259,7 @@ export type FiltersObject = {
   topics: string[];
 };
 
-export type XdrType = "TransactionEnvelope" | "LedgerKey";
+export type XdrType = "TransactionEnvelope" | "LedgerKey" | "ScVal";
 
 export type LedgerKeyType =
   | "account"

--- a/src/validate/methods/getContractIdError.ts
+++ b/src/validate/methods/getContractIdError.ts
@@ -9,7 +9,7 @@ export const getContractIdError = (value: string) => {
   } else if (value.length > CONTRACT_MAX_LENGTH) {
     return `The string length is too large.`;
   } else if (value.length < CONTRACT_MIN_LENGTH) {
-    return `The string length should be at least ${CONTRACT_MAX_LENGTH} characters long.`;
+    return `The string length should be at least ${CONTRACT_MIN_LENGTH} characters long.`;
   }
 
   return false;

--- a/src/validate/methods/getContractIdError.ts
+++ b/src/validate/methods/getContractIdError.ts
@@ -1,6 +1,15 @@
+// contract IDs are fixed 32-byte byte arrays, and are represented as BytesN<32>
+// https://developers.stellar.org/docs/learn/encyclopedia/contract-development/types/built-in-types#bytes-strings-bytes-bytesn-string
+const CONTRACT_MAX_LENGTH = 66;
+const CONTRACT_MIN_LENGTH = 32;
+
 export const getContractIdError = (value: string) => {
   if (value.charAt(0) !== "C") {
     return "The string must start with 'C'.";
+  } else if (value.length > CONTRACT_MAX_LENGTH) {
+    return `The string length is too large.`;
+  } else if (value.length < CONTRACT_MIN_LENGTH) {
+    return `The string length should be at least ${CONTRACT_MAX_LENGTH} characters long.`;
   }
 
   return false;

--- a/src/validate/methods/getContractIdError.ts
+++ b/src/validate/methods/getContractIdError.ts
@@ -1,10 +1,6 @@
-const CONTRACT_LENGTH = 56;
-
 export const getContractIdError = (value: string) => {
   if (value.charAt(0) !== "C") {
     return "The string must start with 'C'.";
-  } else if (value.length !== CONTRACT_LENGTH) {
-    return `The string must be exactly ${CONTRACT_LENGTH} characters long.`;
   }
 
   return false;

--- a/tests/buildTransaction.test.ts
+++ b/tests/buildTransaction.test.ts
@@ -1394,7 +1394,7 @@ test.describe("Build Transaction Page", () => {
         });
       });
 
-      test("Check rendering betweem classic and soroban", async ({ page }) => {
+      test("Check rendering between classic and soroban", async ({ page }) => {
         // Select Soroban Operation
         const { operation_0 } = await selectOperationType({
           page,

--- a/tests/buildTransaction.test.ts
+++ b/tests/buildTransaction.test.ts
@@ -1393,6 +1393,47 @@ test.describe("Build Transaction Page", () => {
           errorMessage: "Expected a whole number.",
         });
       });
+
+      test("Check rendering betweem classic and soroban", async ({ page }) => {
+        // Select Soroban Operation
+        const { operation_0 } = await selectOperationType({
+          page,
+          opType: "extend_footprint_ttl",
+        });
+        // we are going from classic operation to soroban operation
+        // so the classic operation should not be visible
+        await expect(operation_0).not.toBeVisible();
+
+        const soroban_operation = page.getByTestId(
+          "build-soroban-transaction-operation",
+        );
+
+        // Verify warning message about one operation limit
+        await expect(
+          page.getByText(
+            "Note that Soroban transactions can only contain one operation per transaction.",
+          ),
+        ).toBeVisible();
+
+        // Soroban Operation only allows one operation
+        // Add Operation button should not be visible
+        await expect(page.getByText("Add Operation")).not.toBeVisible();
+
+        // Select Classic Operation
+        await soroban_operation.getByLabel("Operation type").selectOption({
+          value: "payment",
+        });
+
+        const classicOperation = page.getByTestId(
+          "build-transaction-operation-0",
+        );
+
+        await expect(classicOperation).toBeVisible();
+
+        // Soroban Operation only allows one operation
+        // Add Operation button should not be visible
+        await expect(page.getByText("Add Operation")).toBeVisible();
+      });
     });
   });
 });

--- a/tests/feeBumpPage.test.ts
+++ b/tests/feeBumpPage.test.ts
@@ -59,6 +59,8 @@ test.describe("Fee Bump Page", () => {
       await expect(signButton).toBeVisible();
       await signButton.click();
 
+      await page.waitForURL("**/transaction/sign");
+
       await expect(page.locator("h1")).toHaveText("Transaction Overview");
       await expect(page.getByLabel("Transaction Envelope XDR")).toHaveText(
         MOCK_XDR,
@@ -75,6 +77,8 @@ test.describe("Fee Bump Page", () => {
 
       await expect(viewButton).toBeVisible();
       await viewButton.click();
+
+      await page.waitForURL("**/xdr");
 
       await expect(page.locator("h1")).toHaveText("View XDR");
       await expect(page.getByLabel("Base-64 encoded XDR")).toHaveText(MOCK_XDR);

--- a/tests/feeBumpPage.test.ts
+++ b/tests/feeBumpPage.test.ts
@@ -78,7 +78,7 @@ test.describe("Fee Bump Page", () => {
       await expect(viewButton).toBeVisible();
       await viewButton.click();
 
-      await page.waitForURL("**/xdr");
+      await page.waitForURL("**/xdr/view");
 
       await expect(page.locator("h1")).toHaveText("View XDR");
       await expect(page.getByLabel("Base-64 encoded XDR")).toHaveText(MOCK_XDR);

--- a/tests/mock/localStorage.ts
+++ b/tests/mock/localStorage.ts
@@ -156,6 +156,46 @@ const SAVED_TRANSACTIONS = [
       },
     ],
   },
+  // Soroban Transaction
+  {
+    timestamp: 1737143650128,
+    network: { id: "testnet", label: "Testnet" },
+    name: "Extend to TTL",
+    xdr: "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAAA",
+    page: "build",
+    shareableUrl:
+      "http://localhost:3000/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$params$source_account=GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG&seq_num=1727208213184537;&operations@$operation_type=payment&params$destination=GAQ6LVQXNRX26CBIKCYGGGD6B4SNQACTJ46QMHS4Q5S52UHZW76XJJPJ&asset$code=&issuer=&type=native;&amount=5;&source_account=;;&isValid$params:true&operations:true;&soroban$operation$operation_type=extend_footprint_ttl&params$durability=persistent&contract=CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S&key_xdr=AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD&extend_ttl_to=30000&resource_fee=46753;;",
+    params: {
+      source_account:
+        "GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG",
+      fee: "100",
+      seq_num: "1727208213184537",
+      cond: { time: { min_time: "", max_time: "" } },
+      memo: {},
+    },
+    operations: [
+      {
+        operation_type: "extend_footprint_ttl",
+        params: {
+          durability: "persistent",
+          contract: "CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S",
+          key_xdr:
+            "AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD",
+          extend_ttl_to: "30000",
+          resource_fee: "46753",
+        },
+        source_account: "",
+      },
+    ],
+  },
+  {
+    timestamp: 1737148428325,
+    network: { id: "testnet", label: "Testnet" },
+    name: "Extend TTL",
+    xdr: "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAABUZAigwAAAEADYbntiznotYPblvJQ35DiGEpMTQU9jCYANxV18VVGV6zDFSjB+qK++dF656Pr4oMTpyBVvE15YSo6ITxR5DoE",
+    page: "submit",
+    shareableUrl: "http://localhost:3000/transaction/submit?$=;;",
+  },
 ];
 
 export const MOCK_LOCAL_STORAGE = {

--- a/tests/savedTransactions.test.ts
+++ b/tests/savedTransactions.test.ts
@@ -25,7 +25,7 @@ test.describe("Saved Transactions Page", () => {
     // local storage data
     let pageContext: Page;
 
-    test.beforeAll(async ({ browser }) => {
+    test.beforeEach(async ({ browser }) => {
       const browserContext = await browser.newContext({
         storageState: MOCK_LOCAL_STORAGE,
       });
@@ -42,10 +42,10 @@ test.describe("Saved Transactions Page", () => {
 
       const txItems = pageContext.getByTestId("saved-transactions-item");
 
-      await expect(txItems).toHaveCount(2);
+      await expect(txItems).toHaveCount(4);
     });
 
-    test("Submit item", async () => {
+    test("[Classic] Submit item", async () => {
       const submitItem = pageContext
         .getByTestId("saved-transactions-item")
         .nth(0);
@@ -86,7 +86,7 @@ test.describe("Saved Transactions Page", () => {
       );
     });
 
-    test("Build item", async () => {
+    test("[Classic] Build item", async () => {
       const buildItem = pageContext
         .getByTestId("saved-transactions-item")
         .nth(1);
@@ -137,13 +137,124 @@ test.describe("Saved Transactions Page", () => {
       );
     });
 
+    test("[Soroban] Submit item", async () => {
+      await pageContext.waitForSelector(
+        '[data-testid="saved-transactions-item"]',
+      );
+      const items = pageContext.getByTestId("saved-transactions-item");
+
+      const submitItem = items.last();
+      await expect(submitItem).toBeVisible();
+
+      const nameInput = submitItem.getByTestId("saved-transactions-name");
+      await expect(nameInput).toBeVisible();
+
+      await expect(nameInput).toHaveValue("Extend TTL");
+      await expect(
+        submitItem.getByText("Last saved Jan 17, 2025, 9:13 PM UTC"),
+      ).toBeVisible();
+
+      // Edit name
+      await submitItem.getByTestId("saved-transactions-edit").click();
+
+      await expect(
+        pageContext.getByText("Edit Saved Transaction", { exact: true }),
+      ).toBeVisible();
+
+      const newName = "Extend TTL New";
+
+      await pageContext.getByLabel("Name").fill(newName);
+      await pageContext.getByText("Save", { exact: true }).click();
+
+      await expect(nameInput).toHaveValue(newName);
+
+      // View in submitter
+      await submitItem.getByText("View in submitter").click();
+      await pageContext.waitForURL("**/transaction/submit");
+
+      await expect(pageContext.locator("h1")).toHaveText("Submit Transaction");
+      await expect(
+        pageContext.getByLabel("Input a base-64 encoded TransactionEnvelope:"),
+      ).toHaveValue(
+        "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAABUZAigwAAAEADYbntiznotYPblvJQ35DiGEpMTQU9jCYANxV18VVGV6zDFSjB+qK++dF656Pr4oMTpyBVvE15YSo6ITxR5DoE",
+      );
+      await expect(pageContext.getByLabel("Transaction hash")).toHaveValue(
+        "0571508f487a343006d231d11f201a855f67973e0e019da6164b32b992dab46f",
+      );
+    });
+
+    test("[Soroban] Build item", async () => {
+      const buildItem = pageContext
+        .getByTestId("saved-transactions-item")
+        .nth(2);
+
+      await expect(
+        buildItem.getByTestId("saved-transactions-name"),
+      ).toHaveValue("Extend to TTL");
+
+      const ops = buildItem.getByTestId("saved-transactions-op");
+
+      await expect(ops.nth(0)).toHaveValue("Extend Footprint TTL");
+
+      await expect(
+        buildItem.getByText("Last saved Jan 17, 2025, 7:54 PM UTC"),
+      ).toBeVisible();
+
+      // Click the button
+      await buildItem.getByText("View in builder", { exact: true }).click();
+
+      // Wait for navigation
+      await pageContext.waitForURL("**/transaction/build");
+
+      // Params
+      await expect(
+        pageContext.getByLabel("Source Account").first(),
+      ).toHaveValue("GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG");
+      await expect(
+        pageContext.getByLabel("Transaction Sequence Number"),
+      ).toHaveValue("1727208213184537");
+
+      const sorobanOperation = pageContext.getByTestId(
+        "build-soroban-transaction-operation",
+      );
+      await expect(sorobanOperation.getByLabel("Operation type")).toHaveValue(
+        "extend_footprint_ttl",
+      );
+
+      // Operations
+      await expect(
+        pageContext.getByTestId("build-soroban-transaction-operation"),
+      ).toBeVisible();
+      await expect(pageContext.getByLabel("Contract ID")).toHaveValue(
+        "CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S",
+      );
+      await expect(pageContext.getByLabel("Key ScVal in XDR")).toHaveValue(
+        "AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD",
+      );
+      await expect(pageContext.getByLabel("Extend To")).toHaveValue("30000");
+      await expect(
+        pageContext.getByLabel("Resource Fee (in stroops)"),
+      ).toHaveValue("46753");
+
+      const xdrElement = pageContext.getByTestId(
+        "build-soroban-transaction-envelope-xdr",
+      );
+
+      await xdrElement.isVisible();
+
+      // XDR
+      await expect(xdrElement.getByText("XDR").locator("+ div")).toHaveText(
+        "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAAA",
+      );
+    });
+
     test("Delete transaction", async () => {
       const txItem = pageContext.getByTestId("saved-transactions-item").first();
 
       await txItem.locator(".Button--error").click();
 
       const txItems = pageContext.getByTestId("saved-transactions-item");
-      await expect(txItems).toHaveCount(1);
+      await expect(txItems).toHaveCount(3);
     });
   });
 });

--- a/tests/savedTransactions.test.ts
+++ b/tests/savedTransactions.test.ts
@@ -73,6 +73,7 @@ test.describe("Saved Transactions Page", () => {
 
       // View in submitter
       await submitItem.getByText("View in submitter").click();
+      await pageContext.waitForURL("**/transaction/submit");
 
       await expect(pageContext.locator("h1")).toHaveText("Submit Transaction");
       await expect(
@@ -106,6 +107,7 @@ test.describe("Saved Transactions Page", () => {
       // View in builder
       await buildItem.getByText("View in builder", { exact: true }).click();
 
+      await pageContext.waitForURL("**/transaction/build");
       await expect(pageContext.locator("h1")).toHaveText("Build Transaction");
 
       // Params

--- a/tests/submitTransactionPage.test.ts
+++ b/tests/submitTransactionPage.test.ts
@@ -416,6 +416,25 @@ test.describe("Submit Transaction Page", () => {
       // Omitting the API end result because the test gives inconsistenet results
     });
   });
+
+  test.describe("Update default submit method to RPC when it is a Soroban XDR", () => {
+    test("Submit Soroban", async ({ page }) => {
+      const xdrInput = page.getByLabel(
+        "Input a base-64 encoded TransactionEnvelope",
+      );
+      const submitMethodsBtn = page
+        .locator(".SubmitTx__buttons")
+        .getByRole("button", { name: /via/i });
+
+      await expect(submitMethodsBtn).toBeVisible();
+
+      // Input the Soroban XDR
+      await xdrInput.fill(MOCK_VALID_SOROBAN_TX_XDR.XDR);
+
+      // Check if the submit method button shows RPC as default
+      await expect(submitMethodsBtn).toHaveText("via RPC");
+    });
+  });
 });
 
 const testSuccessHashAndJson = async ({
@@ -536,6 +555,12 @@ const MOCK_VALID_SUCCESS_TX_XDR_RPC = {
   XDR: "AAAAAgAAAABua+HUFN6zjqIQaw+w+xQgEmGB7deJ7fGT6bez/oKDzwAAAGQAAY/PAAAACQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAkykrlZ6vjTMpbViATGt20liShZWOSoGzFDkcPC9C5KgAAAAAAAAAAAvrwgAAAAAAAAAAB/oKDzwAAAEDo5iGuMU5bhYmLZsfb13hnwPvXnO9VwMQvuoHKcPiIB3u5aa/1zfgm/hzFYY+g66LbgkXoOKcCCvVj708iwTgJ",
   JSON: `{"tx":{2 items"tx":{7 items"source_account":"GBXGXYOUCTPLHDVCCBVQ7MH3CQQBEYMB5XLYT3PRSPU3PM76QKB47XJQ","fee":100,"seq_num":439594197712905,"cond":{1 item"time":{2 items"min_time":0,"max_time":0,},},"memo":"none","operations":[1 item{2 items"source_account":null,"body":{1 item"payment":{3 items"destination":"GASMUSXFM6V6GTGKLNLCAEY23W2JMJFBMVRZFIDMYUHEODYL2C4SVKUP","asset":"native","amount":5.0 (raw: 50000000),},},},],"ext":"v0",},"signatures":[1 item· Signatures Checked{2 items"hint":"G----------------------------------------------6QKB4----","signature":"e8e621ae314e5b85898b66c7dbd77867c0fbd79cef55c0c42fba81ca70f888077bb969aff5cdf826fe1cc5618fa0eba2db8245e838a7020af563ef4f22c13809",},],},}`,
   hash: "00cb774dce521a93438236d49f8154ede32729a595c797d51c1a72c364056fd0",
+};
+
+const MOCK_VALID_SOROBAN_TX_XDR = {
+  XDR: "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAABUZAigwAAAEADYbntiznotYPblvJQ35DiGEpMTQU9jCYANxV18VVGV6zDFSjB+qK++dF656Pr4oMTpyBVvE15YSo6ITxR5DoE",
+  JSON: `{"tx":{"tx":{"source_account":"GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG","fee":46853,"seq_num":1727208213184537,"cond":{"time":{"min_time":0,"max_time":0}},"memo":"none","operations":[{"source_account":null,"body":{"extend_footprint_ttl":{"ext":"v0","extend_to":30000}}}],"ext":{"v1":{"ext":"v0","resources":{"footprint":{"read_only":[{"contract_data":{"contract":"CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S","key":{"vec":[{"symbol":"Counter"},{"address":"GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG"}]},"durability":"persistent"}}],"read_write":[]},"instructions":0,"read_bytes":0,"write_bytes":0},"resource_fee":46753}}},"signatures":[{"hint":"51902283","signature":"0361b9ed8b39e8b583db96f250df90e2184a4c4d053d8c2600371575f1554657acc31528c1faa2bef9d17ae7a3ebe28313a72055bc4d79612a3a213c51e43a04"}]}}`,
+  hash: "0571508f487a343006d231d11f201a855f67973e0e019da6164b32b992dab46f",
 };
 
 const MOCK_VALID_TX_SUCCESS_HORIZON_RESPONSE = {

--- a/tests/urlParams.test.ts
+++ b/tests/urlParams.test.ts
@@ -36,9 +36,9 @@ test.describe("URL Params", () => {
   });
 
   test.describe("Transactions", () => {
-    test("Build Transaction", async ({ page }) => {
+    test("[Classic] Build Transaction", async ({ page }) => {
       await page.goto(
-        "http://localhost:3000/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$params$source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&fee=2000&seq_num=3668692344766465&cond$time$max_time=1733409768;;&memo$text=123;;&operations@$operation_type=create_account&params$destination=GC5TQ7TXKHGE5JQMZPYV5KBSQ67X6PYQVU5QN7JRGWCHRA227UFPZ6LD&starting_balance=3000;&source_account=;&$operation_type=payment&params$destination=GAJAIHPKNTJ362TAUWTU2S56B7PULRTMY456LUELK53USX43537IFMS3&asset$code=USDC&issuer=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&type=credit_alphanum4;&amount=4000;&source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG;;&isValid$params:true&operations:true;;",
+        "http://localhost:3000/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=create_account&params$destination=GC5TQ7TXKHGE5JQMZPYV5KBSQ67X6PYQVU5QN7JRGWCHRA227UFPZ6LD&starting_balance=3000;&source_account=;&$operation_type=payment&params$destination=GAJAIHPKNTJ362TAUWTU2S56B7PULRTMY456LUELK53USX43537IFMS3&asset$code=USDC&issuer=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&type=credit_alphanum4;&amount=4000;&source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG;;;&params$source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&fee=2000&seq_num=3668692344766465&cond$time$max_time=1733409768;;&memo$text=123;;&isValid$params:true&operations:true;;",
       );
 
       await expect(page.locator("h1")).toHaveText("Build Transaction");
@@ -111,7 +111,7 @@ test.describe("URL Params", () => {
       );
     });
 
-    test("Sign Transaction", async ({ page }) => {
+    test("[Classic] Sign Transaction", async ({ page }) => {
       await page.goto(
         "http://localhost:3000/transaction/sign?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$sign$activeView=overview&importXdr=AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq//5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79//PxCtOwb9MTWEeINa//Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V//N4s9eMsMt2mWr//kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO//amClp01Lvg//fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+//7BkrIVo//G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==;;",
       );
@@ -143,7 +143,7 @@ test.describe("URL Params", () => {
       );
     });
 
-    test("Submit Transaction", async ({ page }) => {
+    test("[Classic] Submit Transaction", async ({ page }) => {
       await page.goto(
         "http://localhost:3000/transaction/submit?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq//5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79//PxCtOwb9MTWEeINa//Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V//N4s9eMsMt2mWr//kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO//amClp01Lvg//fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+//7BkrIVo//G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==;;",
       );
@@ -157,6 +157,67 @@ test.describe("URL Params", () => {
       );
       await expect(page.getByLabel("Transaction hash")).toHaveValue(
         "44abaabac11c318d595d392c24166965301b48109899bc8e819723afb89d5e37",
+      );
+    });
+
+    test("[Soroban] Build Transaction", async ({ page }) => {
+      await page.goto(
+        "http://localhost:3000/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=payment&params$destination=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&asset$code=&issuer=&type=native;&amount=5;&source_account=;;;&soroban$operation$operation_type=extend_footprint_ttl&params$durability=persistent&contract=CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S&key_xdr=AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD&extend_ttl_to=20000&resource_fee=46753;;;&params$source_account=GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG&seq_num=1727208213184538&cond$time$min_time=1733409768;;&memo$text=100;;&isValid$params:true&operations:true;;",
+      );
+
+      await expect(page.locator("h1")).toHaveText("Build Transaction");
+
+      // Params
+      await expect(
+        page.getByLabel("Source Account", { exact: true }),
+      ).toHaveValue("GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG");
+      await expect(page.getByLabel("Transaction Sequence Number")).toHaveValue(
+        "1727208213184538",
+      );
+      await expect(page.getByLabel("Base Fee")).toHaveValue("100");
+
+      await expect(page.locator("#text-memo")).toBeChecked();
+      await expect(page.locator("#memo_value")).toHaveValue("100");
+
+      await expect(
+        page.getByPlaceholder(
+          "Lower time bound unix timestamp. Ex: 1479151713",
+        ),
+      ).toHaveValue("1733409768");
+      await expect(
+        page.getByPlaceholder(
+          "Upper time bound unix timestamp. Ex: 1479151713",
+        ),
+      ).toHaveValue("");
+
+      // Only One Operation Allowed in Soroban
+      const sorobanOp = page.getByTestId("build-soroban-transaction-operation");
+
+      await expect(sorobanOp.getByLabel("Operation Type")).toHaveValue(
+        "extend_footprint_ttl",
+      );
+      await expect(sorobanOp.getByLabel("Contract ID")).toHaveValue(
+        "CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S",
+      );
+      await expect(sorobanOp.getByLabel("Extend To")).toHaveValue("20000");
+      await expect(sorobanOp.getByLabel("Durability")).toHaveValue(
+        "persistent",
+      );
+      await expect(sorobanOp.getByLabel("Resource Fee")).toHaveValue("46753");
+
+      // Validation
+      const txnSuccess = page.getByTestId(
+        "build-soroban-transaction-envelope-xdr",
+      );
+
+      await expect(
+        txnSuccess.getByText("Network Passphrase").locator("+ div"),
+      ).toHaveText("Test SDF Network ; September 2015");
+      await expect(txnSuccess.getByText("Hash").locator("+ div")).toHaveText(
+        "d8c7f3dee39f14373e2f1a1131bcc91a49694b6af6b6d81b7703784b3a51bc94",
+      );
+      await expect(txnSuccess.getByText("XDR").locator("+ div")).toHaveText(
+        "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGgAAAAEAAAAAZ1G76AAAAAAAAAAAAAAAAQAAAAMxMDAAAAAAAQAAAAAAAAAZAAAAAAAATiAAAAABAAAAAAAAAAEAAAAGAAAAASD+7zozM+tVyk2uwVRrzhPzYqyzwMsAT1kzEuqEzbYfAAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKDAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2oQAAAAA=",
       );
     });
 


### PR DESCRIPTION
**Add Soroban Operation - Extend TTL**

includes:
- displaying only one operation when soroban operation is selected
- add a `fetch minimum resource fee` button that simulates tx and calculates the resource fee
- it follows how cli is operating using `key-xdr` ([cli doc](url)) (as recommended by dima)
- I used auth soroban example to invoke a contract and use stellat js sdk to get the key xdr ([example](https://github.com/ElliotFriend/ye-olde-guestbook/blob/main/src/lib/server/getLedgerEntries.ts#L45))
- On sign transaction, method dropdown to auto select `rpc` if it's a soroban tx
- separate the soroban logic from classic in `Operation`
- `createStore` to include a separate soroban object that stores `xdr` and `params`
- added tests
- Updated `saved` page