### PR TITLE
add "restore footprint" operation

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -52,6 +52,8 @@ export const Operations = () => {
 
   const [operationsError, setOperationsError] = useState<OperationError[]>([]);
 
+  console.log("[Operations] sorobanOperation: ", sorobanOperation);
+
   // For Classic Operations
   const updateOptionParamAndError = ({
     type,
@@ -847,10 +849,11 @@ export const Operations = () => {
           }
         >
           <option value="">Select operation type</option>
-          <option value="create_account">Create Account</option>
           <option value="extend_footprint_ttl">
             Extend Footprint TTL (Soroban)
           </option>
+          <option value="restore_footprint">Restore Footprint (Soroban)</option>
+          <option value="create_account">Create Account</option>
           <option value="payment">Payment</option>
           <option value="path_payment_strict_send">
             Path Payment Strict Send

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -848,9 +848,11 @@ export const Operations = () => {
         >
           <option value="">Select operation type</option>
           <option value="extend_footprint_ttl">
-            Extend Footprint TTL (Soroban)
+            Extend Footprint TTL (Smart Contract)
           </option>
-          <option value="restore_footprint">Restore Footprint (Soroban)</option>
+          <option value="restore_footprint">
+            Restore Footprint (Smart Contract)
+          </option>
           <option value="create_account">Create Account</option>
           <option value="payment">Payment</option>
           <option value="path_payment_strict_send">

--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -52,8 +52,6 @@ export const Operations = () => {
 
   const [operationsError, setOperationsError] = useState<OperationError[]>([]);
 
-  console.log("[Operations] sorobanOperation: ", sorobanOperation);
-
   // For Classic Operations
   const updateOptionParamAndError = ({
     type,

--- a/src/components/FormElements/ResourceFeePickerWithQuery.tsx
+++ b/src/components/FormElements/ResourceFeePickerWithQuery.tsx
@@ -18,7 +18,8 @@ import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
 
 const isAllParamsExceptResourceFeeValid = (params: Record<string, any>) => {
   // Create a copy of params without resource_fee
-  const { ...requiredParams } = params;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { resource_fee, ...requiredParams } = params;
 
   // Check if all remaining fields have truthy values
   return Object.values(requiredParams).every((value) => Boolean(value));
@@ -65,6 +66,11 @@ export const ResourceFeePickerWithQuery = ({
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined,
   );
+
+  useEffect(() => {
+    // Reset error message when operation params change
+    setErrorMessage(undefined);
+  }, [soroban.operation]);
 
   // operation.params.resource_fee is required for submitting; however,
   // we don't check for it here in case user doesn't have one and we still want to simulate

--- a/src/constants/transactionOperations.tsx
+++ b/src/constants/transactionOperations.tsx
@@ -394,6 +394,23 @@ export const TRANSACTION_OPERATIONS: { [key: string]: TransactionOperation } = {
     params: ["revokeSponsorship"],
     requiredParams: ["revokeSponsorship"],
   },
+  restore_footprint: {
+    label: "Restore Footprint",
+    description:
+      "Builds an operation to restore the archived ledger entries specified by the ledger keys.",
+    docsUrl:
+      "https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#restore-footprint",
+    params: ["contract", "key_xdr", "durability", "resource_fee"],
+    requiredParams: ["contract", "key_xdr", "durability", "resource_fee"],
+    defaultParams: {
+      durability: "persistent",
+    },
+    custom: {
+      durability: {
+        note: "TTL for the temporary data can be extended; however, it is unsafe to rely on the extensions to preserve data since there is always a risk of losing temporary data",
+      },
+    },
+  },
   clawback_claimable_balance: {
     label: "Clawback Claimable Balance",
     description: "Creates a clawback operation for a claimable balance.",

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -13,8 +13,8 @@ import { TransactionBuildParams } from "@/store/createStore";
 import { SorobanOpType, TxnOperation } from "@/types/types";
 
 export const isSorobanOperationType = (operationType: string) => {
-  // @TODO: add restore_footprint and invoke_host_function
-  return ["extend_footprint_ttl"].includes(operationType);
+  // @TODO: add invoke_host_function
+  return ["extend_footprint_ttl", "restore_footprint"].includes(operationType);
 };
 
 // https://developers.stellar.org/docs/learn/glossary#ledgerkey
@@ -70,6 +70,11 @@ export const getSorobanTxData = ({
     case "extend_footprint_ttl":
       return buildSorobanData({
         readOnlyXdrLedgerKey: [contractDataXDR],
+        resourceFee: fee,
+      });
+    case "restore_footprint":
+      return buildSorobanData({
+        readWriteXdrLedgerKey: [contractDataXDR],
         resourceFee: fee,
       });
     default:
@@ -128,7 +133,8 @@ export const buildSorobanTx = ({
           extendTo: Number(sorobanOp.params.extend_ttl_to),
           source: sorobanOp.source_account,
         });
-      // case "restore_footprint":
+      case "restore_footprint":
+        return Operation.restoreFootprint({});
       default:
         throw new Error(`Unsupported Soroban operation type: ${operationType}`);
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -249,7 +249,7 @@ export type SponsorshipType =
 // =============================================================================
 // Soroban Operations
 // =============================================================================
-export type SorobanOpType = "extend_footprint_ttl";
+export type SorobanOpType = "extend_footprint_ttl" | "restore_footprint";
 
 // =============================================================================
 // RPC

--- a/tests/buildTransaction.test.ts
+++ b/tests/buildTransaction.test.ts
@@ -1391,7 +1391,8 @@ test.describe("Build Transaction Page", () => {
           isSorobanOp: true,
           label: "Resource Fee (in stroops)",
           value: "aaa",
-          errorMessage: "Expected a whole number.",
+          errorMessage:
+            "Expected a positive number with a period for the decimal point.",
         });
       });
 
@@ -1400,6 +1401,132 @@ test.describe("Build Transaction Page", () => {
         const { operation_0 } = await selectOperationType({
           page,
           opType: "extend_footprint_ttl",
+        });
+        // we are going from classic operation to soroban operation
+        // so the classic operation should not be visible
+        await expect(operation_0).not.toBeVisible();
+
+        const soroban_operation = page.getByTestId(
+          "build-soroban-transaction-operation",
+        );
+
+        // Verify warning message about one operation limit
+        await expect(
+          page.getByText(
+            "Note that Soroban transactions can only contain one operation per transaction.",
+          ),
+        ).toBeVisible();
+
+        // Soroban Operation only allows one operation
+        // Add Operation button should be disabled
+        await expect(page.getByText("Add Operation")).toBeDisabled();
+
+        // Select Classic Operation
+        await soroban_operation.getByLabel("Operation type").selectOption({
+          value: "payment",
+        });
+
+        const classicOperation = page.getByTestId(
+          "build-transaction-operation-0",
+        );
+
+        await expect(classicOperation).toBeVisible();
+
+        await expect(page.getByText("Add Operation")).toBeVisible();
+      });
+    });
+
+    // Soroban Restore Footprint
+    test.describe("Soroban Restore Footprint", () => {
+      test("Happy path", async ({ page }) => {
+        const { operation_0 } = await selectOperationType({
+          page,
+          opType: "restore_footprint",
+        });
+        // we are going from classic operation to soroban operation
+        // so the classic operation should not be visible
+        await expect(operation_0).not.toBeVisible();
+
+        const soroban_operation = page.getByTestId(
+          "build-soroban-transaction-operation",
+        );
+
+        // Verify warning message about one operation limit
+        await expect(
+          page.getByText(
+            "Note that Soroban transactions can only contain one operation per transaction.",
+          ),
+        ).toBeVisible();
+
+        // Soroban Operation only allows one operation
+        // Add Operation button should be disabled
+        await expect(page.getByText("Add Operation")).toBeDisabled();
+
+        // Fill in required fields
+        await soroban_operation
+          .getByLabel("Contract ID")
+          .fill("CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S");
+        await soroban_operation
+          .getByLabel("Key ScVal in XDR")
+          .fill(
+            "AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD",
+          );
+        await soroban_operation
+          .getByLabel("Durability")
+          .selectOption({ value: "persistent" });
+        await soroban_operation
+          .getByLabel("Resource Fee (in stroops)")
+          .fill("46684");
+
+        await testOpSuccessHashAndXdr({
+          isSorobanOp: true,
+          page,
+          hash: "232c61d2e07fae61a09ffe12102f13c79c86dadbf0c49f8237fcbe0a2231921c",
+          xdr: "AAAAAgAAAAANLHqVohDTxPKQ3fawTPgHahe0TzJjJkWV1WakcbeADgAAtsAAD95QAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGgAAAAAAAAABAAAAAAAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAC2XAAAAAA=",
+        });
+      });
+
+      test("Validation", async ({ page }) => {
+        const { operation_0 } = await selectOperationType({
+          page,
+          opType: "restore_footprint",
+        });
+
+        await expect(operation_0).not.toBeVisible();
+
+        await testInputError({
+          page,
+          isSorobanOp: true,
+          label: "Contract ID",
+          value: "aaa",
+          errorMessage:
+            "Invalid contract ID. Please enter a valid contract ID.",
+        });
+
+        await testInputError({
+          page,
+          isSorobanOp: true,
+          label: "Contract ID",
+          value: "CAQP53Z2GMZ6WVOKJWXMCVDL",
+          errorMessage:
+            "Invalid contract ID. Please enter a valid contract ID.",
+        });
+
+        await testInputError({
+          page,
+          isSorobanOp: true,
+          label: "Resource Fee (in stroops)",
+          value: "aaa",
+          errorMessage:
+            "Expected a positive number with a period for the decimal point.",
+        });
+      });
+
+      test("Check rendering between classic and soroban", async ({ page }) => {
+        // Select Soroban Operation
+        const { operation_0 } = await selectOperationType({
+          page,
+          opType: "restore_footprint",
         });
         // we are going from classic operation to soroban operation
         // so the classic operation should not be visible


### PR DESCRIPTION
**Summary:**
- Add a 'restore footprint' operation
- [example preview link](https://laboratory-pr1257.previews.kube001.services.stellar-ops.com/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=&params@;;;;&soroban$operation$operation_type=restore_footprint&params$durability=persistent&contract=CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S&key_xdr=AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD&resource_fee=46684;;;&params$source_account=GBPIMUEJFYS7RT23QO2ACH2JMKGXLXZI4E5ACBSQMF32RKZ5H3SVNL5F&seq_num=3640268251201541;&isValid$params:true&operations:true;;) with the account `GBPIMUEJFYS7RT23QO2ACH2JMKGXLXZI4E5ACBSQMF32RKZ5H3SVNL5F`
- `GBPIMUEJFYS7RT23QO2ACH2JMKGXLXZI4E5ACBSQMF32RKZ5H3SVNL5F` [stellar.expert link](https://stellar.expert/explorer/testnet/account/GBPIMUEJFYS7RT23QO2ACH2JMKGXLXZI4E5ACBSQMF32RKZ5H3SVNL5F) that shows it has successfully restored ledger state entry

- Related developer docs:
1. https://developers.stellar.org/docs/build/guides/archival/create-restoration-footprint-js
2. https://stellar.github.io/js-stellar-sdk/Operation.html#.restoreFootprint 

![Screenshot 2025-02-20 at 9 32 50 AM](https://github.com/user-attachments/assets/8a967e45-bb9e-407b-a40f-e56ab9167cab)

![Screenshot 2025-02-20 at 9 40 23 AM](https://github.com/user-attachments/assets/e7ad9e75-0012-46ea-b683-eecfbdeae031)

To do:
- [ ]  add `SorobanRpc.Api.isSimulationRestore` to check if restoration is necessary
