### PR TITLE
[Sign Tx] Reset the previous signed tx; enable simulate tx only for soroban operation

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -47,6 +47,7 @@ export const Operations = () => {
     updateBuildSingleOperation,
     // Soroban
     updateSorobanBuildOperation,
+    updateSorobanBuildXdr,
     // Either Classic or Soroban
     updateBuildIsValid,
     setBuildOperationsError,
@@ -123,6 +124,7 @@ export const Operations = () => {
   const resetSorobanOperation = () => {
     updateSorobanBuildOperation(INITIAL_OPERATION);
     setOperationsError([EMPTY_OPERATION_ERROR]);
+    updateSorobanBuildXdr("");
   };
 
   // Preserve values and validate inputs when components mounts
@@ -786,11 +788,12 @@ export const Operations = () => {
 
             if (isSorobanOperationType(newOpType)) {
               // reset both the soroban and classic operation
-              // we reset soroban operatiion because its invoke host function
+              // we reset soroban operation because its invoke host function
               // will have a nested operation
+              updateBuildOperations([INITIAL_OPERATION]);
+
               resetSorobanOperation();
               updateOptionParamAndError({ type: "reset" });
-
               updateSorobanBuildOperation({
                 operation_type: newOpType,
                 params: defaultParams,

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -57,6 +57,7 @@ export const Overview = () => {
     resetSign,
     updateFeeBumpParams,
   } = transaction;
+  const { soroban } = transaction.build;
 
   const router = useRouter();
   const successResponseEl = useRef<HTMLDivElement | null>(null);
@@ -145,6 +146,13 @@ export const Overview = () => {
     updateSignActiveView,
     updateSignImportTx,
   ]);
+
+  useEffect(() => {
+    // Always reset the signed tx since user's signature(s) always get reset as well
+    updateSignedTx("");
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (exSuccessMsg || exErrorMsg) {
@@ -948,10 +956,15 @@ export const Overview = () => {
                   >
                     Submit transaction
                   </Button>
-
-                  <Button size="md" variant="tertiary" onClick={onSimulateTxn}>
-                    Simulate transaction
-                  </Button>
+                  {soroban.xdr ? (
+                    <Button
+                      size="md"
+                      variant="tertiary"
+                      onClick={onSimulateTxn}
+                    >
+                      Simulate transaction
+                    </Button>
+                  ) : null}
                 </Box>
               }
               footerRightEl={

--- a/src/app/(sidebar)/transaction/sign/components/Overview.tsx
+++ b/src/app/(sidebar)/transaction/sign/components/Overview.tsx
@@ -37,6 +37,7 @@ import { PubKeyPicker } from "@/components/FormElements/PubKeyPicker";
 import { LabelHeading } from "@/components/LabelHeading";
 import { PageCard } from "@/components/layout/PageCard";
 import { MessageField } from "@/components/MessageField";
+import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
 const MIN_LENGTH_FOR_FULL_WIDTH_FIELD = 30;
 
@@ -57,7 +58,6 @@ export const Overview = () => {
     resetSign,
     updateFeeBumpParams,
   } = transaction;
-  const { soroban } = transaction.build;
 
   const router = useRouter();
   const successResponseEl = useRef<HTMLDivElement | null>(null);
@@ -110,6 +110,8 @@ export const Overview = () => {
   const [sigSuccessMsg, setSigSuccessMsg] = useState("");
   const [sigErrorMsg, setSigErrorMsg] = useState("");
 
+  const [isSorobanXdr, setIsSorobanXdr] = useState(false);
+
   const HAS_SECRET_KEYS = secretKeyInputs.some((input) => input !== "");
   const HAS_INVALID_SECRET_KEYS = secretKeyInputs.some((input) => {
     if (input.length) {
@@ -136,6 +138,11 @@ export const Overview = () => {
         network.passphrase,
       );
 
+      const isSorobanTx = isSorobanOperationType(
+        transaction?.operations?.[0]?.type,
+      );
+
+      setIsSorobanXdr(isSorobanTx);
       updateSignImportTx(transaction);
     } else {
       updateSignActiveView("import");
@@ -956,15 +963,15 @@ export const Overview = () => {
                   >
                     Submit transaction
                   </Button>
-                  {soroban.xdr ? (
-                    <Button
-                      size="md"
-                      variant="tertiary"
-                      onClick={onSimulateTxn}
-                    >
-                      Simulate transaction
-                    </Button>
-                  ) : null}
+
+                  <Button
+                    size="md"
+                    variant="tertiary"
+                    onClick={onSimulateTxn}
+                    disabled={!isSorobanXdr}
+                  >
+                    Simulate transaction
+                  </Button>
                 </Box>
               }
               footerRightEl={

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -18,6 +18,7 @@ export const isSorobanOperationType = (operationType: string) =>
     "extend_footprint_ttl",
     "restore_footprint",
     "invoke_contract_function",
+    "invokeHostFunction",
   ].includes(operationType);
 
 // https://developers.stellar.org/docs/learn/glossary#ledgerkey

--- a/tests/signTransactionPage.test.ts
+++ b/tests/signTransactionPage.test.ts
@@ -9,106 +9,6 @@ test.describe("Sign Transaction Page", () => {
     await expect(page.locator("h1")).toHaveText("Sign Transaction");
   });
 
-  test("Overview with a VALID Soroban Transaction", async ({ page }) => {
-    // sections
-    const overview = page.getByTestId("sign-tx-overview");
-    const signaturesView = page.getByTestId("sign-tx-sigs");
-    const secretKeysView = page.getByTestId("sign-tx-secretkeys");
-    const validationView = page.getByTestId("sign-tx-validation-card");
-    const signedXdr = page.getByTestId("validation-card-response");
-
-    // Import Screen
-    const importBtn = page.getByText("Import transaction");
-    const validMsg = page.getByText("Valid Transaction Envelope XDR");
-
-    const xdrInput = page.getByLabel(
-      "Import a transaction envelope in XDR format",
-    );
-    await xdrInput.fill(MOCK_SOROBAN_XDR);
-
-    await expect(validMsg).toBeVisible();
-
-    await importBtn.click();
-
-    // Overview and Signatures Screen
-    await expect(overview).toBeVisible();
-    await expect(signaturesView).toBeVisible();
-
-    /*** TX Overview Details ***/
-    // Network passphrase
-    const overviewSigning = page.getByLabel("Signing for");
-    await expect(overviewSigning).toHaveValue(
-      "Test SDF Network ; September 2015",
-    );
-
-    // TX XDR
-    const overviewTxXDR = page.getByLabel("Transaction Envelope XDR");
-    await expect(overviewTxXDR).toHaveValue(MOCK_SOROBAN_XDR);
-
-    // TX HASH
-    const overviewTxHash = page.getByLabel("Transaction Hash");
-    await expect(overviewTxHash).toHaveValue(
-      "ab12155abb53a5f8177e47683a870976621fcac62cc3441d997cc0aafaac99ad",
-    );
-
-    // Source Account
-    const overviewSource = page.getByLabel("Source account");
-    await expect(overviewSource).toHaveValue(
-      "GBOTV3EYB4BO26MK3PFXNDWKI54XGXMLMK52F7TYLNOOQLL2GCJGBUQQ",
-    );
-
-    // Sequence number
-    const overviewSeq = page.getByLabel("Sequence number");
-    await expect(overviewSeq).toHaveValue("1112100176920589");
-
-    // Transaction Fee (stroops)
-    const overviewTxFee = page.getByLabel("Transaction Fee (stroops)");
-    await expect(overviewTxFee).toHaveValue("1920974");
-
-    // Number of operations
-    const overviewOpsNum = page.getByLabel("Number of operations");
-    await expect(overviewOpsNum).toHaveValue("1");
-
-    /*** Signatures: Secret Keys ***/
-    // Click 'Add additional' button to get an additional secret input field
-    const multiPickerContainer = page.getByTestId("multipicker-signer");
-    const multiPickerInput = multiPickerContainer.getByPlaceholder(
-      "Secret key (starting with S) or hash preimage (in hex)",
-    );
-    const secretKeysSignBtn = secretKeysView.getByText("Sign transaction");
-    const invalidSecretKeyErrorMsg = page.getByText(
-      "Invalid secret key. Please check your secret key and try again.",
-    );
-    const successSecretKeyMsg = secretKeysView.getByText(
-      "Successfully added 1 signature",
-    );
-
-    await expect(multiPickerInput).toHaveCount(1);
-
-    // Type in a string in an valid secret key format
-    await multiPickerInput
-      .nth(0)
-      .fill("SCX5AFVSAW7NUDWMYIO6E5BVLNHHU4YELSP2YI66YAQKPQXT2UXJWLJ6");
-    await expect(invalidSecretKeyErrorMsg).toBeHidden();
-    await expect(secretKeysSignBtn).toBeEnabled();
-
-    await secretKeysSignBtn.click();
-
-    await expect(successSecretKeyMsg).toBeVisible();
-
-    await expect(signedXdr).toContainText(
-      "AAAAAgAAAABdOuyYDwLteYrby3aOykd5c12LYrui/nhbXOgtejCSYAAdT84AA/NzAAAADQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABlL5dkzzoyLMbmYEsrdy39HekdojWLuKyg7lC02jClEoAAAAEbWludAAAAAIAAAASAAAAAAAAAADRh2IaEYIegGIrvdxKRF5FM9AGClfaqPnxY7SmWduVggAAAAoAAAAAAAAAAAAAAAAAAAABAAAAAQAAAAAAAAAAAAAAAZS+XZM86MizG5mBLK3ct/R3pHaI1i7isoO5QtNowpRKAAAABG1pbnQAAAACAAAAEgAAAAAAAAAA0YdiGhGCHoBiK73cSkReRTPQBgpX2qj58WO0plnblYIAAAAKAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAHJ9d4ncm4GZ+WLWTVqsnHAEkBZcuJ/PoXwvzFTQBx5ygAAAACAAAABgAAAAGUvl2TPOjIsxuZgSyt3Lf0d6R2iNYu4rKDuULTaMKUSgAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAADRh2IaEYIegGIrvdxKRF5FM9AGClfaqPnxY7SmWduVggAAAAEAAAAGAAAAAZS+XZM86MizG5mBLK3ct/R3pHaI1i7isoO5QtNowpRKAAAAFAAAAAEAL4fdAABS/AAAAfwAAAAAAB1PBgAAAAF6MJJgAAAAQA+i1MPVxoGS9hO+roDg4od2KV1TmaaeuTwswZ5FLW/24F+oRFFwUetyxQ8SKfY0SPSyCvJdVo1bbv/65NugBwI=",
-    );
-
-    const submitBtn = validationView.getByText("Submit transaction");
-    const simulateBtn = validationView.getByText("Simulate transaction");
-
-    await expect(submitBtn).toBeEnabled();
-    await expect(simulateBtn).toBeEnabled();
-
-    await submitBtn.click();
-  });
-
   test("Overview with a VALID Classic Transaction with ONE operation envelope XDR", async ({
     page,
   }) => {
@@ -318,6 +218,106 @@ test.describe("Sign Transaction Page", () => {
 
     await expect(submitBtn).toBeEnabled();
     await expect(simulateBtn).toBeDisabled();
+
+    await submitBtn.click();
+  });
+
+  test("Overview with a VALID Soroban Transaction", async ({ page }) => {
+    // sections
+    const overview = page.getByTestId("sign-tx-overview");
+    const signaturesView = page.getByTestId("sign-tx-sigs");
+    const secretKeysView = page.getByTestId("sign-tx-secretkeys");
+    const validationView = page.getByTestId("sign-tx-validation-card");
+    const signedXdr = page.getByTestId("validation-card-response");
+
+    // Import Screen
+    const importBtn = page.getByText("Import transaction");
+    const validMsg = page.getByText("Valid Transaction Envelope XDR");
+
+    const xdrInput = page.getByLabel(
+      "Import a transaction envelope in XDR format",
+    );
+    await xdrInput.fill(MOCK_SOROBAN_XDR);
+
+    await expect(validMsg).toBeVisible();
+
+    await importBtn.click();
+
+    // Overview and Signatures Screen
+    await expect(overview).toBeVisible();
+    await expect(signaturesView).toBeVisible();
+
+    /*** TX Overview Details ***/
+    // Network passphrase
+    const overviewSigning = page.getByLabel("Signing for");
+    await expect(overviewSigning).toHaveValue(
+      "Test SDF Network ; September 2015",
+    );
+
+    // TX XDR
+    const overviewTxXDR = page.getByLabel("Transaction Envelope XDR");
+    await expect(overviewTxXDR).toHaveValue(MOCK_SOROBAN_XDR);
+
+    // TX HASH
+    const overviewTxHash = page.getByLabel("Transaction Hash");
+    await expect(overviewTxHash).toHaveValue(
+      "ab12155abb53a5f8177e47683a870976621fcac62cc3441d997cc0aafaac99ad",
+    );
+
+    // Source Account
+    const overviewSource = page.getByLabel("Source account");
+    await expect(overviewSource).toHaveValue(
+      "GBOTV3EYB4BO26MK3PFXNDWKI54XGXMLMK52F7TYLNOOQLL2GCJGBUQQ",
+    );
+
+    // Sequence number
+    const overviewSeq = page.getByLabel("Sequence number");
+    await expect(overviewSeq).toHaveValue("1112100176920589");
+
+    // Transaction Fee (stroops)
+    const overviewTxFee = page.getByLabel("Transaction Fee (stroops)");
+    await expect(overviewTxFee).toHaveValue("1920974");
+
+    // Number of operations
+    const overviewOpsNum = page.getByLabel("Number of operations");
+    await expect(overviewOpsNum).toHaveValue("1");
+
+    /*** Signatures: Secret Keys ***/
+    // Click 'Add additional' button to get an additional secret input field
+    const multiPickerContainer = page.getByTestId("multipicker-signer");
+    const multiPickerInput = multiPickerContainer.getByPlaceholder(
+      "Secret key (starting with S) or hash preimage (in hex)",
+    );
+    const secretKeysSignBtn = secretKeysView.getByText("Sign transaction");
+    const invalidSecretKeyErrorMsg = page.getByText(
+      "Invalid secret key. Please check your secret key and try again.",
+    );
+    const successSecretKeyMsg = secretKeysView.getByText(
+      "Successfully added 1 signature",
+    );
+
+    await expect(multiPickerInput).toHaveCount(1);
+
+    // Type in a string in an valid secret key format
+    await multiPickerInput
+      .nth(0)
+      .fill("SCX5AFVSAW7NUDWMYIO6E5BVLNHHU4YELSP2YI66YAQKPQXT2UXJWLJ6");
+    await expect(invalidSecretKeyErrorMsg).toBeHidden();
+    await expect(secretKeysSignBtn).toBeEnabled();
+
+    await secretKeysSignBtn.click();
+
+    await expect(successSecretKeyMsg).toBeVisible();
+
+    await expect(signedXdr).toContainText(
+      "AAAAAgAAAABdOuyYDwLteYrby3aOykd5c12LYrui/nhbXOgtejCSYAAdT84AA/NzAAAADQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABlL5dkzzoyLMbmYEsrdy39HekdojWLuKyg7lC02jClEoAAAAEbWludAAAAAIAAAASAAAAAAAAAADRh2IaEYIegGIrvdxKRF5FM9AGClfaqPnxY7SmWduVggAAAAoAAAAAAAAAAAAAAAAAAAABAAAAAQAAAAAAAAAAAAAAAZS+XZM86MizG5mBLK3ct/R3pHaI1i7isoO5QtNowpRKAAAABG1pbnQAAAACAAAAEgAAAAAAAAAA0YdiGhGCHoBiK73cSkReRTPQBgpX2qj58WO0plnblYIAAAAKAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAHJ9d4ncm4GZ+WLWTVqsnHAEkBZcuJ/PoXwvzFTQBx5ygAAAACAAAABgAAAAGUvl2TPOjIsxuZgSyt3Lf0d6R2iNYu4rKDuULTaMKUSgAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAADRh2IaEYIegGIrvdxKRF5FM9AGClfaqPnxY7SmWduVggAAAAEAAAAGAAAAAZS+XZM86MizG5mBLK3ct/R3pHaI1i7isoO5QtNowpRKAAAAFAAAAAEAL4fdAABS/AAAAfwAAAAAAB1PBgAAAAF6MJJgAAAAQA+i1MPVxoGS9hO+roDg4od2KV1TmaaeuTwswZ5FLW/24F+oRFFwUetyxQ8SKfY0SPSyCvJdVo1bbv/65NugBwI=",
+    );
+
+    const submitBtn = validationView.getByText("Submit transaction");
+    const simulateBtn = validationView.getByText("Simulate transaction");
+
+    await expect(submitBtn).toBeEnabled();
+    await expect(simulateBtn).toBeEnabled();
 
     await submitBtn.click();
   });


### PR DESCRIPTION
**Bugs:**
- When a tx gets successfully submitted via Sign Tx page and user goes back to Build TX to build a new tx, once they enter Sign TX page, their previous signed tx result stays intact. This fixes this by resetting the sign`.signedtx`. Resetting the signed passwords is the default behavior so its previous successful signed tx should also be reset
- This also fixes enabling `Simulate Transaction` button only for Soroban operation. Previous `simulate tx` was also shown for classic tx

https://github.com/user-attachments/assets/0de11595-8217-4740-87b4-2b4e750c5103

