### PR TITLE
Contract Explorer: show GitHub repo README.md in Source Code tab

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractInfo.tsx
@@ -23,6 +23,7 @@ import { ContractInfoApiResponse, EmptyObj, Network } from "@/types/types";
 import { ContractSpec } from "./ContractSpec";
 import { ContractStorage } from "./ContractStorage";
 import { VersionHistory } from "./VersionHistory";
+import { SourceCode } from "./SourceCode";
 
 export const ContractInfo = ({
   infoData,
@@ -331,7 +332,18 @@ export const ContractInfo = ({
             tab3={{
               id: "contract-source-code",
               label: "Source Code",
-              content: <ComingSoonText />,
+              content: (
+                <SourceCode
+                  isActive={activeTab === "contract-source-code"}
+                  repo={
+                    infoData.validation?.repository?.replace(
+                      "https://github.com/",
+                      "",
+                    ) || ""
+                  }
+                  commit={infoData.validation?.commit || ""}
+                />
+              ),
             }}
             tab4={{
               id: "contract-contract-storage",

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/SourceCode.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/SourceCode.tsx
@@ -1,0 +1,46 @@
+import { Code, Loader, Text } from "@stellar/design-system";
+import { CodeEditor } from "@/components/CodeEditor";
+import { Box } from "@/components/layout/Box";
+import { useGitHubReadmeText } from "@/query/useGitHubReadmeText";
+import { ErrorText } from "@/components/ErrorText";
+
+export const SourceCode = ({
+  isActive,
+  repo,
+  commit,
+}: {
+  isActive: boolean;
+  repo: string;
+  commit: string;
+}) => {
+  const {
+    data: readmeText,
+    error: readmeTextError,
+    isLoading: isReadmeTextLoading,
+    isFetching: isReadmeTextFetching,
+  } = useGitHubReadmeText({ repo, commit, isActive });
+
+  if (isReadmeTextLoading || isReadmeTextFetching) {
+    return (
+      <Box gap="sm" direction="row" justify="center">
+        <Loader />
+      </Box>
+    );
+  }
+
+  if (readmeTextError) {
+    return <ErrorText errorMessage={readmeTextError.toString()} size="sm" />;
+  }
+
+  if (!readmeText) {
+    return (
+      <Text as="div" size="sm">
+        Couldn’t find <Code size="sm">README.md</Code> in this repository.
+      </Text>
+    );
+  }
+
+  return (
+    <CodeEditor title="README.md" value={readmeText} selectedLanguage="text" />
+  );
+};

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -9,7 +9,7 @@ import { downloadFile } from "@/helpers/downloadFile";
 
 import "./styles.scss";
 
-export type SupportedLanguage = "json" | "xdr";
+export type SupportedLanguage = "json" | "xdr" | "text";
 
 type CodeEditorProps = {
   title: string;

--- a/src/query/useGitHubReadmeText.ts
+++ b/src/query/useGitHubReadmeText.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Fetch readme file from a GitHub repo.
+ */
+export const useGitHubReadmeText = ({
+  repo,
+  commit,
+  isActive,
+}: {
+  repo: string;
+  commit: string;
+  isActive: boolean;
+}) => {
+  const query = useQuery<string | null>({
+    queryKey: ["useGitHubReadmeText", repo, commit],
+    queryFn: async () => {
+      if (!repo || !commit) {
+        return null;
+      }
+
+      try {
+        const response = await fetch(
+          `https://raw.githubusercontent.com/${repo}/${commit}/README.md`,
+        );
+
+        if (response.status !== 200) {
+          return null;
+        }
+
+        return await response.text();
+      } catch (e: any) {
+        throw `Something went wrong fetching README file. ${e.message || e}.`;
+      }
+    },
+    enabled: isActive,
+  });
+
+  return query;
+};


### PR DESCRIPTION
- Using GitHub repo from StellarExpert's API
- Fetching `README.md` file from that repo
  - File name is case sensitive, but the GitHub official naming convention is "README.md", so we'll check that.

![image](https://github.com/user-attachments/assets/716d5c91-009c-4979-b09f-65cd70416e9d)
