### PR TITLE
Network Selector: show new network settings modal from URL on Mainnet

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/SourceCode.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/SourceCode.tsx
@@ -10,6 +10,7 @@ import { CodeEditor } from "@/components/CodeEditor";
 import { Box } from "@/components/layout/Box";
 import { ErrorText } from "@/components/ErrorText";
 import { useGitHubReadmeText } from "@/query/useGitHubReadmeText";
+import { openUrl } from "@/helpers/openUrl";
 
 export const SourceCode = ({
   isActive,
@@ -99,7 +100,7 @@ export const SourceCode = ({
       return;
     }
 
-    window.open(url, "_blank");
+    openUrl(url);
   };
 
   return (

--- a/src/components/NetworkSelector/LoadNetworkModal.tsx
+++ b/src/components/NetworkSelector/LoadNetworkModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, Text } from "@stellar/design-system";
+import { Alert, Button, Modal, Text } from "@stellar/design-system";
 import { Box } from "@/components/layout/Box";
 import { Network } from "@/types/types";
 
@@ -35,6 +35,12 @@ export const LoadNetworkModal = ({
             value={loadedNetwork.passphrase}
           />
         </Box>
+
+        <Alert variant="warning" placement="inline">
+          You should only use Horizon and RPC URLs that you trust. Using
+          unknown/untrusted Horizon and RPC URLs can make your connection
+          insecure.
+        </Alert>
       </Modal.Body>
 
       <Modal.Footer>

--- a/src/components/NetworkSelector/LoadNetworkModal.tsx
+++ b/src/components/NetworkSelector/LoadNetworkModal.tsx
@@ -1,0 +1,68 @@
+import { Button, Modal, Text } from "@stellar/design-system";
+import { Box } from "@/components/layout/Box";
+import { Network } from "@/types/types";
+
+type LoadNetworkModalProps = {
+  onClose: () => void;
+  onAccept: () => void;
+  loadedNetwork: Network | null;
+};
+
+export const LoadNetworkModal = ({
+  onClose,
+  onAccept,
+  loadedNetwork,
+}: LoadNetworkModalProps) => {
+  if (!loadedNetwork) {
+    return null;
+  }
+
+  return (
+    <Modal visible={Boolean(loadedNetwork)} onClose={onClose}>
+      <Modal.Heading>Review Network Settings</Modal.Heading>
+
+      <Modal.Body>
+        <Text as="div" size="sm">
+          You haven’t used these network settings on Mainnet before. Please
+          review them carefully and confirm.
+        </Text>
+
+        <Box gap="sm" direction="column">
+          <NetworkItem label="RPC URL" value={loadedNetwork.rpcUrl} />
+          <NetworkItem label="Horizon URL" value={loadedNetwork.horizonUrl} />
+          <NetworkItem
+            label="Network Passphrase"
+            value={loadedNetwork.passphrase}
+          />
+        </Box>
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Button size="md" variant="tertiary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          size="md"
+          variant="primary"
+          onClick={() => {
+            onAccept();
+            onClose();
+          }}
+        >
+          Accept
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+const NetworkItem = ({ label, value }: { label: string; value: string }) => (
+  <Box gap="xs" direction="column">
+    <Text as="div" size="sm" weight="semi-bold">
+      {label}
+    </Text>
+    <Text as="div" size="sm">
+      {value}
+    </Text>
+  </Box>
+);

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -8,6 +8,7 @@ import React, {
 import { Button, Icon, Input, Notification } from "@stellar/design-system";
 
 import { NetworkIndicator } from "@/components/NetworkIndicator";
+import { LoadNetworkModal } from "@/components/NetworkSelector/LoadNetworkModal";
 import { NetworkOptions } from "@/constants/settings";
 import { useStore } from "@/store/useStore";
 import { trackEvent, TrackingEvent } from "@/metrics/tracking";
@@ -38,6 +39,7 @@ export const NetworkSelector = () => {
   const [activeNetwork, setActiveNetwork] = useState<Network | EmptyObj>(
     network,
   );
+  const [loadedNetwork, setLoadedNetwork] = useState<Network | null>(null);
   const [validationError, setValidationError] = useState<AnyObject>({});
 
   const [isDropdownActive, setIsDropdownActive] = useState(false);
@@ -46,15 +48,21 @@ export const NetworkSelector = () => {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
-  const isSameNetwork =
-    activeNetwork.id === network.id &&
-    activeNetwork.horizonUrl === network.horizonUrl &&
-    activeNetwork.horizonHeaderName === network.horizonHeaderName &&
-    activeNetwork.horizonHeaderValue === network.horizonHeaderValue &&
-    activeNetwork.rpcUrl === network.rpcUrl &&
-    activeNetwork.rpcHeaderName === network.rpcHeaderName &&
-    activeNetwork.rpcHeaderValue === network.rpcHeaderValue &&
-    activeNetwork.passphrase === network.passphrase;
+  const isSameNetwork = (
+    networkOne: Network | EmptyObj,
+    networkTwo: Network | EmptyObj,
+  ) => {
+    return (
+      networkOne.id === networkTwo.id &&
+      networkOne.horizonUrl === networkTwo.horizonUrl &&
+      networkOne.horizonHeaderName === networkTwo.horizonHeaderName &&
+      networkOne.horizonHeaderValue === networkTwo.horizonHeaderValue &&
+      networkOne.rpcUrl === networkTwo.rpcUrl &&
+      networkOne.rpcHeaderName === networkTwo.rpcHeaderName &&
+      networkOne.rpcHeaderValue === networkTwo.rpcHeaderValue &&
+      networkOne.passphrase === networkTwo.passphrase
+    );
+  };
 
   const isNetworkUrlInvalid = (url: string) => {
     if (!url) {
@@ -71,7 +79,7 @@ export const NetworkSelector = () => {
   };
 
   const isSubmitDisabled = () => {
-    if (isSameNetwork) {
+    if (isSameNetwork(activeNetwork, network)) {
       return true;
     }
 
@@ -123,15 +131,47 @@ export const NetworkSelector = () => {
           rpcHeaderName: savedNetwork.rpcHeaderName || "",
         };
       } else {
-        // Network values that don’t match saved network values
-        const newNetwork = {
-          ...network,
-          label: getNetworkById(network.id)?.label,
+        // Network settings in the URL don’t match saved network settings
+        // Get the network from our preset list
+        const networkPreset = getNetworkById(network.id);
+        // Check if there is previously saved network for this network ID
+        const savedPreviousNetwork =
+          localStorageSavedNetworksPrevious.get()?.[network.id];
+
+        const currentNetwork = {
+          ...networkPreset,
+          rpcUrl: savedPreviousNetwork?.rpcUrl || networkPreset?.rpcUrl || "",
+          horizonUrl:
+            savedPreviousNetwork?.horizonUrl || networkPreset?.horizonUrl || "",
+          passphrase:
+            savedPreviousNetwork?.passphrase || networkPreset?.passphrase || "",
         } as Network;
 
-        setActiveNetwork(newNetwork);
-        selectNetwork(newNetwork);
-        updateNetwork(newNetwork);
+        // Loaded network settings
+        const newNetwork = {
+          ...network,
+          label: networkPreset?.label,
+        } as Network;
+
+        // Only on Mainnet with a new network, temporarily set network settings
+        // (user will approve new settings in the modal)
+        if (
+          network.id === "mainnet" &&
+          !isSameNetwork(currentNetwork, newNetwork)
+        ) {
+          setActiveNetwork(currentNetwork);
+          selectNetwork(currentNetwork);
+          updateNetwork(currentNetwork);
+
+          // This will trigger the modal to open
+          setLoadedNetwork(newNetwork);
+        } else {
+          // If it’s not Mainnet, use loaded network settings
+          setActiveNetwork(newNetwork);
+          selectNetwork(newNetwork);
+          updateNetwork(newNetwork);
+        }
+
         return;
       }
     } else {
@@ -450,6 +490,22 @@ export const NetworkSelector = () => {
           </div>
         </div>
       </div>
+
+      <LoadNetworkModal
+        onClose={() => {
+          setLoadedNetwork(null);
+        }}
+        onAccept={() => {
+          if (loadedNetwork) {
+            setActiveNetwork(loadedNetwork);
+            selectNetwork(loadedNetwork);
+            updateNetwork(loadedNetwork);
+
+            handleNetworkSaveLocalStorage(loadedNetwork);
+          }
+        }}
+        loadedNetwork={loadedNetwork}
+      />
     </div>
   );
 };

--- a/src/query/useHorizonHealthCheckUntilReady.ts
+++ b/src/query/useHorizonHealthCheckUntilReady.ts
@@ -10,7 +10,7 @@ export const useHorizonHealthCheckUntilReady = (
   headers: AnyObject,
 ) => {
   const query = useQuery({
-    queryKey: ["useHorizonHealthCheckUntilReady"],
+    queryKey: ["useHorizonHealthCheckUntilReady", horizonUrl],
     queryFn: async () => {
       if (!horizonUrl) {
         return null;

--- a/src/query/useRpcHealthCheckUntilReady.ts
+++ b/src/query/useRpcHealthCheckUntilReady.ts
@@ -10,7 +10,7 @@ export const useRpcHealthCheckUntilReady = (
   headers: AnyObject,
 ) => {
   const query = useQuery({
-    queryKey: ["useRpcHealthCheckUntilReady"],
+    queryKey: ["useRpcHealthCheckUntilReady", rpcUrl],
     queryFn: async () => {
       if (!rpcUrl) {
         return null;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -27,6 +27,16 @@
       --Card-padding: #{pxToRem(16px)};
     }
   }
+
+  .Modal {
+    &__content {
+      grid-template-rows: minmax(0,max-content) fit-content(24rem) minmax(0,max-content);
+    }
+
+    .Card {
+      height: fit-content;
+    }
+  }
 }
 
 .LabLayout {
@@ -337,8 +347,7 @@
   color: var(--Nav-navLink-color);
   text-decoration: none;
   padding: pxToRem(12px) 0;
-  transition:
-    color var(--sds-anim-transition-default),
+  transition: color var(--sds-anim-transition-default),
     border-color var(--sds-anim-transition-default);
   white-space: nowrap;
 
@@ -454,9 +463,8 @@
   &__nestedItemsWrapper {
     display: grid;
     grid-template-rows: 0fr;
-    transition:
-      grid-template-rows 100ms ease-out,
-      margin-top 100ms ease-out;
+    transition: grid-template-rows 100ms ease-out,
+    margin-top 100ms ease-out;
     margin-left: pxToRem(16px);
 
     &[data-is-expanded="true"] {
@@ -964,18 +972,22 @@
     .Select__container {
       border: 0;
     }
+
     input {
       flex-shrink: 1;
     }
   }
+
   .Input__buttons {
     .Input__container {
       padding-right: 0;
     }
+
     .hardware-button {
       flex-grow: 1;
       border-left: 1px solid var(--Input-color-border);
     }
+
     .hardware-sign-button {
       .Button {
         margin-top: pxToRem(25px);


### PR DESCRIPTION
On Mainnet, if the user loads custom Mainnet settings for the first time that don't match our defaults, we'll show a modal to accept the new settings.

[Example URL](https://laboratory-pr1385.previews.kube001.services.stellar-ops.com/?$=network$id=mainnet&label=Testnet&horizonUrl=https:////evil-horizon.org&rpcUrl=https:////evil-rpc.org&passphrase=EVIL;;)

![image](https://github.com/user-attachments/assets/b2e290a0-f3dc-4bea-9f2b-dd60b3c6af11)
