### PR TITLE
zustand store to properly store invoke contract function's input fields

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
@@ -22,7 +22,8 @@ import {
   INITIAL_OPERATION,
   TRANSACTION_OPERATIONS,
 } from "@/constants/transactionOperations";
-import { OperationError } from "@/types/types";
+import { OperationError, SorobanInvokeValue } from "@/types/types";
+import { sanitizeObject } from "@/helpers/sanitizeObject";
 
 export const SorobanOperation = ({
   operationTypeSelector,
@@ -66,10 +67,10 @@ export const SorobanOperation = ({
     const updatedOperation = {
       ...sorobanOperation,
       operation_type: opType,
-      params: {
+      params: sanitizeObject({
         ...sorobanOperation?.params,
         [opParam]: opValue,
-      },
+      }),
     };
 
     updateSorobanBuildOperation(updatedOperation);
@@ -176,10 +177,16 @@ export const SorobanOperation = ({
                         <div key={`soroban-param-${input}`}>
                           {component.render({
                             ...sorobanBaseProps,
-                            onChange: (value: string) => {
+                            onChange: (value: SorobanInvokeValue) => {
                               handleSorobanOperationParamChange({
                                 opParam: input,
-                                opValue: value,
+                                // invoke_contract has a nested object within params
+                                // { contract_id: "", data: {} }
+                                // we need to stringify the nested object
+                                // for zustand querystring to properly save the value in the url
+                                opValue: value
+                                  ? JSON.stringify(value)
+                                  : undefined,
                                 opType: sorobanOperation.operation_type,
                               });
                             },

--- a/src/components/FormElements/ContractMethodSelectPicker.tsx
+++ b/src/components/FormElements/ContractMethodSelectPicker.tsx
@@ -7,29 +7,51 @@ import { Box } from "@/components/layout/Box";
 import { JsonSchemaForm } from "@/components/JsonSchemaForm";
 import { ExpandBox } from "@/components/ExpandBox";
 
+import { SorobanInvokeValue } from "@/types/types";
+
 // @todo for testing
 // comment it out before committing
 // remove it before merging into main
 import Form from "@rjsf/core";
 import validator from "@rjsf/validator-ajv8";
+
+const cleanupData = (data: any) => {
+  if (!data) return {};
+  // Only keep function_method if it exists, reset all other fields
+  return {
+    function_method: data.function_method || "",
+  };
+};
+
 export const ContractMethodSelectPicker = ({
+  value,
   methods,
   spec,
   id,
+  onChange,
 }: {
+  value: SorobanInvokeValue;
   methods: string[];
   spec: contract.Spec;
   id: string;
+  onChange: (val: SorobanInvokeValue) => void;
 }) => {
   const [selectedValue, setSelectedValue] = useState<string>("");
   const [funcSpec, setFuncSpec] = useState<JSONSchema7 | undefined>(undefined);
 
-  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedValue(e.target.value);
-
+  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value) {
       const selectedFuncSchema = spec.jsonSchema(e.target.value);
+      setSelectedValue(e.target.value);
       setFuncSpec(selectedFuncSchema);
+
+      onChange({
+        ...value,
+        data: {
+          ...cleanupData(value.data),
+          function_method: e.target.value,
+        },
+      });
     } else {
       setFuncSpec(undefined);
     }
@@ -42,9 +64,12 @@ export const ContractMethodSelectPicker = ({
         label="Select a method"
         id={id}
         value={selectedValue}
-        onChange={onChange}
+        onChange={(e) => {
+          onSelectChange(e);
+        }}
       >
         <option value="">Select a method</option>
+
         {methods.map((method) => (
           <option key={method} value={method}>
             {method}
@@ -54,7 +79,12 @@ export const ContractMethodSelectPicker = ({
       <ExpandBox isExpanded={Boolean(selectedValue)} offsetTop="sm">
         {selectedValue && funcSpec ? (
           <>
-            <JsonSchemaForm schema={funcSpec} name={selectedValue} />
+            <JsonSchemaForm
+              schema={funcSpec}
+              name={selectedValue}
+              value={value}
+              onChange={onChange}
+            />
             {/* 
             // @todo for testing
             // comment it out before committing

--- a/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
+++ b/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
@@ -14,22 +14,20 @@ import {
 import { useStore } from "@/store/useStore";
 import { validate } from "@/validate";
 import { Spec } from "@stellar/stellar-sdk/contract";
+import { SorobanInvokeValue } from "@/types/types";
 
 interface FetchContractMethodPickerWithQueryProps {
   id: string;
-  value: string;
+  value: SorobanInvokeValue | undefined;
   error?: string | undefined;
   label?: string;
   disabled?: boolean;
-  onChange: (val: string) => void;
+  onChange: (val: SorobanInvokeValue | undefined) => void;
 }
 
 /**
- * FetchContractMethodPickerWithQuery
- *
  * This component is used to fetch the contract methods for a given contract id.
  * It is used in the SorobanOperation component.
- *
  */
 export const FetchContractMethodPickerWithQuery = ({
   id,
@@ -64,7 +62,12 @@ export const FetchContractMethodPickerWithQuery = ({
       }
     }
 
-    onChange(e.target.value || "");
+    const newValue: SorobanInvokeValue = {
+      contract_id: e.target.value || "",
+      data: value?.data || {},
+    };
+
+    onChange(newValue);
   };
 
   const handleFetchContractMethods = async () => {
@@ -77,7 +80,7 @@ export const FetchContractMethodPickerWithQuery = ({
 
     const contractMethods: ContractFunctionMethods =
       await fetchContractFunctionMethods({
-        contractId: value,
+        contractId: value.contract_id,
         networkPassphrase: network.passphrase,
         rpcUrl: network.rpcUrl,
       });
@@ -102,7 +105,7 @@ export const FetchContractMethodPickerWithQuery = ({
         id={id}
         label={label}
         placeholder="Ex: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-        value={value || ""}
+        value={value?.contract_id || ""}
         error={error || contractIdError}
         onChange={handleContractIdChange}
         disabled={disabled}
@@ -125,6 +128,8 @@ export const FetchContractMethodPickerWithQuery = ({
       <>
         {contractMethods.length && value ? (
           <ContractMethodSelectPicker
+            value={value}
+            onChange={onChange}
             spec={contractMethodsSpec}
             methods={contractMethods}
             id={`${id}-method`}

--- a/src/components/JsonSchemaForm/index.tsx
+++ b/src/components/JsonSchemaForm/index.tsx
@@ -10,13 +10,18 @@ import {
 import { Box } from "@/components/layout/Box";
 import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
 import { LabelHeading } from "@/components/LabelHeading";
+import { SorobanInvokeValue } from "@/types/types";
 
 export const JsonSchemaForm = ({
   schema,
   name,
+  value,
+  onChange,
 }: {
   schema: JSONSchema7;
   name: string;
+  value: SorobanInvokeValue;
+  onChange: (value: SorobanInvokeValue) => void;
 }) => {
   const [dereferencedSchema, setDereferencedSchema] =
     useState<DereferencedSchema>({
@@ -25,15 +30,19 @@ export const JsonSchemaForm = ({
       additionalProperties: false,
     });
 
-  const [schemaValues, setSchemaValues] = useState<Record<string, string>>({});
-
   useEffect(() => {
     const dereferencedSchema = getDereferenceSchema(schema, name);
     setDereferencedSchema(dereferencedSchema);
   }, [schema, name]);
 
-  const handleChange = (key: string, value: string) => {
-    setSchemaValues({ ...schemaValues, [key]: value });
+  const handleChange = (key: string, newVal: string) => {
+    onChange({
+      ...value,
+      data: {
+        ...value.data,
+        [key]: newVal,
+      },
+    });
   };
 
   // key: argument label
@@ -66,7 +75,7 @@ export const JsonSchemaForm = ({
               key={label}
               fieldSize="md"
               label={label}
-              value={schemaValues[label] || ""}
+              value={value.data[label] || ""}
               error={""}
               onChange={(e) => {
                 handleChange(label, e.target.value);
@@ -84,7 +93,7 @@ export const JsonSchemaForm = ({
               key={label}
               fieldSize="md"
               label={label}
-              value={schemaValues[label] || ""}
+              value={value.data[label] || ""}
               error={""}
               onChange={(e) => {
                 handleChange(label, e.target.value);
@@ -100,7 +109,7 @@ export const JsonSchemaForm = ({
               id={key}
               key={label}
               label={label}
-              value={schemaValues[label] || ""}
+              value={value.data[label] || ""}
               error={""}
               onChange={(e) => {
                 handleChange(label, e.target.value);

--- a/src/components/formComponentTemplateTxnOps.tsx
+++ b/src/components/formComponentTemplateTxnOps.tsx
@@ -29,7 +29,9 @@ import {
   NumberFractionValue,
   OptionSigner,
   RevokeSponsorshipValue,
+  SorobanInvokeValue,
 } from "@/types/types";
+import { parseJsonString } from "@/helpers/parseJsonString";
 
 // Types
 type TemplateRenderProps = {
@@ -37,23 +39,6 @@ type TemplateRenderProps = {
   error: string | undefined;
   onChange: (val: any) => void;
   isRequired?: boolean;
-};
-
-// Types
-type SorobanTemplateRenderProps = {
-  value: string | undefined;
-  error: string | undefined;
-  onChange: (val: any) => void;
-  isRequired?: boolean;
-  isDisabled?: boolean;
-};
-
-type SorobanInvokeTemplateRenderProps = {
-  value: string;
-  error: string | undefined;
-  onChange: (val: string) => void;
-  isRequired?: boolean;
-  isDisabled?: boolean;
 };
 
 type TemplateRenderAssetProps = {
@@ -108,6 +93,22 @@ type TemplateRenderClaimantsProps = {
   error: (AnyObject | undefined)[] | undefined;
   onChange: (val: AnyObject[] | undefined) => void;
   isRequired?: boolean;
+};
+
+type TemplateRenderSorobanProps = {
+  value: string | undefined;
+  error: string | undefined;
+  onChange: (val: any) => void;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+};
+
+type TemplateRenderSorobanInvokeProps = {
+  value: SorobanInvokeValue | undefined;
+  error: string | undefined;
+  onChange: (val: SorobanInvokeValue | undefined) => void;
+  isRequired?: boolean;
+  isDisabled?: boolean;
 };
 
 type FormComponentTemplateTxnOpsProps = {
@@ -402,7 +403,7 @@ export const formComponentTemplateTxnOps = ({
       };
     case "extend_ttl_to": {
       return {
-        render: (templ: SorobanTemplateRenderProps) => (
+        render: (templ: TemplateRenderSorobanProps) => (
           <PositiveIntPicker
             key={id}
             id={id}
@@ -468,7 +469,7 @@ export const formComponentTemplateTxnOps = ({
       };
     case "key_xdr":
       return {
-        render: (templ: SorobanTemplateRenderProps) => (
+        render: (templ: TemplateRenderSorobanProps) => (
           <TextPicker
             key={id}
             id={id}
@@ -488,7 +489,7 @@ export const formComponentTemplateTxnOps = ({
     // Soroban Only
     case "resource_fee":
       return {
-        render: (templ: SorobanTemplateRenderProps) => (
+        render: (templ: TemplateRenderSorobanProps) => (
           <ResourceFeePickerWithQuery
             id={id}
             label="Resource Fee (in stroops)"
@@ -513,15 +514,17 @@ export const formComponentTemplateTxnOps = ({
         validate: validate.getPositiveNumberError,
       };
 
-    // Soroban Custom Soroban Operation
+    // Custom Soroban Operation
     case "invoke_contract":
       return {
-        render: (templ: SorobanInvokeTemplateRenderProps) => {
+        render: (templ: TemplateRenderSorobanInvokeProps) => {
           return (
             <FetchContractMethodPickerWithQuery
               id={id}
               label="Contract ID"
-              value={templ.value}
+              // parse the JSON string that we converted for zustand querystring to
+              // back to an object to properly display the value
+              value={parseJsonString(templ.value)}
               error={templ.error}
               onChange={templ.onChange}
               disabled={templ.isDisabled}

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -1,5 +1,4 @@
 import {
-  contract,
   Address,
   Contract,
   Operation,
@@ -12,12 +11,6 @@ import {
 
 import { TransactionBuildParams } from "@/store/createStore";
 import { SorobanOpType, TxnOperation } from "@/types/types";
-
-export type ContractFunctionMethods = {
-  methods: string[];
-  error: string;
-  spec: contract.Spec;
-};
 
 export const isSorobanOperationType = (operationType: string) => {
   // @TODO: add restore_footprint
@@ -158,39 +151,6 @@ export const buildSorobanTx = ({
     .setSorobanData(sorobanData)
     .addOperation(getSorobanOp(sorobanOp.operation_type))
     .build();
-};
-
-export const fetchContractFunctionMethods = async ({
-  contractId,
-  networkPassphrase,
-  rpcUrl,
-}: {
-  contractId: string;
-  networkPassphrase: string;
-  rpcUrl: string;
-}): Promise<ContractFunctionMethods> => {
-  try {
-    const client = await contract.Client.from({
-      contractId,
-      networkPassphrase,
-      rpcUrl,
-    });
-
-    const spec = client.spec;
-    const methods = spec.funcs();
-
-    return {
-      methods: methods.map((method) => method.name().toString()),
-      spec,
-      error: "",
-    };
-  } catch (e: any) {
-    return {
-      methods: [],
-      spec: {} as contract.Spec,
-      error: `error while fetching contract information: ${e?.message ? e?.message : e}`,
-    };
-  }
 };
 
 // Preparing Soroban Transaction Data

--- a/src/query/useContractClientFromRpc.ts
+++ b/src/query/useContractClientFromRpc.ts
@@ -1,0 +1,32 @@
+import { contract } from "@stellar/stellar-sdk";
+import { useQuery } from "@tanstack/react-query";
+
+export const useContractClientFromRpc = ({
+  contractId,
+  networkPassphrase,
+  rpcUrl,
+}: {
+  contractId: string;
+  networkPassphrase: string;
+  rpcUrl: string;
+}) => {
+  const query = useQuery<contract.Client | null>({
+    queryKey: ["useClientFromRpc", contractId, networkPassphrase, rpcUrl],
+    queryFn: async () => {
+      try {
+        const client = await contract.Client.from({
+          contractId,
+          networkPassphrase,
+          rpcUrl,
+        });
+
+        return client;
+      } catch (e: any) {
+        throw `error while fetching contract information: ${e?.message ? e?.message : e}`;
+      }
+    },
+    enabled: !!contractId && !!networkPassphrase && !!rpcUrl,
+  });
+
+  return query;
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -251,6 +251,11 @@ export type SponsorshipType =
 // =============================================================================
 export type SorobanOpType = "extend_footprint_ttl" | "invoke_contract_function";
 
+export type SorobanInvokeValue = {
+  contract_id: string;
+  data: AnyObject;
+};
+
 // =============================================================================
 // RPC
 // =============================================================================


### PR DESCRIPTION
**Summary:**
- Updating the zustand store with the following type:
`{ contract_data: "", "data:" { "function_method": "", fields: {}}}`
- for the zustand querystring to work, we have to convert the object into a string (see file update note)

**How to Test:**
- go to the preview link ([example link](https://laboratory-pr1253.previews.kube001.services.stellar-ops.com/transaction/build?$=network$id=mainnet&label=Mainnet&horizonUrl=https:////horizon.stellar.org&rpcUrl=https:////mainnet.sorobanrpc.com&passphrase=Public%20Global%20Stellar%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=&params@;;;;&soroban$operation$operation_type=invoke_contract_function&params$invoke_contract=%7B%22contract_id%22:%22CA6PUJLBYKZKUEKLZJMKBZLEKP2OTHANDEOWSFF44FTSYLKQPIICCJBE%22,%22data%22:%7B%22function_method%22:%22initialize_all%22,%22admin%22:%22asdfs%22,%22privileged_addrs-1%22:%22asdfa%22,%22privileged_addrs-2%22:%22sdf%22,%22privileged_addrs-3%22:%22asdf%22,%22privileged_addrs-4%22:%22asdf%22%7D%7D;;;&isValid$operations:true;;) with params filled in)
- select `Mainnet` with the rpc endpoint: `https://mainnet.sorobanrpc.com`
- go to transactions > build transactions
- select `invoke contract function (soroban)`
- type in `CA6PUJLBYKZKUEKLZJMKBZLEKP2OTHANDEOWSFF44FTSYLKQPIICCJBE` or any other mainnet contract id
- click `fetch contract methods`
- select a method you like
- it should display fields, type in whatever you'd like (not all inputs are created yet but the text ones are ready)
- the data being stored should follow the following format:

```
{
    "contract_id": "CA6PUJLBYKZKUEKLZJMKBZLEKP2OTHANDEOWSFF44FTSYLKQPIICCJBE",
    "data": { // [input_key]: value
        "function_method": "initialize_all",
        "admin": "asdf",
        "privileged_addrs-1": "asdfa",
        "privileged_addrs-2": "sdf",
        "privileged_addrs-3": "asdf",
        "privileged_addrs-4": "asdf"
    }
}
```

<img width="700" alt="image" src="https://github.com/user-attachments/assets/5b00c6bd-3961-415e-b09b-98fa00224e0d" />
