### PR TITLE
Contract Spec: add XDR format + docs link

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
@@ -35,7 +35,7 @@ export const ContractSpec = ({
   const isXdrInit = useIsXdrInit();
   const queryClient = useQueryClient();
 
-  const [selectedLanguage, setSelectedLanguage] =
+  const [selectedFormat, setSelectedFormat] =
     useState<SupportedLanguage>("json");
 
   const {
@@ -138,7 +138,7 @@ export const ContractSpec = ({
     const entries = wasmData?.spec?.entries || [];
 
     // JSON
-    if (selectedLanguage === "json") {
+    if (selectedFormat === "json") {
       try {
         if (isXdrInit) {
           const decodedEntries = entries.map((e) => {
@@ -156,7 +156,7 @@ export const ContractSpec = ({
         // do nothing
       }
       // XDR
-    } else if (selectedLanguage === "xdr") {
+    } else if (selectedFormat === "xdr") {
       const xdrEntries = entries?.map((e) => {
         return e.toXDR("base64");
       });
@@ -172,11 +172,11 @@ export const ContractSpec = ({
       <CodeEditor
         title="Contract Spec"
         value={formatSpec()}
-        selectedLanguage={selectedLanguage}
+        selectedLanguage={selectedFormat}
         fileName={`${wasmHash}-contract-spec`}
         languages={["json", "xdr"]}
         onLanguageChange={(newLanguage) => {
-          setSelectedLanguage(newLanguage);
+          setSelectedFormat(newLanguage);
         }}
         infoLink="https://developers.stellar.org/docs/build/guides/dapps/working-with-contract-specs#what-are-contract-specs"
       />

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Alert, Text, Loader, Button, Icon } from "@stellar/design-system";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { CodeEditor } from "@/components/CodeEditor";
+import { CodeEditor, SupportedLanguage } from "@/components/CodeEditor";
 import { Box } from "@/components/layout/Box";
 import { ErrorText } from "@/components/ErrorText";
 
@@ -34,6 +34,9 @@ export const ContractSpec = ({
 }) => {
   const isXdrInit = useIsXdrInit();
   const queryClient = useQueryClient();
+
+  const [selectedLanguage, setSelectedLanguage] =
+    useState<SupportedLanguage>("json");
 
   const {
     data: wasmData,
@@ -132,23 +135,33 @@ export const ContractSpec = ({
   }
 
   const formatSpec = () => {
-    const entries = wasmData?.spec?.entries;
+    const entries = wasmData?.spec?.entries || [];
 
-    try {
-      if (isXdrInit && entries?.length) {
-        const decodedEntries = entries.map((e) => {
-          const jsonString = StellarXdr.decode(
-            "ScSpecEntry",
-            e.toXDR("base64"),
-          );
+    // JSON
+    if (selectedLanguage === "json") {
+      try {
+        if (isXdrInit) {
+          const decodedEntries = entries.map((e) => {
+            const jsonString = StellarXdr.decode(
+              "ScSpecEntry",
+              e.toXDR("base64"),
+            );
 
-          return prettifyJsonString(jsonString);
-        });
+            return prettifyJsonString(jsonString);
+          });
 
-        return decodedEntries.join(",\n\n");
+          return decodedEntries.join(",\n\n");
+        }
+      } catch (e) {
+        // do nothing
       }
-    } catch (e) {
-      // do nothing
+      // XDR
+    } else if (selectedLanguage === "xdr") {
+      const xdrEntries = entries?.map((e) => {
+        return e.toXDR("base64");
+      });
+
+      return xdrEntries?.join("\n\n");
     }
 
     return "";
@@ -159,8 +172,13 @@ export const ContractSpec = ({
       <CodeEditor
         title="Contract Spec"
         value={formatSpec()}
-        language="json"
+        selectedLanguage={selectedLanguage}
         fileName={`${wasmHash}-contract-spec`}
+        languages={["json", "xdr"]}
+        onLanguageChange={(newLanguage) => {
+          setSelectedLanguage(newLanguage);
+        }}
+        infoLink="https://developers.stellar.org/docs/build/guides/dapps/working-with-contract-specs#what-are-contract-specs"
       />
 
       <Box gap="xs" direction="column" align="end">

--- a/src/components/CodeEditor/styles.scss
+++ b/src/components/CodeEditor/styles.scss
@@ -47,10 +47,20 @@
       font-weight: var(--sds-fw-semi-bold);
       color: var(--sds-clr-gray-12);
       white-space: nowrap;
+
+      .WithInfoText__button svg {
+        stroke: var(--sds-clr-gray-09);
+      }
     }
   }
 
   &__content {
     width: 100%;
+  }
+
+  &__actions {
+    & > .Select {
+      width: pxToRem(120px);
+    }
   }
 }

--- a/src/components/WithInfoText/index.tsx
+++ b/src/components/WithInfoText/index.tsx
@@ -34,7 +34,7 @@ export const WithInfoText = ({
         {children}
 
         <NextLink {...buttonBaseProps} href={href}>
-          <Icon.InfoCircle />
+          <Icon.BookOpen01 />
         </NextLink>
       </div>
     );

--- a/src/components/layout/Box/index.tsx
+++ b/src/components/layout/Box/index.tsx
@@ -15,7 +15,7 @@ export const Box = ({
   | { gap: "xs" | "sm" | "md" | "lg" | "xl" | "xxl"; customValue?: undefined }
   | { gap: "custom"; customValue: string }
 ) & {
-  children: React.ReactElement | React.ReactElement[] | null;
+  children: React.ReactElement | React.ReactElement[] | React.ReactNode;
   addlClassName?: string;
   direction?: "column" | "row" | "column-reverse" | "row-reverse";
   justify?:

--- a/src/query/useWasmFromRpc.ts
+++ b/src/query/useWasmFromRpc.ts
@@ -30,7 +30,7 @@ export const useWasmFromRpc = ({
 
         return wasm;
       } catch (e: any) {
-        throw `Something went wrong downloading the wasm binary. ${e}`;
+        throw `Something went wrong downloading the wasm binary. ${e.message || e}`;
       }
     },
     enabled: isActive,


### PR DESCRIPTION
- Updated `CodeEditor` component:
  - added languages dropdown to support language switching,
  - added optional info text or link to the title
- Added XDR format and info link to the Contract Spec