### PR TITLE
Enable an array of non object in invoke contract form

### DIFF
--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -47,7 +47,6 @@ export const JsonSchemaFormRenderer = ({
   console.log("schema: ", schema);
   const schemaType = getDefType(schema);
 
-  console.log("schemaType: ", schemaType);
   const label = path.length > 0 ? getNestedValueLabel(path.join(".")) : name;
   const labelWithSchemaType = `${label} (${schemaType})`;
 
@@ -138,8 +137,6 @@ export const JsonSchemaFormRenderer = ({
     });
   };
 
-  console.log("schemaType", schemaType);
-
   if (schemaType === null || schemaType === undefined) {
     return (
       <Box gap="md">
@@ -208,7 +205,6 @@ export const JsonSchemaFormRenderer = ({
   if (schemaType === "array") {
     const storedItems = parsedSorobanOperation.args?.[name] || [];
 
-    console.log("schema", schema);
     const addDefaultSchemaTemplate = () => {
       // template created based on the schema.properties
       const defaultTemplate = Object.keys(schema.properties || {}).reduce(
@@ -257,20 +253,12 @@ export const JsonSchemaFormRenderer = ({
                         {Object.keys(args).map((arg) => {
                           const nestedPath = [name, index, arg].join(".");
 
-                          console.log("args", args);
-                          console.log("schema", schema);
-                          console.log(
-                            "schema?.items?.properties?.[arg]",
-                            schema?.items?.properties?.[arg],
-                          );
                           return (
                             <JsonSchemaFormRenderer
                               name={name}
                               index={index}
                               key={nestedPath}
-                              schema={
-                                schema?.items?.properties?.[arg] as JSONSchema7
-                              }
+                              schema={schema.properties?.[arg] as JSONSchema7}
                               path={[...path, nestedPath]}
                               formData={args}
                               onChange={onChange}

--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -19,7 +19,6 @@ export const JsonSchemaFormRenderer = ({
   name,
   schema,
   path = [],
-  formData,
   onChange,
   index,
   requiredFields,
@@ -29,7 +28,6 @@ export const JsonSchemaFormRenderer = ({
   name: string;
   schema: JSONSchema7;
   path?: (string | number)[];
-  formData: AnyObject;
   onChange: (value: SorobanInvokeValue) => void;
   index?: number;
   requiredFields?: string[];
@@ -184,7 +182,6 @@ export const JsonSchemaFormRenderer = ({
                         key={`${key}-${index}`}
                         schema={subSchema as JSONSchema7}
                         onChange={onChange}
-                        formData={formData}
                         requiredFields={schema.required}
                         setFormError={setFormError}
                         formError={formError}
@@ -201,7 +198,6 @@ export const JsonSchemaFormRenderer = ({
                 key={`${key}-${index}`}
                 schema={subSchema as JSONSchema7}
                 onChange={onChange}
-                formData={formData}
                 requiredFields={schema.required}
                 setFormError={setFormError}
                 formError={formError}
@@ -223,7 +219,7 @@ export const JsonSchemaFormRenderer = ({
 
       if (isSchemaObject(schema.items) && schema.items.type === "object") {
         defaultTemplate = Object.keys(schemaItems || {}).reduce(
-          (acc: Record<string, string | any[]>, key) => {
+          (acc: Record<string, string | AnyObject>, key) => {
             // For example, if the schema.items has an array of object type like following:
             // {
             //   "items": {
@@ -237,11 +233,11 @@ export const JsonSchemaFormRenderer = ({
             // }
             // then the defaultTemplate will be:
             // {
-            //   "address": [],
-            //   "amount": [],
-            //   "request_type": []
+            //   "address": {},
+            //   "amount": {},
+            //   "request_type": {}
             // }
-            acc[key] = [];
+            acc[key] = {};
             return acc;
           },
           {},
@@ -300,7 +296,6 @@ export const JsonSchemaFormRenderer = ({
                                 key={nestedPath}
                                 schema={schemaItems?.[arg] as JSONSchema7}
                                 path={[...path, nestedPath]}
-                                formData={args}
                                 onChange={onChange}
                                 requiredFields={schema.required}
                                 setFormError={setFormError}
@@ -316,7 +311,6 @@ export const JsonSchemaFormRenderer = ({
                             key={[name, index].join(".")}
                             schema={schemaItems}
                             path={[[name, index].join(".")]}
-                            formData={args}
                             onChange={onChange}
                             requiredFields={schema.required}
                             setFormError={setFormError}

--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -533,16 +533,12 @@ const isSchemaObject = (schema: any): schema is JSONSchema7 => {
 };
 
 const getSchemaItems = (schema: any) => {
-  // First, check if schema.items exists and is not a boolean
   if (schema.items && typeof schema.items !== "boolean") {
-    // Now check if it has properties (object schema)
     if (schema.items.properties) {
       return schema.items.properties;
     }
-    // If no properties, return the items schema itself
     return schema.items;
   }
-  // Handle the case where items is false or doesn't exist
   return {};
 };
 

--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -44,7 +44,10 @@ export const JsonSchemaFormRenderer = ({
     sorobanOperation.params.invoke_contract,
   ) as AnyObject;
 
+  console.log("schema: ", schema);
   const schemaType = getDefType(schema);
+
+  console.log("schemaType: ", schemaType);
   const label = path.length > 0 ? getNestedValueLabel(path.join(".")) : name;
   const labelWithSchemaType = `${label} (${schemaType})`;
 
@@ -135,6 +138,8 @@ export const JsonSchemaFormRenderer = ({
     });
   };
 
+  console.log("schemaType", schemaType);
+
   if (schemaType === null || schemaType === undefined) {
     return (
       <Box gap="md">
@@ -203,6 +208,7 @@ export const JsonSchemaFormRenderer = ({
   if (schemaType === "array") {
     const storedItems = parsedSorobanOperation.args?.[name] || [];
 
+    console.log("schema", schema);
     const addDefaultSchemaTemplate = () => {
       // template created based on the schema.properties
       const defaultTemplate = Object.keys(schema.properties || {}).reduce(
@@ -251,12 +257,20 @@ export const JsonSchemaFormRenderer = ({
                         {Object.keys(args).map((arg) => {
                           const nestedPath = [name, index, arg].join(".");
 
+                          console.log("args", args);
+                          console.log("schema", schema);
+                          console.log(
+                            "schema?.items?.properties?.[arg]",
+                            schema?.items?.properties?.[arg],
+                          );
                           return (
                             <JsonSchemaFormRenderer
                               name={name}
                               index={index}
                               key={nestedPath}
-                              schema={schema.properties?.[arg] as JSONSchema7}
+                              schema={
+                                schema?.items?.properties?.[arg] as JSONSchema7
+                              }
                               path={[...path, nestedPath]}
                               formData={args}
                               onChange={onChange}

--- a/src/components/JsonSchema/index.tsx
+++ b/src/components/JsonSchema/index.tsx
@@ -62,7 +62,7 @@ export const JsonSchemaForm = ({
   const prevValue = usePrevious(stringify(value.args));
 
   const missingReqFields = requiredFields.reduce((res, cur) => {
-    if (value.args[cur].length === 0) {
+    if (value.args[cur]?.length === 0) {
       return [...res, cur];
     }
 

--- a/src/helpers/dereferenceSchema.ts
+++ b/src/helpers/dereferenceSchema.ts
@@ -30,70 +30,20 @@ export const dereferenceSchema = (
 
   // Good example contract: CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP
   // "submit", "queue_set_reserve" function
-  const resolveRef = (val: any, fullSchema: JSONSchema7) => {
+  const resolveSchemaRef = (schema: any, fullSchema: JSONSchema7) => {
     // primitive: { '$ref': '#/definitions/Address' }
     // array: { type: 'array', items: { '$ref': '#/definitions/Request' } }
 
-    const ref = val.$ref;
+    if (!schema.$ref) {
+      return schema;
+    }
 
-    if (ref) {
-      // console.log("ref", ref);
-      // would output something like
-      // "Address"  if it's a primitive
-      const refPath = ref.replace("#/definitions/", "");
-
-      // console.log("refPath", refPath);
-
+    if (schema.$ref) {
+      const refPath = schema.$ref.replace("#/definitions/", "");
       const refPathDef = fullSchema?.definitions?.[refPath] as JSONSchema7;
 
-      // console.log("refPathDef", refPathDef);
-
-      //   {
-      //     "type": "array",
-      //     "items": {
-      //         "$ref": "#/definitions/Request"
-      //     }
-      // }
-      // ref: #/definitions/Request
-      // refPath: Request
-      // refPathDef: {
-      //     "description": "A request a user makes against the pool",
-      //     "properties": {
-      //         "address": {
-      //             "$ref": "#/definitions/Address"
-      //         },
-      //         "amount": {
-      //             "$ref": "#/definitions/I128"
-      //         },
-      //         "request_type": {
-      //             "$ref": "#/definitions/U32"
-      //         },
-      //         "additionalProperties": false
-      //     },
-      //     "required": [
-      //         "address",
-      //         "amount",
-      //         "request_type"
-      //     ],
-      //     "type": "object"
-      // }
-
-      // value: {
-      //     "type": "array",
-      //     "items": {
-      //         "$ref": "#/definitions/Address"
-      //     }
-      // }
-      // ref: #/definitions/Address
-      // refPath: Address
-      // refPathDef: {
-      //     "type": "string",
-      //     "format": "address",
-      //     "description": "Address can be a public key or contract id"
-      // }
-
-      // if the refPathDef has properties aka is an array
-      // we need to recursively dereference the properties
+      // properties indicates that there is an array of objects
+      // we need to recursively dereference properties
       if (refPathDef?.properties) {
         return {
           properties: dereferenceSchemaProps(
@@ -111,35 +61,36 @@ export const dereferenceSchema = (
         description: refPathDef?.description ?? false,
       };
     }
-
-    return val;
   };
 
   const dereferenceSchemaProps = (funcArgs: any) => {
     const resolvedProps: Record<string, any> = {};
 
-    // console.log("funcArgs", funcArgs);
     if (funcArgs.properties) {
-      Object.entries(funcArgs.properties).forEach(([key, value]) => {
-        // `value` can be either JSONSchema7Definition or false
-        // parse the value if it's an object
+      Object.entries(funcArgs.properties).forEach(([key, schema]) => {
+        // `schema` can be either JSONSchema7Definition or false
+        // parse the schema if it's an object
 
-        if (typeof value === "object" && value !== null) {
-          if ("$ref" in value) {
-            resolvedProps[key] = resolveRef(value, fullSchema);
+        if (typeof schema === "object" && schema !== null) {
+          if ("$ref" in schema) {
+            resolvedProps[key] = resolveSchemaRef(schema, fullSchema);
           }
-          if ("items" in value) {
-            // console.log(
-            //   "resolveRef(value.items, fullSchema)",
-            //   resolveRef(value.items, fullSchema),
-            // );
 
-            resolvedProps[key] = {
-              items: resolveRef(value.items, fullSchema),
-              type: "array",
-            };
-
-            // console.log("resolvedProps", resolvedProps);
+          if ("items" in schema) {
+            if (Array.isArray(schema.items)) {
+              const items = schema.items.map((item) =>
+                resolveSchemaRef(item, fullSchema),
+              );
+              resolvedProps[key] = {
+                items: items,
+                type: "array",
+              };
+            } else {
+              resolvedProps[key] = {
+                items: resolveSchemaRef(schema.items, fullSchema),
+                type: "array",
+              };
+            }
           }
         }
       });

--- a/src/helpers/dereferenceSchema.ts
+++ b/src/helpers/dereferenceSchema.ts
@@ -37,11 +37,60 @@ export const dereferenceSchema = (
     const ref = val.$ref;
 
     if (ref) {
+      // console.log("ref", ref);
       // would output something like
       // "Address"  if it's a primitive
       const refPath = ref.replace("#/definitions/", "");
 
+      // console.log("refPath", refPath);
+
       const refPathDef = fullSchema?.definitions?.[refPath] as JSONSchema7;
+
+      // console.log("refPathDef", refPathDef);
+
+      //   {
+      //     "type": "array",
+      //     "items": {
+      //         "$ref": "#/definitions/Request"
+      //     }
+      // }
+      // ref: #/definitions/Request
+      // refPath: Request
+      // refPathDef: {
+      //     "description": "A request a user makes against the pool",
+      //     "properties": {
+      //         "address": {
+      //             "$ref": "#/definitions/Address"
+      //         },
+      //         "amount": {
+      //             "$ref": "#/definitions/I128"
+      //         },
+      //         "request_type": {
+      //             "$ref": "#/definitions/U32"
+      //         },
+      //         "additionalProperties": false
+      //     },
+      //     "required": [
+      //         "address",
+      //         "amount",
+      //         "request_type"
+      //     ],
+      //     "type": "object"
+      // }
+
+      // value: {
+      //     "type": "array",
+      //     "items": {
+      //         "$ref": "#/definitions/Address"
+      //     }
+      // }
+      // ref: #/definitions/Address
+      // refPath: Address
+      // refPathDef: {
+      //     "type": "string",
+      //     "format": "address",
+      //     "description": "Address can be a public key or contract id"
+      // }
 
       // if the refPathDef has properties aka is an array
       // we need to recursively dereference the properties
@@ -69,19 +118,28 @@ export const dereferenceSchema = (
   const dereferenceSchemaProps = (funcArgs: any) => {
     const resolvedProps: Record<string, any> = {};
 
+    // console.log("funcArgs", funcArgs);
     if (funcArgs.properties) {
       Object.entries(funcArgs.properties).forEach(([key, value]) => {
         // `value` can be either JSONSchema7Definition or false
         // parse the value if it's an object
+
         if (typeof value === "object" && value !== null) {
           if ("$ref" in value) {
             resolvedProps[key] = resolveRef(value, fullSchema);
           }
           if ("items" in value) {
+            // console.log(
+            //   "resolveRef(value.items, fullSchema)",
+            //   resolveRef(value.items, fullSchema),
+            // );
+
             resolvedProps[key] = {
-              ...resolveRef(value.items, fullSchema),
+              items: resolveRef(value.items, fullSchema),
               type: "array",
             };
+
+            // console.log("resolvedProps", resolvedProps);
           }
         }
       });


### PR DESCRIPTION
**Summary:**
- removed `setNestedValueWithArr` for lodash's `set` ([set doc](https://lodash.com/docs/#set))
- removed `getNestedValue` for lodash's `get` ([get doc](https://lodash.com/docs/#get))
- Add an additional `JsonSchemaFormRenderer` rendering for an array of primitive types (previously we only handled array of object types)
- Delete item from `formError` when a trash button icon is clicked
- update `dereferenceSchema` to keep the key `items`. previously we only kept the values of `items`

**Screenshot:**
- success for adding relayers using `CCQXWMZVM3KRTXTUPTN53YHL272QGKF32L7XEDNZ2S6OSUFK3NFBGG5M`
![add_relayers](https://github.com/user-attachments/assets/c9f781b3-24e4-4d16-b792-37318fcdfd92)
