### PR TITLE
error handling and submission for json schema

### DIFF
--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, Card, Icon, Input } from "@stellar/design-system";
+import { Button, Card, Icon, Input, Text } from "@stellar/design-system";
 import type { JSONSchema7 } from "json-schema";
 import { parse } from "lossless-json";
 
@@ -22,6 +22,8 @@ export const JsonSchemaFormRenderer = ({
   onChange,
   index,
   requiredFields,
+  formError,
+  setFormError,
 }: {
   name: string;
   schema: JSONSchema7;
@@ -30,12 +32,12 @@ export const JsonSchemaFormRenderer = ({
   onChange: (value: SorobanInvokeValue) => void;
   index?: number;
   requiredFields?: string[];
+  formError: AnyObject;
+  setFormError: (formError: AnyObject) => void;
 }) => {
   const { transaction } = useStore();
   const { build } = transaction;
   const { operation: sorobanOperation } = build.soroban;
-
-  const [formError, setFormError] = useState<AnyObject>({});
 
   // parse stringified soroban operation
   const parsedSorobanOperation = parse(
@@ -52,7 +54,6 @@ export const JsonSchemaFormRenderer = ({
   };
   const sharedProps = {
     id: path.join("."),
-    key: path.join("."),
     label: labelWithSchemaType,
     value: getNestedValue(parsedSorobanOperation.args, path.join(".")),
     error: path.length > 0 ? formError[path.join(".")] : formError[name],
@@ -60,7 +61,9 @@ export const JsonSchemaFormRenderer = ({
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>,
-    validateFn?: (value: string, required?: boolean) => string | false,
+    validateFn?:
+      | ((value: string, required?: boolean) => string | false)
+      | ((value: string, required?: boolean) => string | false)[],
   ) => {
     /**
      * Example of how setNestedValueWithArr works:
@@ -103,7 +106,13 @@ export const JsonSchemaFormRenderer = ({
     }
 
     // Validate the value
-    const error = validateFn?.(e.target.value, requiredFields?.includes(label));
+    // Address type validates both public key and contract address
+    const error = Array.isArray(validateFn)
+      ? validateFn.every((fn) =>
+          fn(e.target.value, requiredFields?.includes(label)),
+        )
+      : validateFn?.(e.target.value, requiredFields?.includes(label));
+
     const currentPath = path.length > 0 ? path.join(".") : name;
 
     setFormError({
@@ -126,16 +135,52 @@ export const JsonSchemaFormRenderer = ({
     return (
       <Box gap="md">
         {Object.entries(schema.properties || {}).map(
-          ([key, subSchema], index) => (
-            <JsonSchemaFormRenderer
-              name={key}
-              key={`${key}-${index}`}
-              schema={subSchema as JSONSchema7}
-              onChange={onChange}
-              formData={formData}
-              requiredFields={schema.required}
-            />
-          ),
+          ([key, subSchema], index) => {
+            const subSchemaObj = getSchemaProperty(schema, key);
+
+            if (subSchemaObj?.type === "object") {
+              return (
+                <>
+                  <LabelHeading size="md" infoText={schema.description}>
+                    {key}
+                  </LabelHeading>
+                  {subSchemaObj?.description ? (
+                    <Text as="div" size="xs">
+                      {subSchemaObj.description}
+                    </Text>
+                  ) : null}
+
+                  <Box gap="md">
+                    <Card>
+                      <JsonSchemaFormRenderer
+                        name={key}
+                        key={`${key}-${index}`}
+                        schema={subSchema as JSONSchema7}
+                        onChange={onChange}
+                        formData={formData}
+                        requiredFields={schema.required}
+                        setFormError={setFormError}
+                        formError={formError}
+                      />
+                    </Card>
+                  </Box>
+                </>
+              );
+            }
+
+            return (
+              <JsonSchemaFormRenderer
+                name={key}
+                key={`${key}-${index}`}
+                schema={subSchema as JSONSchema7}
+                onChange={onChange}
+                formData={formData}
+                requiredFields={schema.required}
+                setFormError={setFormError}
+                formError={formError}
+              />
+            );
+          },
         )}
       </Box>
     );
@@ -202,6 +247,8 @@ export const JsonSchemaFormRenderer = ({
                               formData={args}
                               onChange={onChange}
                               requiredFields={schema.required}
+                              setFormError={setFormError}
+                              formError={formError}
                             />
                           );
                         })}
@@ -255,8 +302,12 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
-            handleChange(e, validate.getPublicKeyError);
+            handleChange(e, [
+              validate.getPublicKeyError,
+              validate.getContractIdError,
+            ]);
           }}
           infoText={schema.description || ""}
           leftElement={<Icon.User03 />}
@@ -268,6 +319,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <PositiveIntPicker
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getU32Error);
           }}
@@ -277,6 +329,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <PositiveIntPicker
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getU64Error);
           }}
@@ -286,6 +339,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <PositiveIntPicker
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getU128Error);
           }}
@@ -295,6 +349,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <PositiveIntPicker
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getU256Error);
           }}
@@ -304,6 +359,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getI32Error);
           }}
@@ -314,6 +370,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getI64Error);
           }}
@@ -324,6 +381,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getI128Error);
           }}
@@ -334,6 +392,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getI256Error);
           }}
@@ -345,6 +404,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           error="" // @TODO
           onChange={(e) => {
             // @TODO validate the value via length
@@ -358,6 +418,7 @@ export const JsonSchemaFormRenderer = ({
       return (
         <Input
           {...sharedProps}
+          key={path.join(".")}
           onChange={(e) => {
             handleChange(e, validate.getDataUrlError);
           }}

--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Button, Card, Icon, Input, Text } from "@stellar/design-system";
 import type { JSONSchema7 } from "json-schema";
 import { parse } from "lossless-json";

--- a/src/helpers/dereferenceSchema.ts
+++ b/src/helpers/dereferenceSchema.ts
@@ -57,7 +57,6 @@ export const dereferenceSchema = (
         };
       }
 
-      // return fullSchema?.definitions?.[refPath];
       return {
         type: refPath,
         description: refPathDef?.description ?? false,

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -13,14 +13,12 @@ import {
 import { TransactionBuildParams } from "@/store/createStore";
 import { SorobanOpType, TxnOperation } from "@/types/types";
 
-export const isSorobanOperationType = (operationType: string) => {
-  // @TODO: add invoke_host_function
-  return [
+export const isSorobanOperationType = (operationType: string) =>
+  [
     "extend_footprint_ttl",
     "restore_footprint",
     "invoke_contract_function",
   ].includes(operationType);
-};
 
 // https://developers.stellar.org/docs/learn/glossary#ledgerkey
 // https://developers.stellar.org/docs/build/guides/archival/restore-data-js

--- a/tests/signTransactionPage.test.ts
+++ b/tests/signTransactionPage.test.ts
@@ -162,7 +162,7 @@ test.describe("Sign Transaction Page", () => {
     ).toBeVisible();
 
     // Wallet Extension to display 6 wallets
-    await expect(page.getByRole("listitem")).toHaveCount(6);
+    await expect(page.getByRole("listitem")).toHaveCount(7);
 
     // Exit out of the wallet extension modal
     await page.click("body", { position: { x: 10, y: 10 } });

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,9 +522,9 @@
     glob "10.3.10"
 
 "@next/eslint-plugin-next@^14.2.14":
-  version "14.2.27"
-  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.27.tgz#7bb7c2026d16761edac86d41c234f1d6286f7703"
-  integrity sha512-nwXJPtxaL/1Dd80dwmhTZpc/kghn8WJrnKfZr/v+o2tkwlINKiYcflYwm/YIBLiJiwGPZMoFJRDxlsJexv21vw==
+  version "14.2.28"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.28.tgz#831aa5955c96503bf515561cf7b307097b65bbd8"
+  integrity sha512-GQUPA1bTZy5qZdPV5MOHB18465azzhg8xm5o2SqxMF+h1rWNjB43y6xmIPHG5OV2OiU3WxuINpusXom49DdaIQ==
   dependencies:
     glob "10.3.10"
 
@@ -3342,9 +3342,9 @@ bigint-buffer@^1.1.5:
     bindings "^1.3.0"
 
 bignumber.js@^9.0.0, bignumber.js@^9.1.2:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.2.0.tgz#273a03ba2dd44bb29ffff91a1097d9e952d2680d"
-  integrity sha512-JocpCSOixzy5XFJi2ub6IMmV/G9i8Lrm2lZvwBv9xPdglmZM0ufDVBbjbrfU/zuLvBfD7Bv2eYxz9i+OHTgkew==
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.2.1.tgz#3ad0854ad933560a25bbc7c93bc3b7ea6edcad85"
+  integrity sha512-+NzaKgOUvInq9TIUZ1+DRspzf/HApkCwD4btfuasFTdrfnOxqx853TgDpMolp+uv4RpRp7bPcEU2zKr9+fRmyw==
 
 bindings@^1.3.0:
   version "1.5.0"


### PR DESCRIPTION
- moved `setFormError` to parent so that we can disable submit button if there are any errors from its children
- resetting errors for submission when children inputs change
- `Address` field to check either `public key` or `contract id` 