### PR TITLE
Allow setting the default network via env var.

### DIFF
--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -17,7 +17,7 @@ import { isEmptyObject } from "@/helpers/isEmptyObject";
 import { sanitizeObject } from "@/helpers/sanitizeObject";
 import { getNetworkById } from "@/helpers/getNetworkById";
 
-import { AnyObject, EmptyObj, Network } from "@/types/types";
+import { AnyObject, EmptyObj, Network, NetworkType } from "@/types/types";
 
 import "./styles.scss";
 
@@ -99,7 +99,10 @@ export const NetworkSelector = () => {
       }
     } else {
       defaultNetwork =
-        localStorageSavedNetwork.get() || getNetworkById("testnet");
+        localStorageSavedNetwork.get() ||
+        getNetworkById(
+          (process.env.NEXT_PUBLIC_DEFAULT_NETWORK ?? "testnet") as NetworkType,
+        );
     }
 
     if (defaultNetwork) {

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -206,9 +206,25 @@ interface CreateStoreOptions {
   url?: string;
 }
 
+// The default custom network will be used when creating a new store for the
+// lab that runs on quickstart. This can be enabled by passing
+// `NEXT_PUBLIC_DEFAULT_NETWORK=custom` as an env var.
+const defaultCustomNetwork = {
+  id: "custom",
+  label: "Custom",
+  horizonUrl: "http://localhost:8000",
+  rpcUrl: "http://localhost:8000/rpc",
+  passphrase: "Standalone Network ; February 2017",
+};
+
+const initNetwork =
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK === "custom"
+    ? defaultCustomNetwork
+    : {};
+
 // Initial states
 const initEndpointState = {
-  network: {},
+  network: initNetwork,
   currentEndpoint: undefined,
   params: {},
   saved: {
@@ -302,7 +318,7 @@ export const createStore = (options: CreateStoreOptions) =>
     querystring(
       immer((set) => ({
         // Shared
-        network: {},
+        network: initNetwork,
         previousNetwork: {},
         theme: null,
         isDynamicNetworkSelect: false,


### PR DESCRIPTION
This allows setting the default network to the local network. It's a pre-requisite for running the lab in quickstart.