### PR TITLE
Xdr Newline Fix Pr

### DIFF
--- a/src/components/FormElements/XdrPicker.tsx
+++ b/src/components/FormElements/XdrPicker.tsx
@@ -35,17 +35,10 @@ export const XdrPicker = ({
       // Clean the value by removing all whitespace (including newlines)
       const cleanedValue = e.target.value.replace(/\s+/g, '');
       
-      // Create a new event with the cleaned value
-      const newEvent = {
+      onChange({
         ...e,
-        target: {
-          ...e.target,
-          value: cleanedValue
-        }
-      } as React.ChangeEvent<HTMLTextAreaElement>;
-      
-      // Pass the cleaned event to the parent component
-      onChange(newEvent);
+        target: { ...e.target, value: cleanedValue },
+      });
     }
   };
 

--- a/src/components/FormElements/XdrPicker.tsx
+++ b/src/components/FormElements/XdrPicker.tsx
@@ -27,22 +27,45 @@ export const XdrPicker = ({
   readOnly,
   disabled,
   ...props
-}: XdrPickerProps) => (
-  <Textarea
-    id={id}
-    fieldSize={fieldSize}
-    label={label}
-    value={value}
-    labelSuffix={labelSuffix}
-    placeholder="Ex: AAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAZAAAAAMAAAAGAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAJAAAAAAAAAAHwXhY2AAAAQCPAo8QwsZe9FA0sz/deMdhlu6/zrk7SgkBG22ApvtpETBhnGkX4trSFDz8sVlKqvweqGUVgvjUyM0AcHxyXZQw="
-    error={error}
-    success={success}
-    rows={5}
-    onChange={onChange}
-    readOnly={readOnly}
-    disabled={disabled}
-    {...props}
-  >
-    {props.children}
-  </Textarea>
-);
+}: XdrPickerProps) => {
+
+  //Internal function that cleans up the input by removing newlines and extra spaces
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (onChange) {
+      // Clean the value by removing all whitespace (including newlines)
+      const cleanedValue = e.target.value.replace(/\s+/g, '');
+      
+      // Create a new event with the cleaned value
+      const newEvent = {
+        ...e,
+        target: {
+          ...e.target,
+          value: cleanedValue
+        }
+      } as React.ChangeEvent<HTMLTextAreaElement>;
+      
+      // Pass the cleaned event to the parent component
+      onChange(newEvent);
+    }
+  };
+
+  return (
+    <Textarea
+      id={id}
+      fieldSize={fieldSize}
+      label={label}
+      value={value}
+      labelSuffix={labelSuffix}
+      placeholder="Ex: AAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAZAAAAAMAAAAGAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAJAAAAAAAAAAHwXhY2AAAAQCPAo8QwsZe9FA0sz/deMdhlu6/zrk7SgkBG22ApvtpETBhnGkX4trSFDz8sVlKqvweqGUVgvjUyM0AcHxyXZQw="
+      error={error}
+      success={success}
+      rows={5}
+      onChange={handleChange}
+      readOnly={readOnly}
+      disabled={disabled}
+      {...props}
+    >
+      {props.children}
+    </Textarea>
+  );
+};


### PR DESCRIPTION
Fix for Issue #1287 - Filter out \n when decoding the XDR

Description:
This PR resolves issue https://github.com/stellar/laboratory/issues/1287 by adding functionality to filter out newline characters (\n) when decoding XDR strings pasted into the Stellar Laboratory tool. Previously, copying XDR from terminals or other sources that introduced line breaks would cause decoding errors. With this fix, newline characters are automatically removed, allowing smooth decoding.

Changes:

Implemented a sanitization step in the XDR input handling function that removes newline (\n) characters.

Ensured existing functionality remains unaffected.

Testing:

Manual tests were performed:

1. Tested pasting XDR strings containing newlines (\n) to verify successful decoding.
2. Tested normal XDR strings without newlines to ensure no regression.



[Demo Video:](https://www.loom.com/share/803fcc9b829149acaeff44ea0d9c8893)
I've recorded a video demonstration showcasing:

1. The issue resolved (with the new function).
2. The issue occurring (without the new function).