### PR TITLE
Network Selector: keep previously saved network values on change

### DIFF
--- a/src/app/(sidebar)/account/fund/components/SwitchNetwork.tsx
+++ b/src/app/(sidebar)/account/fund/components/SwitchNetwork.tsx
@@ -25,6 +25,7 @@ export const SwitchNetwork = () => {
           <SwitchNetworkButtons
             includedNetworks={["futurenet", "testnet"]}
             buttonSize="md"
+            page="fund account"
           />
         </div>
       </div>

--- a/src/app/(sidebar)/account/saved/page.tsx
+++ b/src/app/(sidebar)/account/saved/page.tsx
@@ -135,6 +135,7 @@ export default function SavedKeypairs() {
           <SwitchNetworkButtons
             includedNetworks={["futurenet", "testnet"]}
             buttonSize="md"
+            page="saved accounts"
           />
         </Box>
       </Box>

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -151,6 +151,7 @@ export default function ContractExplorer() {
         <SwitchNetworkButtons
           includedNetworks={["testnet", "mainnet"]}
           buttonSize="md"
+          page="contract explorer"
         />
       </Box>
     );

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -160,6 +160,7 @@ export const NetworkSelector = () => {
         handleSelectNetwork(event);
       }
     },
+    // Not including handleSelectNetwork
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isSubmitDisabled],
   );

--- a/src/components/SwitchNetworkButtons.tsx
+++ b/src/components/SwitchNetworkButtons.tsx
@@ -8,9 +8,11 @@ import { NetworkType } from "@/types/types";
 export const SwitchNetworkButtons = ({
   includedNetworks,
   buttonSize,
+  page,
 }: {
   includedNetworks: NetworkType[];
   buttonSize: "sm" | "md" | "lg";
+  page: string;
 }) => {
   const { selectNetwork, updateIsDynamicNetworkSelect } = useStore();
 
@@ -34,6 +36,7 @@ export const SwitchNetworkButtons = ({
             getAndSetNetwork(n);
             trackEvent(TrackingEvent.NETWORK_SWITCH, {
               to: n,
+              location: `${page} button`,
             });
           }}
         >

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -3,6 +3,8 @@ import { Network } from "@/types/types";
 
 export const LOCAL_STORAGE_SETTINGS = "stellar_lab_settings";
 export const LOCAL_STORAGE_SAVED_NETWORK = "stellar_lab_network";
+export const LOCAL_STORAGE_SAVED_NETWORKS_PREVIOUS =
+  "stellar_lab_networks_previous";
 export const LOCAL_STORAGE_SAVED_ENDPOINTS_HORIZON =
   "stellar_lab_saved_horizon_endpoints";
 export const LOCAL_STORAGE_SAVED_RPC_METHODS =

--- a/src/helpers/localStorageSavedNetworksPrevious.ts
+++ b/src/helpers/localStorageSavedNetworksPrevious.ts
@@ -1,0 +1,53 @@
+import { LOCAL_STORAGE_SAVED_NETWORKS_PREVIOUS } from "@/constants/settings";
+import { sanitizeObject } from "@/helpers/sanitizeObject";
+import { NetworkType } from "@/types/types";
+
+type SavedPreviousNetworks = Record<
+  NetworkType,
+  {
+    rpcUrl: string;
+    horizonUrl: string;
+    passphrase?: string;
+  }
+>;
+
+export const localStorageSavedNetworksPrevious = {
+  get: () => {
+    const savedNetworksString = localStorage.getItem(
+      LOCAL_STORAGE_SAVED_NETWORKS_PREVIOUS,
+    );
+    return savedNetworksString
+      ? (JSON.parse(savedNetworksString) as SavedPreviousNetworks)
+      : null;
+  },
+  set: ({
+    networkId,
+    rpcUrl,
+    horizonUrl,
+    passphrase,
+  }: {
+    networkId: NetworkType;
+    rpcUrl: string;
+    horizonUrl: string;
+    passphrase?: string;
+  }) => {
+    const currentNetworksString = localStorage.getItem(
+      LOCAL_STORAGE_SAVED_NETWORKS_PREVIOUS,
+    );
+
+    const currentNetworkObj = currentNetworksString
+      ? JSON.parse(currentNetworksString)
+      : {};
+
+    return localStorage.setItem(
+      LOCAL_STORAGE_SAVED_NETWORKS_PREVIOUS,
+      JSON.stringify({
+        ...currentNetworkObj,
+        [networkId]: sanitizeObject({ rpcUrl, horizonUrl, passphrase }),
+      }),
+    );
+  },
+  remove: () => {
+    return localStorage.removeItem(LOCAL_STORAGE_SAVED_NETWORKS_PREVIOUS);
+  },
+};


### PR DESCRIPTION
- Keep previously saved RPC and Horizon URL values when switching back to that network.
- Updated network change tracking to add where it was changed from (button on a page or network selector).