### PR TITLE
 Contract Explorer: Contract storage filters

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractStorage.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractStorage.tsx
@@ -12,7 +12,11 @@ import { capitalizeString } from "@/helpers/capitalizeString";
 
 import { useIsXdrInit } from "@/hooks/useIsXdrInit";
 
-import { ContractStorageResponseItem, NetworkType } from "@/types/types";
+import {
+  ContractStorageProcessedItem,
+  ContractStorageResponseItem,
+  NetworkType,
+} from "@/types/types";
 
 export const ContractStorage = ({
   isActive,
@@ -71,18 +75,28 @@ export const ContractStorage = ({
         { id: "ttl", value: "TTL", isSortable: true },
         { id: "updated", value: "Updated", isSortable: true },
       ]}
-      formatDataRow={(vh: ContractStorageResponseItem) => [
+      formatDataRow={(
+        vh: ContractStorageProcessedItem<ContractStorageResponseItem>,
+      ) => [
         {
           value: (
             <div className="CodeBox">
-              <ScValPrettyJson xdrString={vh.key} isReady={isXdrInit} />
+              <ScValPrettyJson
+                xdrString={vh.key}
+                json={vh.keyJson}
+                isReady={isXdrInit}
+              />
             </div>
           ),
         },
         {
           value: (
             <div className="CodeBox">
-              <ScValPrettyJson xdrString={vh.value} isReady={isXdrInit} />
+              <ScValPrettyJson
+                xdrString={vh.value}
+                json={vh.valueJson}
+                isReady={isXdrInit}
+              />
             </div>
           ),
         },

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -198,7 +198,7 @@ export const DataTable = <T extends AnyObject>({
 
                 return (
                   <div key={id} className="DataTable__filterDropdown__filter">
-                    <Label size="lg" htmlFor={id}>
+                    <Label size="lg" htmlFor={id} title={f}>
                       {f}
                     </Label>
                     <Checkbox
@@ -237,7 +237,9 @@ export const DataTable = <T extends AnyObject>({
                 onClick={() => {
                   setSelectedFilters({ ...selectedFilters, [headerId]: [] });
                   setAppliedFilters({ ...appliedFilters, [headerId]: [] });
+
                   setVisibleFilters(undefined);
+                  setCurrentPage(1);
                 }}
                 disabled={appliedFilters[headerId].length === 0}
               >
@@ -249,7 +251,9 @@ export const DataTable = <T extends AnyObject>({
                 variant="secondary"
                 onClick={() => {
                   setAppliedFilters(selectedFilters);
+
                   setVisibleFilters(undefined);
+                  setCurrentPage(1);
                 }}
                 disabled={isFilterApplyDisabled(headerId)}
               >
@@ -287,6 +291,8 @@ export const DataTable = <T extends AnyObject>({
                   // Update both selected and applied filters
                   setSelectedFilters(updatedFilters);
                   setAppliedFilters(updatedFilters);
+
+                  setCurrentPage(1);
                 }}
               >
                 <Icon.XClose />

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -10,7 +10,13 @@ import {
 
 import { Box } from "@/components/layout/Box";
 import { Dropdown } from "@/components/Dropdown";
+
 import { processContractStorageData } from "@/helpers/processContractStorageData";
+import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
+import { isEmptyObject } from "@/helpers/isEmptyObject";
+
+import { getPublicKeyError } from "@/validate/methods/getPublicKeyError";
+import { getContractIdError } from "@/validate/methods/getContractIdError";
 
 import {
   AnyObject,
@@ -191,7 +197,7 @@ export const DataTable = <T extends AnyObject>({
         >
           <div className="DataTable__filterDropdown__container">
             <div className="DataTable__filterDropdown__title">Filter by</div>
-            <>
+            <div className="DataTable__filterDropdown__filterContainer">
               {filters.map((f, idx) => {
                 const id = `filter-${headerId}-${f}-${idx}`;
                 let currentFilters = selectedFilters[headerId] || [];
@@ -223,7 +229,7 @@ export const DataTable = <T extends AnyObject>({
                   </div>
                 );
               })}
-            </>
+            </div>
             <Box
               gap="sm"
               direction="row"
@@ -268,6 +274,18 @@ export const DataTable = <T extends AnyObject>({
     return null;
   };
 
+  const renderFilterBadgeLabel = (label: string) => {
+    const isValidPubKey = !getPublicKeyError(label);
+    const isValidContractId = !getContractIdError(label);
+
+    // Stellar public key or contract ID
+    if (isValidPubKey || isValidContractId) {
+      return shortenStellarAddress(label);
+    }
+
+    return label;
+  };
+
   const renderFilterBadges = () => {
     return Object.entries(appliedFilters).map((af, afIdx) => {
       const [id, filters] = af;
@@ -279,7 +297,7 @@ export const DataTable = <T extends AnyObject>({
               key={`badge-${id}-${afIdx}-${f}-${fIdx}`}
               className="DataTable__badge Badge Badge--secondary Badge--sm"
             >
-              {f}
+              {renderFilterBadgeLabel(f)}
 
               <div
                 role="button"
@@ -304,6 +322,23 @@ export const DataTable = <T extends AnyObject>({
     });
   };
 
+  const renderFilteredResultCount = () => {
+    // No filters applied
+    if (isEmptyObject(appliedFilters)) {
+      return null;
+    }
+
+    const resultCount = processedData.length;
+
+    if (resultCount === 0) {
+      return null;
+    }
+
+    return (
+      <div className="DataTable__filteredResultCount">{`${resultCount} filtered ${resultCount === 1 ? "results" : "results"}`}</div>
+    );
+  };
+
   const customStyle = {
     "--DataTable-grid-template-columns": cssGridTemplateColumns,
   } as React.CSSProperties;
@@ -313,7 +348,7 @@ export const DataTable = <T extends AnyObject>({
   return (
     <Box gap="md">
       <Box gap="sm" direction="row" align="center" justify="space-between">
-        <Box gap="sm" direction="row" align="center">
+        <Box gap="sm" direction="row" align="center" wrap="wrap">
           {/* Applied filter badges */}
           {renderFilterBadges()}
         </Box>
@@ -387,54 +422,66 @@ export const DataTable = <T extends AnyObject>({
         </div>
       </Card>
 
-      <Box gap="lg" direction="row" align="center" justify="space-between">
+      <Box
+        gap="lg"
+        direction="row"
+        align="center"
+        justify="space-between"
+        wrap="wrap"
+      >
         <div>{customFooterEl || null}</div>
 
         {/* Pagination */}
-        <Box gap="xs" direction="row" align="center">
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => {
-              setCurrentPage(1);
-            }}
-            disabled={currentPage === 1}
-          >
-            First
-          </Button>
+        <Box gap="md" direction="row" align="center" wrap="wrap">
+          <Box gap="xs" direction="row" align="center">
+            <>{renderFilteredResultCount()}</>
+          </Box>
 
-          <Button
-            variant="tertiary"
-            size="sm"
-            icon={<Icon.ArrowLeft />}
-            onClick={() => {
-              setCurrentPage(currentPage - 1);
-            }}
-            disabled={currentPage === 1}
-          ></Button>
+          <Box gap="xs" direction="row" align="center">
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={() => {
+                setCurrentPage(1);
+              }}
+              disabled={currentPage === 1}
+            >
+              First
+            </Button>
 
-          <div className="DataTable__pagination">{`Page ${currentPage} of ${totalPageCount}`}</div>
+            <Button
+              variant="tertiary"
+              size="sm"
+              icon={<Icon.ArrowLeft />}
+              onClick={() => {
+                setCurrentPage(currentPage - 1);
+              }}
+              disabled={currentPage === 1}
+            ></Button>
 
-          <Button
-            variant="tertiary"
-            size="sm"
-            icon={<Icon.ArrowRight />}
-            onClick={() => {
-              setCurrentPage(currentPage + 1);
-            }}
-            disabled={currentPage === totalPageCount}
-          ></Button>
+            <div className="DataTable__pagination">{`Page ${currentPage} of ${totalPageCount}`}</div>
 
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => {
-              setCurrentPage(totalPageCount);
-            }}
-            disabled={currentPage === totalPageCount}
-          >
-            Last
-          </Button>
+            <Button
+              variant="tertiary"
+              size="sm"
+              icon={<Icon.ArrowRight />}
+              onClick={() => {
+                setCurrentPage(currentPage + 1);
+              }}
+              disabled={currentPage === totalPageCount}
+            ></Button>
+
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={() => {
+                setCurrentPage(totalPageCount);
+              }}
+              disabled={currentPage === totalPageCount}
+            >
+              Last
+            </Button>
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useState } from "react";
-import { Button, Card, Icon, Loader } from "@stellar/design-system";
+import {
+  Button,
+  Card,
+  Checkbox,
+  Icon,
+  Label,
+  Loader,
+} from "@stellar/design-system";
+
 import { Box } from "@/components/layout/Box";
+import { Dropdown } from "@/components/Dropdown";
 import { processContractStorageData } from "@/helpers/processContractStorageData";
+
 import {
   AnyObject,
   ContractStorageProcessedItem,
@@ -28,7 +38,6 @@ export const DataTable = <T extends AnyObject>({
   customFooterEl?: React.ReactNode;
 }) => {
   const PAGE_SIZE = 20;
-  const tableDataSize = tableData.length;
 
   // Data
   const [processedData, setProcessedData] = useState<
@@ -40,6 +49,20 @@ export const DataTable = <T extends AnyObject>({
   const [sortById, setSortById] = useState("");
   const [sortByDir, setSortByDir] = useState<SortDirection>("default");
 
+  // Filters
+  type FilterCols = "key" | "value";
+  type DataFilters = { [key: string]: string[] };
+
+  const INIT_FILTERS = { key: [], value: [] };
+
+  const [visibleFilters, setVisibleFilters] = useState<FilterCols | undefined>(
+    undefined,
+  );
+  const [selectedFilters, setSelectedFilters] =
+    useState<DataFilters>(INIT_FILTERS);
+  const [appliedFilters, setAppliedFilters] =
+    useState<DataFilters>(INIT_FILTERS);
+
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPageCount, setTotalPageCount] = useState(1);
@@ -49,25 +72,30 @@ export const DataTable = <T extends AnyObject>({
       data: tableData,
       sortById,
       sortByDir,
+      filters: appliedFilters,
     });
 
     setProcessedData(data);
-  }, [tableData, sortByDir, sortById]);
-
-  useEffect(() => {
-    setTotalPageCount(Math.ceil(tableDataSize / PAGE_SIZE));
-  }, [tableDataSize]);
+  }, [tableData, sortByDir, sortById, appliedFilters]);
 
   // Hide loader when processed data is done
   useEffect(() => {
     setIsUpdating(false);
+    setTotalPageCount(Math.ceil(processedData.length / PAGE_SIZE));
   }, [processedData]);
 
-  const getSortByProps = (th: DataTableHeader) => {
+  const getCustomProps = (th: DataTableHeader) => {
     if (th.isSortable) {
       return {
         "data-sortby-dir": sortById === th.id ? sortByDir : "default",
         onClick: () => handleSort(th.id),
+      };
+    }
+
+    if (th.filter && th.filter.length > 0) {
+      return {
+        "data-filter": "true",
+        onClick: () => toggleFilterDropdown(th.id as FilterCols),
       };
     }
 
@@ -98,6 +126,10 @@ export const DataTable = <T extends AnyObject>({
     setIsUpdating(true);
   };
 
+  const toggleFilterDropdown = (headerId: FilterCols) => {
+    setVisibleFilters(visibleFilters === headerId ? undefined : headerId);
+  };
+
   const paginateData = (data: DataTableCell[][]): DataTableCell[][] => {
     if (!data || data.length === 0) {
       return [];
@@ -109,6 +141,148 @@ export const DataTable = <T extends AnyObject>({
     return data.slice(startIndex, endIndex);
   };
 
+  const isFilterApplyDisabled = (headerId: string) => {
+    const selected = selectedFilters[headerId];
+    const applied = appliedFilters[headerId];
+
+    // Both filters are empty
+    if (selected.length === 0 && applied.length === 0) {
+      return true;
+    }
+
+    // Different array sizes
+    if (selected.length !== applied.length) {
+      return false;
+    }
+
+    // The array sizes are equal, need to check if items are the same
+    return (
+      selected.reduce((res: string[], cur) => {
+        if (!applied.includes(cur)) {
+          return [...res, cur];
+        }
+
+        return res;
+      }, []).length === 0
+    );
+  };
+
+  const renderFilterDropdown = (
+    headerId: string,
+    filters: string[] | undefined,
+  ) => {
+    if (filters && filters.length > 0) {
+      return (
+        <Dropdown
+          addlClassName="DataTable__filterDropdown"
+          isDropdownVisible={visibleFilters === headerId}
+          onClose={() => {
+            setVisibleFilters(undefined);
+          }}
+          triggerDataAttribute="filter"
+        >
+          <div className="DataTable__filterDropdown__container">
+            <div className="DataTable__filterDropdown__title">Filter by</div>
+            <div>
+              {filters.map((f) => {
+                const id = `filter-${headerId}-${f}`;
+                let currentFilters = selectedFilters[headerId] || [];
+
+                return (
+                  <div key={id} className="DataTable__filterDropdown__filter">
+                    <Label size="sm" htmlFor={id}>
+                      {f}
+                    </Label>
+                    <Checkbox
+                      id={id}
+                      fieldSize="sm"
+                      onChange={() => {
+                        if (currentFilters.includes(f)) {
+                          currentFilters = currentFilters.filter(
+                            (c) => c !== f,
+                          );
+                        } else {
+                          currentFilters = [...currentFilters, f];
+                        }
+
+                        setSelectedFilters({
+                          ...selectedFilters,
+                          [headerId]: currentFilters,
+                        });
+                      }}
+                      checked={currentFilters.includes(f)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <div>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  setAppliedFilters(selectedFilters);
+                  setVisibleFilters(undefined);
+                }}
+                disabled={isFilterApplyDisabled(headerId)}
+              >
+                Apply
+              </Button>
+              <Button
+                size="sm"
+                variant="error"
+                onClick={() => {
+                  setSelectedFilters({ ...selectedFilters, [headerId]: [] });
+                  setAppliedFilters({ ...appliedFilters, [headerId]: [] });
+                  setVisibleFilters(undefined);
+                }}
+                disabled={appliedFilters[headerId].length === 0}
+              >
+                Clear filter
+              </Button>
+            </div>
+          </div>
+        </Dropdown>
+      );
+    }
+
+    return null;
+  };
+
+  const renderFilterBadges = () => {
+    return Object.entries(appliedFilters).map((af) => {
+      const [id, filters] = af;
+
+      return (
+        <>
+          {filters.map((f) => (
+            <div
+              key={`badge-${id}-${f}`}
+              className="DataTable__badge Badge Badge--secondary Badge--sm"
+            >
+              {f}
+
+              <div
+                role="button"
+                className="DataTable__badge__button"
+                onClick={() => {
+                  const idFilters = appliedFilters[id].filter((c) => c !== f);
+                  const updatedFilters = { ...appliedFilters, [id]: idFilters };
+
+                  // Update both selected and applied filters
+                  setSelectedFilters(updatedFilters);
+                  setAppliedFilters(updatedFilters);
+                }}
+              >
+                <Icon.XClose />
+              </div>
+            </div>
+          ))}
+        </>
+      );
+    });
+  };
+
   const customStyle = {
     "--DataTable-grid-template-columns": cssGridTemplateColumns,
   } as React.CSSProperties;
@@ -117,6 +291,13 @@ export const DataTable = <T extends AnyObject>({
 
   return (
     <Box gap="md">
+      <Box gap="sm" direction="row" align="center" justify="space-between">
+        <Box gap="sm" direction="row" align="center">
+          {/* Applied filter badges */}
+          {renderFilterBadges()}
+        </Box>
+      </Box>
+
       {/* Table */}
       <Card noPadding={true}>
         <div className="DataTable__container">
@@ -131,14 +312,27 @@ export const DataTable = <T extends AnyObject>({
               <thead>
                 <tr data-style="row" role="row">
                   {tableHeaders.map((th) => (
-                    <th key={th.id} role="cell" {...getSortByProps(th)}>
-                      {th.value}
-                      {th.isSortable ? (
-                        <span className="DataTable__sortBy">
-                          <Icon.ChevronUp />
-                          <Icon.ChevronDown />
-                        </span>
-                      ) : null}
+                    <th key={`col-${th.id}`} role="cell">
+                      <div {...getCustomProps(th)}>
+                        {th.value}
+
+                        {/* Sort icon */}
+                        {th.isSortable ? (
+                          <span className="DataTable__sortBy">
+                            <Icon.ChevronUp />
+                            <Icon.ChevronDown />
+                          </span>
+                        ) : null}
+
+                        {/* Filter icon */}
+                        {th.filter ? (
+                          <span className="DataTable__filter">
+                            <Icon.FilterFunnel01 />
+                          </span>
+                        ) : null}
+                      </div>
+
+                      {renderFilterDropdown(th.id, th.filter)}
                     </th>
                   ))}
                 </tr>

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import {
   Button,
   Card,
@@ -126,8 +126,18 @@ export const DataTable = <T extends AnyObject>({
     setIsUpdating(true);
   };
 
+  const closeFilterDropdown = () => {
+    setVisibleFilters(undefined);
+    // Clear selections that weren't applied
+    setSelectedFilters({ ...appliedFilters });
+  };
+
   const toggleFilterDropdown = (headerId: FilterCols) => {
-    setVisibleFilters(visibleFilters === headerId ? undefined : headerId);
+    if (visibleFilters === headerId) {
+      closeFilterDropdown();
+    } else {
+      setVisibleFilters(headerId);
+    }
   };
 
   const paginateData = (data: DataTableCell[][]): DataTableCell[][] => {
@@ -176,21 +186,19 @@ export const DataTable = <T extends AnyObject>({
         <Dropdown
           addlClassName="DataTable__filterDropdown"
           isDropdownVisible={visibleFilters === headerId}
-          onClose={() => {
-            setVisibleFilters(undefined);
-          }}
+          onClose={closeFilterDropdown}
           triggerDataAttribute="filter"
         >
           <div className="DataTable__filterDropdown__container">
             <div className="DataTable__filterDropdown__title">Filter by</div>
-            <div>
-              {filters.map((f) => {
-                const id = `filter-${headerId}-${f}`;
+            <>
+              {filters.map((f, idx) => {
+                const id = `filter-${headerId}-${f}-${idx}`;
                 let currentFilters = selectedFilters[headerId] || [];
 
                 return (
                   <div key={id} className="DataTable__filterDropdown__filter">
-                    <Label size="sm" htmlFor={id}>
+                    <Label size="lg" htmlFor={id}>
                       {f}
                     </Label>
                     <Checkbox
@@ -215,19 +223,14 @@ export const DataTable = <T extends AnyObject>({
                   </div>
                 );
               })}
-            </div>
-            <div>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => {
-                  setAppliedFilters(selectedFilters);
-                  setVisibleFilters(undefined);
-                }}
-                disabled={isFilterApplyDisabled(headerId)}
-              >
-                Apply
-              </Button>
+            </>
+            <Box
+              gap="sm"
+              direction="row"
+              align="center"
+              justify="space-between"
+              addlClassName="DataTable__filterDropdown__buttons"
+            >
               <Button
                 size="sm"
                 variant="error"
@@ -240,7 +243,19 @@ export const DataTable = <T extends AnyObject>({
               >
                 Clear filter
               </Button>
-            </div>
+
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  setAppliedFilters(selectedFilters);
+                  setVisibleFilters(undefined);
+                }}
+                disabled={isFilterApplyDisabled(headerId)}
+              >
+                Apply
+              </Button>
+            </Box>
           </div>
         </Dropdown>
       );
@@ -250,14 +265,14 @@ export const DataTable = <T extends AnyObject>({
   };
 
   const renderFilterBadges = () => {
-    return Object.entries(appliedFilters).map((af) => {
+    return Object.entries(appliedFilters).map((af, afIdx) => {
       const [id, filters] = af;
 
       return (
-        <>
-          {filters.map((f) => (
+        <Fragment key={`badge-${id}-${afIdx}`}>
+          {filters.map((f, fIdx) => (
             <div
-              key={`badge-${id}-${f}`}
+              key={`badge-${id}-${afIdx}-${f}-${fIdx}`}
               className="DataTable__badge Badge Badge--secondary Badge--sm"
             >
               {f}
@@ -278,7 +293,7 @@ export const DataTable = <T extends AnyObject>({
               </div>
             </div>
           ))}
-        </>
+        </Fragment>
       );
     });
   };
@@ -311,8 +326,8 @@ export const DataTable = <T extends AnyObject>({
             >
               <thead>
                 <tr data-style="row" role="row">
-                  {tableHeaders.map((th) => (
-                    <th key={`col-${th.id}`} role="cell">
+                  {tableHeaders.map((th, idx) => (
+                    <th key={`col-${idx}-${th.id}`} role="cell">
                       <div {...getCustomProps(th)}>
                         {th.value}
 

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -346,7 +346,7 @@ export const DataTable = <T extends AnyObject>({
                         ) : null}
 
                         {/* Filter icon */}
-                        {th.filter ? (
+                        {th.filter?.length ? (
                           <span className="DataTable__filter">
                             <Icon.FilterFunnel01 />
                           </span>

--- a/src/components/DataTable/styles.scss
+++ b/src/components/DataTable/styles.scss
@@ -7,6 +7,13 @@
     width: 100%;
     position: relative;
     overflow: hidden;
+
+    & > .Loader {
+      position: absolute;
+      top: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+    }
   }
 
   &__scroll {
@@ -19,6 +26,7 @@
     text-align: left;
     font-weight: var(--sds-fw-medium);
     color: var(--sds-clr-gray-11);
+    transition: opacity var(--sds-anim-transition-default);
 
     tr[data-style="row"] {
       display: grid;
@@ -70,6 +78,10 @@
     tr:not(:last-child),
     thead tr {
       border-bottom: 1px solid var(--sds-clr-gray-06);
+    }
+
+    &[data-disabled="true"] {
+      opacity: 0.5;
     }
   }
 

--- a/src/components/DataTable/styles.scss
+++ b/src/components/DataTable/styles.scss
@@ -159,6 +159,7 @@
       flex-direction: row;
       align-items: center;
       justify-content: space-between;
+      gap: pxToRem(8px);
       padding: pxToRem(6px) pxToRem(8px);
       background-color: transparent;
       transition: background-color var(--sds-anim-transition-default);
@@ -167,12 +168,17 @@
 
       .Label__wrapper {
         width: 100%;
+        overflow: hidden;
       }
 
       .Label {
         color: var(--sds-clr-gray-12);
         width: 100%;
         cursor: pointer;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
       }
 
       @media (hover: hover) {

--- a/src/components/DataTable/styles.scss
+++ b/src/components/DataTable/styles.scss
@@ -140,14 +140,56 @@
     top: 85%;
     left: pxToRem(4px);
 
-    // TODO: style
     &__container {
+      display: flex;
+      flex-direction: column;
+      gap: pxToRem(4px);
     }
 
     &__title {
+      font-size: pxToRem(14px);
+      line-height: pxToRem(20px);
+      font-weight: var(--sds-fw-medium);
+      color: var(--sds-clr-gray-11);
+      padding: pxToRem(6px) pxToRem(8px);
     }
 
     &__filter {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      padding: pxToRem(6px) pxToRem(8px);
+      background-color: transparent;
+      transition: background-color var(--sds-anim-transition-default);
+      border-radius: pxToRem(4px);
+      cursor: pointer;
+
+      .Label__wrapper {
+        width: 100%;
+      }
+
+      .Label {
+        color: var(--sds-clr-gray-12);
+        width: 100%;
+        cursor: pointer;
+      }
+
+      @media (hover: hover) {
+        &:hover {
+          background-color: var(--sds-clr-gray-04);
+        }
+      }
+
+      &:has(input[type="checkbox"]:checked) {
+        background-color: var(--sds-clr-gray-04);
+      }
+    }
+
+    &__buttons {
+      .Button {
+        flex: 1;
+      }
     }
   }
 

--- a/src/components/DataTable/styles.scss
+++ b/src/components/DataTable/styles.scss
@@ -45,23 +45,33 @@
       font-size: pxToRem(12px);
       line-height: pxToRem(18px);
       min-width: 100px;
+      position: relative;
+      overflow: visible;
 
-      &[data-sortby-dir] {
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        gap: pxToRem(4px);
-      }
-
-      &[data-sortby-dir="asc"] {
-        .DataTable__sortBy svg:first-of-type {
-          stroke: var(--sds-clr-gray-12);
+      & > div {
+        &[data-sortby-dir],
+        &[data-filter] {
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          gap: pxToRem(4px);
+          position: relative;
         }
-      }
 
-      &[data-sortby-dir="desc"] {
-        .DataTable__sortBy svg:last-of-type {
-          stroke: var(--sds-clr-gray-12);
+        &[data-filter] {
+          overflow: visible;
+        }
+
+        &[data-sortby-dir="asc"] {
+          .DataTable__sortBy svg:first-of-type {
+            stroke: var(--sds-clr-gray-12);
+          }
+        }
+
+        &[data-sortby-dir="desc"] {
+          .DataTable__sortBy svg:last-of-type {
+            stroke: var(--sds-clr-gray-12);
+          }
         }
       }
     }
@@ -85,11 +95,15 @@
     }
   }
 
-  &__sortBy {
+  &__sortBy,
+  &__filter {
     display: block;
     position: relative;
     width: pxToRem(12px);
     height: pxToRem(12px);
+  }
+
+  &__sortBy {
     overflow: hidden;
 
     svg {
@@ -118,5 +132,46 @@
     line-height: pxToRem(18px);
     font-weight: var(--sds-fw-semi-bold);
     color: var(--sds-clr-gray-12);
+  }
+
+  &__filterDropdown {
+    position: absolute;
+    width: calc(100% - 0.6rem);
+    top: 85%;
+    left: pxToRem(4px);
+
+    // TODO: style
+    &__container {
+    }
+
+    &__title {
+    }
+
+    &__filter {
+    }
+  }
+
+  &__badge {
+    &__button {
+      cursor: pointer;
+      width: pxToRem(12px);
+      height: pxToRem(12px);
+
+      svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+        stroke: var(--sds-clr-lilac-11);
+        transition: stroke var(--sds-anim-transition-default);
+      }
+
+      @media (hover: hover) {
+        &:hover {
+          svg {
+            stroke: var(--sds-clr-lilac-12);
+          }
+        }
+      }
+    }
   }
 }

--- a/src/components/DataTable/styles.scss
+++ b/src/components/DataTable/styles.scss
@@ -18,6 +18,11 @@
 
   &__scroll {
     overflow-x: auto;
+
+    // Set min-height to make sure filter dropdown will fit
+    &:has(.DataTable__filter) {
+      min-height: pxToRem(400px);
+    }
   }
 
   &__table {
@@ -132,6 +137,14 @@
     line-height: pxToRem(18px);
     font-weight: var(--sds-fw-semi-bold);
     color: var(--sds-clr-gray-12);
+    flex-shrink: 0;
+  }
+
+  &__filteredResultCount {
+    font-size: pxToRem(12px);
+    line-height: pxToRem(18px);
+    font-weight: var(--sds-fw-semi-bold);
+    color: var(--sds-clr-gray-09);
   }
 
   &__filterDropdown {
@@ -152,6 +165,11 @@
       font-weight: var(--sds-fw-medium);
       color: var(--sds-clr-gray-11);
       padding: pxToRem(6px) pxToRem(8px);
+    }
+
+    &__filterContainer {
+      max-height: pxToRem(250px);
+      overflow-x: auto;
     }
 
     &__filter {

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,0 +1,103 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { delayedAction } from "@/helpers/delayedAction";
+
+import "./styles.scss";
+
+type DropdownProps = {
+  children: React.ReactNode;
+  isDropdownVisible: boolean;
+  onClose: () => void;
+  // [data-] attribute must be set on the trigger element
+  triggerDataAttribute: string;
+  addlClassName?: string;
+  testId?: string;
+};
+
+export const Dropdown = ({
+  children,
+  isDropdownVisible,
+  onClose,
+  triggerDataAttribute,
+  addlClassName,
+  testId,
+}: DropdownProps) => {
+  const [isActive, setIsActive] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  const toggleDropdown = useCallback((show: boolean) => {
+    const delay = 100;
+
+    if (show) {
+      setIsActive(true);
+      delayedAction({
+        action: () => {
+          setIsVisible(true);
+        },
+        delay,
+      });
+    } else {
+      setIsVisible(false);
+      delayedAction({
+        action: () => {
+          setIsActive(false);
+        },
+        delay,
+      });
+    }
+  }, []);
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      // Ignore the dropdown
+      if (dropdownRef?.current?.contains(event.target as Node)) {
+        return;
+      }
+
+      // Ingnore the trigger element
+      if ((event.target as any).dataset?.[triggerDataAttribute]) {
+        return;
+      }
+
+      onClose();
+    },
+    [onClose, triggerDataAttribute],
+  );
+
+  // Update internal state when visible state changes from outside
+  useEffect(() => {
+    toggleDropdown(isDropdownVisible);
+  }, [isDropdownVisible, toggleDropdown]);
+
+  // Close dropdown when clicked outside
+  useLayoutEffect(() => {
+    if (isVisible) {
+      document.addEventListener("pointerup", handleClickOutside);
+    } else {
+      document.removeEventListener("pointerup", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("pointerup", handleClickOutside);
+    };
+  }, [isVisible, handleClickOutside]);
+
+  return (
+    <div
+      className={`Dropdown Floater__content Floater__content--light ${addlClassName || ""}`}
+      data-is-active={isActive}
+      data-is-visible={isVisible}
+      ref={dropdownRef}
+      data-testid={testId}
+    >
+      <div className="Dropdown__body">{children}</div>
+    </div>
+  );
+};

--- a/src/components/Dropdown/styles.scss
+++ b/src/components/Dropdown/styles.scss
@@ -1,0 +1,20 @@
+@use "../../styles/utils.scss" as *;
+
+.Dropdown {
+  z-index: 2;
+  transform: none;
+  display: none;
+  opacity: 0;
+
+  &[data-is-active="true"] {
+    display: block;
+  }
+
+  &[data-is-visible="true"] {
+    opacity: 1;
+  }
+
+  &__body {
+    padding: pxToRem(4px);
+  }
+}

--- a/src/components/ScValPrettyJson/index.tsx
+++ b/src/components/ScValPrettyJson/index.tsx
@@ -17,11 +17,13 @@ import "./styles.scss";
 
 /* Create contract storage JSON-like structure */
 export const ScValPrettyJson = ({
-  xdrString,
   isReady,
+  xdrString,
+  json,
 }: {
-  xdrString: string;
   isReady: boolean;
+  xdrString?: string;
+  json?: AnyObject | null;
 }) => {
   const { network } = useStore();
 
@@ -31,7 +33,9 @@ export const ScValPrettyJson = ({
 
   const parseJson = () => {
     try {
-      return parse(StellarXdr.decode("ScVal", xdrString)) as AnyObject;
+      return xdrString
+        ? (parse(StellarXdr.decode("ScVal", xdrString)) as AnyObject)
+        : null;
     } catch (e: any) {
       return null;
     }
@@ -329,7 +333,11 @@ export const ScValPrettyJson = ({
   };
 
   // Entry point
-  return <div className="ScValPrettyJson">{render({ item: parseJson() })}</div>;
+  return (
+    <div className="ScValPrettyJson">
+      {render({ item: typeof json !== "undefined" ? json : parseJson() })}
+    </div>
+  );
 };
 
 // =============================================================================

--- a/src/components/ScValPrettyJson/index.tsx
+++ b/src/components/ScValPrettyJson/index.tsx
@@ -10,6 +10,7 @@ import { useStore } from "@/store/useStore";
 import { shortenStellarAddress } from "@/helpers/shortenStellarAddress";
 import * as StellarXdr from "@/helpers/StellarXdr";
 import { getStellarExpertNetwork } from "@/helpers/getStellarExpertNetwork";
+import { getContractIdError } from "@/validate/methods/getContractIdError";
 
 import { AnyObject } from "@/types/types";
 
@@ -63,12 +64,13 @@ export const ScValPrettyJson = ({
 
   const renderAddress = (value: string) => {
     const seNetwork = getStellarExpertNetwork(network.id);
+    const isContract = !getContractIdError(value);
 
     if (seNetwork) {
       return (
         <div className="ScValPrettyJson__value" data-type="address">
           <SdsLink
-            href={`${STELLAR_EXPERT}/${seNetwork}/account/${value}`}
+            href={`${STELLAR_EXPERT}/${seNetwork}/${isContract ? "contract" : "account"}/${value}`}
             variant="secondary"
             isUnderline
             title={value}

--- a/src/components/ScValPrettyJson/index.tsx
+++ b/src/components/ScValPrettyJson/index.tsx
@@ -335,7 +335,7 @@ export const ScValPrettyJson = ({
   // Entry point
   return (
     <div className="ScValPrettyJson">
-      {render({ item: typeof json !== "undefined" ? json : parseJson() })}
+      {render({ item: json ? json : parseJson() })}
     </div>
   );
 };

--- a/src/helpers/decodeScVal.ts
+++ b/src/helpers/decodeScVal.ts
@@ -1,0 +1,10 @@
+import { scValToNative, xdr } from "@stellar/stellar-sdk";
+
+export const decodeScVal = (xdrString: string) => {
+  try {
+    const scv = xdr.ScVal.fromXDR(xdrString, "base64");
+    return scValToNative(scv);
+  } catch (e) {
+    return null;
+  }
+};

--- a/src/helpers/processContractStorageData.ts
+++ b/src/helpers/processContractStorageData.ts
@@ -1,0 +1,55 @@
+import { parse } from "lossless-json";
+import * as StellarXdr from "@/helpers/StellarXdr";
+import {
+  AnyObject,
+  ContractStorageProcessedItem,
+  SortDirection,
+} from "@/types/types";
+
+export const processContractStorageData = <T extends AnyObject>({
+  data,
+  sortById,
+  sortByDir,
+}: {
+  data: T[];
+  sortById: string | undefined;
+  sortByDir: SortDirection;
+}): ContractStorageProcessedItem<T>[] => {
+  let sortedData = [...data];
+
+  // Decode key and value
+  sortedData = sortedData.map((i) => ({
+    ...i,
+    keyJson: i.key ? decodeScVal(i.key) : undefined,
+    valueJson: i.value ? decodeScVal(i.value) : undefined,
+  }));
+
+  // Sort
+  if (sortById) {
+    if (["asc", "desc"].includes(sortByDir)) {
+      // Asc
+      sortedData = sortedData.sort((a: any, b: any) =>
+        a[sortById] > b[sortById] ? 1 : -1,
+      );
+
+      // Desc
+      if (sortByDir === "desc") {
+        sortedData = sortedData.reverse();
+      }
+    }
+  }
+
+  // TODO: Filter
+
+  return sortedData as ContractStorageProcessedItem<T>[];
+};
+
+const decodeScVal = (xdrString: string) => {
+  try {
+    return xdrString
+      ? (parse(StellarXdr.decode("ScVal", xdrString)) as AnyObject)
+      : null;
+  } catch (e) {
+    return null;
+  }
+};

--- a/src/helpers/processContractStorageData.ts
+++ b/src/helpers/processContractStorageData.ts
@@ -19,16 +19,18 @@ export const processContractStorageData = <T extends AnyObject>({
 
   // Sort
   if (sortById) {
-    if (["asc", "desc"].includes(sortByDir)) {
-      // Asc
+    // Asc
+    if (sortByDir === "asc") {
       sortedData = sortedData.sort((a: any, b: any) =>
         a[sortById] > b[sortById] ? 1 : -1,
       );
+    }
 
-      // Desc
-      if (sortByDir === "desc") {
-        sortedData = sortedData.reverse();
-      }
+    // Desc
+    if (sortByDir === "desc") {
+      sortedData = sortedData.sort((a: any, b: any) =>
+        a[sortById] > b[sortById] ? -1 : 1,
+      );
     }
   }
 

--- a/src/query/external/useSEContracStorage.ts
+++ b/src/query/external/useSEContracStorage.ts
@@ -65,6 +65,7 @@ export const useSEContractStorage = ({
           await fetchData(lastRecord?.paging_token);
         }
 
+        // TODO: check max entries for smooth UX
         return allRecords;
       } catch (e: any) {
         throw `Something went wrong. ${e}`;

--- a/src/query/external/useSEContracStorage.ts
+++ b/src/query/external/useSEContracStorage.ts
@@ -65,7 +65,6 @@ export const useSEContractStorage = ({
           await fetchData(lastRecord?.paging_token);
         }
 
-        // TODO: check max entries for smooth UX
         return allRecords;
       } catch (e: any) {
         throw `Something went wrong. ${e}`;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -403,6 +403,11 @@ export type ContractStorageResponseItem = {
   expired?: boolean;
 };
 
+export type ContractStorageProcessedItem<T> = T & {
+  keyJson?: AnyObject;
+  valueJson?: AnyObject;
+};
+
 // =============================================================================
 // Data table
 // =============================================================================

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -404,8 +404,8 @@ export type ContractStorageResponseItem = {
 };
 
 export type ContractStorageProcessedItem<T> = T & {
-  keyJson?: AnyObject;
-  valueJson?: AnyObject;
+  keyJson?: AnyObject | null;
+  valueJson?: AnyObject | null;
 };
 
 // =============================================================================
@@ -417,6 +417,7 @@ export type DataTableHeader = {
   id: string;
   value: string;
   isSortable?: boolean;
+  filter?: string[];
 };
 
 export type DataTableCell = {


### PR DESCRIPTION
1. The filter logic is "or", meaning that selecting more filters includes more records. We could implement "and" logic (narrowing down selection), making the filters dynamic. Adding more data to store locally might slow the UI, though.
2. We need an "Apply" button to apply the selected filters. Because we can have thousands of records, we can't make updates on the fly as the filters are selected. For now, I added a basic button, so we have "Apply" and "Clear filter" buttons.
3. What should be the logic for selecting `value` filters? I'm using object keys from decoded `value` XDR, and we might end up with numbers. For example, `CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM` (Mainnet). `key` filters are much more predictable than `value`, which can be pretty much anything.
4. How should we handle very long lists of filters? For example, `CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP` (Mainnet) has a very long list of `value` filters.
5. We need to keep checking how we handle thousands of records. On my machine, `CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP` (Mainnet) with 6k+ records at this time, seems OK. It takes a few seconds on the initial load, and then the loader is displayed when sorting. But the UI doesn't feel sluggish; it just takes longer to load the result.
6. Should we display the filtered results count?
7. I will add tests in a follow-up PR once we're all set with the UI.

![image](https://github.com/user-attachments/assets/533d5ffe-e3c1-458d-a16d-83d8d858b58c)
