### PR TITLE
[Invoke Contract] Fetch wasm's spec when clicking Load Contract

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContract.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContract.tsx
@@ -1,8 +1,6 @@
 import { Alert, Card, Loader, Text } from "@stellar/design-system";
-
+import { contract } from "@stellar/stellar-sdk";
 import { useStore } from "@/store/useStore";
-
-import { useContractClientFromRpc } from "@/query/useContractClientFromRpc";
 
 import { Box } from "@/components/layout/Box";
 
@@ -11,30 +9,23 @@ import { ContractInfoApiResponse, EmptyObj, Network } from "@/types/types";
 import { InvokeContractForm } from "./InvokeContractForm";
 
 export const InvokeContract = ({
-  infoData,
   network,
   isLoading,
+  infoData,
+  contractSpec,
+  contractClientError,
 }: {
-  infoData: ContractInfoApiResponse;
   network: Network | EmptyObj;
   isLoading: boolean;
+  infoData: ContractInfoApiResponse;
+  contractSpec: contract.Spec;
+  contractClientError: Error | null;
 }) => {
   const { walletKit } = useStore();
-  const {
-    data: contractClient,
-    isFetching: isFetchingContractClient,
-    isError,
-    isSuccess,
-    error: contractClientError,
-  } = useContractClientFromRpc({
-    contractId: infoData.contract,
-    networkPassphrase: network.passphrase,
-    rpcUrl: network.rpcUrl,
-  });
+  const contractSpecFuncs = contractSpec?.funcs();
 
   const renderFunctionCard = () =>
-    contractClient?.spec
-      ?.funcs()
+    contractSpecFuncs
       ?.filter((func) => !func.name().toString().includes("__"))
       ?.map((func) => (
         <InvokeContractForm
@@ -51,7 +42,7 @@ export const InvokeContract = ({
     </Alert>
   );
 
-  if (isLoading || isFetchingContractClient) {
+  if (isLoading) {
     return (
       <Box gap="sm" direction="row" justify="center">
         <Loader />
@@ -73,8 +64,8 @@ export const InvokeContract = ({
             Invoke Contract
           </Text>
 
-          {isSuccess ? renderFunctionCard() : null}
-          {isError ? renderError() : null}
+          {contractSpecFuncs ? renderFunctionCard() : null}
+          {contractClientError ? renderError() : null}
         </Box>
       </Card>
     </Box>

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -256,7 +256,9 @@ export default function ContractExplorer() {
             }}
           />
 
-          <PoweredByStellarExpert />
+          {contractActiveTab === "contract-info" ? (
+            <PoweredByStellarExpert />
+          ) : null}
         </>
       </>
     </Box>


### PR DESCRIPTION
**Summary:**
- Add a direct call to contract client in Smart Contract page to fetch spec's functions. I didn't catch this bug until today. During the development I was going back and forth between build tx (which calls contract client) and smart contracts page (which does not because it used to rely on stellar expert's api).
- Do not display `powered by stellar.expert` on Invoke Contract since it no longer relies on its api

Before:
<img width="1200" alt="before" src="https://github.com/user-attachments/assets/c547b83e-b95a-48ca-92e7-f3e8d0b512d9" />

After:
<img width="1196" alt="after" src="https://github.com/user-attachments/assets/8a317439-44da-4460-b957-117f4cdd683c" />
