### PR TITLE
[getLedgerEntries] convert asset field and parse key field from the form for XDR encoding

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/ClassicTransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/ClassicTransactionXdr.tsx
@@ -12,6 +12,7 @@ import { ValidationResponseCard } from "@/components/ValidationResponseCard";
 import { isEmptyObject } from "@/helpers/isEmptyObject";
 import { xdrUtils } from "@/helpers/xdr/utils";
 import { optionsFlagDetails } from "@/helpers/optionsFlagDetails";
+import { formatAssetValue } from "@/helpers/formatAssetValue";
 import { useIsXdrInit } from "@/hooks/useIsXdrInit";
 
 import { useStore } from "@/store/useStore";
@@ -28,7 +29,6 @@ import {
 import {
   AnyObject,
   AssetObjectValue,
-  AssetPoolShareObjectValue,
   KeysOfUnion,
   NumberFractionValue,
   OptionFlag,
@@ -113,42 +113,6 @@ export const ClassicTransactionXdr = () => {
 
         return { ...res, [key]: val };
       }, {});
-
-      const formatAssetValue = (
-        asset: AssetObjectValue | AssetPoolShareObjectValue,
-      ): any => {
-        let formattedAsset;
-
-        if (asset.type === "native") {
-          formattedAsset = "native";
-        } else if (
-          asset.type &&
-          ["credit_alphanum4", "credit_alphanum12"].includes(asset.type)
-        ) {
-          const assetValue = asset as AssetObjectValue;
-
-          formattedAsset = {
-            [asset.type]: {
-              asset_code: assetValue.code,
-              issuer: assetValue.issuer,
-            },
-          };
-        } else if (asset.type === "liquidity_pool_shares") {
-          const assetPoolShareValue = asset as AssetPoolShareObjectValue;
-
-          formattedAsset = {
-            pool_share: {
-              liquidity_pool_constant_product: {
-                asset_a: formatAssetValue(assetPoolShareValue.asset_a),
-                asset_b: formatAssetValue(assetPoolShareValue.asset_b),
-                fee: 30,
-              },
-            },
-          };
-        }
-
-        return formattedAsset;
-      };
 
       const formatAssetMultiValue = (assets: AssetObjectValue[]) => {
         return assets.reduce((res, cur) => {

--- a/src/components/FormElements/XdrLedgerKeyPicker.tsx
+++ b/src/components/FormElements/XdrLedgerKeyPicker.tsx
@@ -165,7 +165,7 @@ export const XdrLedgerKeyPicker = ({
     } catch (e) {
       return {
         xdr: "",
-        error: `[MEOW] Unable to encode JSON as LedgerKey: ${e}`,
+        error: `Unable to encode JSON as LedgerKey: ${e}`,
       };
     }
   };

--- a/src/components/FormElements/XdrLedgerKeyPicker.tsx
+++ b/src/components/FormElements/XdrLedgerKeyPicker.tsx
@@ -325,6 +325,7 @@ export const XdrLedgerKeyPicker = ({
 
           let xdrJson: AnyObject = {
             [selectedLedgerKey.id]: {
+              // parseFormJsonValues is needed to convert either the asset or key field to the correct format
               ...parseFormJsonValues(formInputs), // Start with existing form inputs
             },
           };

--- a/src/components/FormElements/XdrLedgerKeyPicker.tsx
+++ b/src/components/FormElements/XdrLedgerKeyPicker.tsx
@@ -112,7 +112,7 @@ export const XdrLedgerKeyPicker = ({
     useState<LedgerKeyFieldsType | null>(null);
   const [isXdrInputActive, setIsXdrInputActive] = useState(true);
   const [formError, setFormError] = useState<AnyObject>({});
-  const [ledgerKeyXdrToJsonString, setLedgerKeyJsonString] =
+  const [ledgerKeyXdrToJsonString, setLedgerKeyXdrToJsonString] =
     useState<string>("");
   const [ledgerKeyXdrError, setLedgerKeyXdrError] = useState<string>("");
 
@@ -172,7 +172,7 @@ export const XdrLedgerKeyPicker = ({
 
   const reset = () => {
     setFormError({});
-    setLedgerKeyJsonString("");
+    setLedgerKeyXdrToJsonString("");
     setLedgerKeyXdrError("");
     onChange("");
   };
@@ -259,7 +259,7 @@ export const XdrLedgerKeyPicker = ({
         xdrJsonToString = stringify(decodedXdrJson.xdrToJson) || "";
       }
 
-      setLedgerKeyJsonString(xdrJsonToString);
+      setLedgerKeyXdrToJsonString(xdrJsonToString);
 
       if (selectedLedgerKeyFields) {
         setSelectedLedgerKey(selectedLedgerKeyFields);
@@ -288,7 +288,7 @@ export const XdrLedgerKeyPicker = ({
       const ledgerKeyFieldInputsToString = stringify(ledgerKeyFieldInputs);
 
       if (ledgerKeyFieldInputsToString) {
-        setLedgerKeyJsonString(ledgerKeyFieldInputsToString);
+        setLedgerKeyXdrToJsonString(ledgerKeyFieldInputsToString);
       }
     }
   }, [ledgerKeyXdrToJsonString, selectedLedgerKey]);
@@ -299,12 +299,12 @@ export const XdrLedgerKeyPicker = ({
       return null;
     }
 
+    const ledgerKeyXdrToJson = parse(ledgerKeyXdrToJsonString) as AnyObject;
+
+    // output that fits into the fields
+    const formInputs = ledgerKeyXdrToJson[selectedLedgerKey.id];
+
     return selectedLedgerKey.fields.split(",").map((field) => {
-      const ledgerKeyXdrToJson = parse(ledgerKeyXdrToJsonString) as AnyObject;
-
-      // output that fits into the fields
-      const formInputs = ledgerKeyXdrToJson[selectedLedgerKey.id];
-
       const component = formComponentTemplateEndpoints(
         field,
         selectedLedgerKey?.custom,
@@ -331,13 +331,17 @@ export const XdrLedgerKeyPicker = ({
           };
 
           if (field === "key") {
-            xdrJson = {
-              [selectedLedgerKey.id]: {
-                ...formInputs,
-                // Parse the nested JSON string key value
-                key: parse(formInputs[field]),
-              },
-            };
+            try {
+              xdrJson = {
+                [selectedLedgerKey.id]: {
+                  ...formInputs,
+                  // Parse the nested JSON string key value
+                  key: parse(formInputs[field]),
+                },
+              };
+            } catch (e) {
+              // noop
+            }
           }
 
           if (field === "asset") {
@@ -361,7 +365,7 @@ export const XdrLedgerKeyPicker = ({
           // stringify the updated json with the input value
           const ledgerKeyJsonToString = stringify(ledgerKeyXdrToJson) || "";
 
-          setLedgerKeyJsonString(ledgerKeyJsonToString || "");
+          setLedgerKeyXdrToJsonString(ledgerKeyJsonToString || "");
 
           // for every template that is not an asset, encode the json string
           const jsonToXdr = encodeJsonToXdr(xdrJson || "");

--- a/src/components/formComponentTemplateEndpoints.tsx
+++ b/src/components/formComponentTemplateEndpoints.tsx
@@ -474,14 +474,25 @@ export const formComponentTemplateEndpoints = (
             fieldSize="md"
             key={id}
             id={id}
-            label="Key"
-            placeholder="Ex: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9"
-            // @TODO we should display an input for each value
-            // hotfix: sanitizing value from backlashes and extra quotes
+            label="Key (ScVal)"
+            rows={10}
+            placeholder={`{
+      "vec": [
+        {
+          "symbol": "Balance"
+        },
+        {
+          "address": "CDGAH7TU7UH3BXGYXRIXLJX63LYRIF6APZPIG64ZAW3NNDCPJ7AAWVTZ"
+        }
+      ]
+    }
+  }
+}`}
+            // Convert object to string if needed
             value={
-              JSON.stringify(templ.value)
-                .replace(/\\/g, "")
-                .replace(/^"+|"+$/g, "") || ""
+              typeof templ.value === "object"
+                ? JSON.stringify(templ.value, null, 2)
+                : templ.value || ""
             }
             error={templ.error}
             onChange={templ.onChange}

--- a/src/helpers/formatAssetValue.ts
+++ b/src/helpers/formatAssetValue.ts
@@ -1,0 +1,52 @@
+import {
+  AssetObjectValue,
+  AssetPoolShareObjectValue,
+  AssetSinglePoolShareValue,
+} from "@/types/types";
+
+export const formatAssetValue = (
+  asset:
+    | AssetObjectValue
+    | AssetPoolShareObjectValue
+    | AssetSinglePoolShareValue,
+): any => {
+  console.log("[formatAssetValue] asset:", asset);
+  console.log("[formatAssetValue] typeof asset:", typeof asset);
+  let formattedAsset;
+
+  if (asset.type === "native") {
+    formattedAsset = "native";
+  } else if (
+    asset.type &&
+    ["credit_alphanum4", "credit_alphanum12"].includes(asset.type)
+  ) {
+    const assetValue = asset as AssetObjectValue;
+
+    formattedAsset = {
+      [asset.type]: {
+        asset_code: assetValue.code,
+        issuer: assetValue.issuer,
+      },
+    };
+  } else if (asset.type === "liquidity_pool_shares") {
+    const assetPoolSharesValue = asset as AssetPoolShareObjectValue;
+
+    formattedAsset = {
+      pool_share: {
+        liquidity_pool_constant_product: {
+          asset_a: formatAssetValue(assetPoolSharesValue.asset_a),
+          asset_b: formatAssetValue(assetPoolSharesValue.asset_b),
+          fee: 30,
+        },
+      },
+    };
+  } else if (asset.type === "pool_share") {
+    const assetPoolShareValue = asset as AssetSinglePoolShareValue;
+
+    formattedAsset = {
+      pool_share: assetPoolShareValue.pool_share,
+    };
+  }
+
+  return formattedAsset;
+};

--- a/src/helpers/formatAssetValue.ts
+++ b/src/helpers/formatAssetValue.ts
@@ -10,8 +10,6 @@ export const formatAssetValue = (
     | AssetPoolShareObjectValue
     | AssetSinglePoolShareValue,
 ): any => {
-  console.log("[formatAssetValue] asset:", asset);
-  console.log("[formatAssetValue] typeof asset:", typeof asset);
   let formattedAsset;
 
   if (asset.type === "native") {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -294,7 +294,7 @@ export type LedgerKeyEntryTypeProps =
 export type LedgerKeyFieldsType = {
   id: LedgerKeyType;
   label: string;
-  templates: string;
+  fields: string;
   custom?: AnyObject;
 };
 


### PR DESCRIPTION
**Summary:**
- bugfix: added a proper parsing or converting for `contract_data`'s `key (ScVal)` and trustline's `asset`
- use `lossless-json` `parse` and `stringify` instead of the native `JSON.parse`
- added more comments

some helpful testing xdr from this PR:
- Account: Use any public key
- Trustline:
-- For pool share, use `67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9`
-- pool share xdr: `AAAAAQAAAACm45wpNUH4LHLWH4qc39cu1tmRsEY1/2+qC4lklkkmCQAAAANnJgxMGAeyYv+FGwo/4UEZSTa7AhWy93RH8d8RmY6ruQ==`
- Claimable Balance
-- balance_id: `0000000010a8f6991f79df306f22a2032f6007ad594dd30f966b21556f7d75658ec1c4e9`
- Liquidity Pool
-- `67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9`
Contract Data
-- xdr example: `AAAABgAAAAHXkotywnA8z+r365/0701QSlWouXn8m0UOoshCtNHOYQAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAcwD/nT9D7Dc2LxRdab+2vEUF8B+XoN7mQW21oxPT8ALAAAAAQ==`
Contract Code
-- wasm hash: `f5c9668827b4783e1f87a7f6b7406f6c426b72e82f114654a724713e4e6c0de4`
-- xdr: `AAAAB/XJZogntHg+H4en9rdAb2xCa3LoLxFGVKckcT5ObA3k`
