### PR TITLE
Contract Spec: Update links to dev docs on contract info page

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
@@ -115,7 +115,7 @@ export const ContractSpec = ({
             sectionName: "contractmetav0",
             title: "Contract Meta",
             infoLink:
-              "https://developers.stellar.org/docs/tools/sdks/build-your-own#contract-meta-generation",
+              "https://developers.stellar.org/docs/learn/encyclopedia/contract-development/stellar-contract#contract-meta",
             height: "22",
           })
         : null}
@@ -125,7 +125,7 @@ export const ContractSpec = ({
             sectionName: "contractenvmetav0",
             title: "Contract Env Meta",
             infoLink:
-              "https://developers.stellar.org/docs/tools/sdks/build-your-own#environment-meta-generation",
+              "https://developers.stellar.org/docs/learn/encyclopedia/contract-development/stellar-contract#environment-meta",
             height: "15",
           })
         : null}
@@ -135,7 +135,7 @@ export const ContractSpec = ({
             sectionName: "contractspecv0",
             title: "Contract Spec",
             infoLink:
-              "https://developers.stellar.org/docs/build/guides/dapps/working-with-contract-specs#what-are-contract-specs",
+              "https://developers.stellar.org/docs/learn/encyclopedia/contract-development/stellar-contract#contract-spec",
           })
         : null}
 


### PR DESCRIPTION
Fixes issue https://github.com/stellar/laboratory/issues/1360.
Updates the dev doc links shown in the Contract Spec preview page.

- [x] Env Meta - https://developers.stellar.org/docs/learn/encyclopedia/contract-development/stellar-contract#environment-meta
- [x] Contract Meta - https://developers.stellar.org/docs/learn/encyclopedia/contract-development/stellar-contract#contract-meta
- [x] Contract Spec - https://developers.stellar.org/docs/learn/encyclopedia/contract-development/stellar-contract#contract-spec
