### PR TITLE
[Invoke Contract] create a function that converts spec type to scVal type

### DIFF
--- a/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
+++ b/src/components/JsonSchema/JsonSchemaFormRenderer.tsx
@@ -12,6 +12,7 @@ import { PositiveIntPicker } from "@/components/FormElements/PositiveIntPicker";
 import { LabelHeading } from "@/components/LabelHeading";
 
 import { AnyObject, SorobanInvokeValue } from "@/types/types";
+import { convertSpecTypeToScValType } from "@/helpers/sorobanUtils";
 
 export const JsonSchemaFormRenderer = ({
   name,
@@ -76,10 +77,12 @@ export const JsonSchemaFormRenderer = ({
      * This will update the value of requests[1].request_type
      */
 
+    const scValType = convertSpecTypeToScValType(schemaType);
+
     if (path.length > 0) {
       const updatedList = set(parsedSorobanOperation.args, path.join("."), {
         value: e.target.value,
-        type: schemaType,
+        type: scValType,
       });
       onChange({
         ...invokeContractBaseProps,
@@ -93,7 +96,7 @@ export const JsonSchemaFormRenderer = ({
         ...invokeContractBaseProps,
         args: {
           ...parsedSorobanOperation.args,
-          [name]: { value: e.target.value, type: schemaType },
+          [name]: { value: e.target.value, type: scValType },
         },
       });
     }

--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -246,9 +246,7 @@ const convertObjectToScVal = (obj: Record<string, any>): xdr.ScVal => {
 
   for (const key in obj) {
     convertedValue[key] = obj[key].value;
-    // toLowerCase() is needed because the type we save from the label is in uppercase
-    // but nativeToScval expects the type to be in lowercase
-    typeHints[key] = ["symbol", obj[key].type.toLowerCase()];
+    typeHints[key] = ["symbol", obj[key].type];
   }
 
   return nativeToScVal(convertedValue, { type: typeHints });
@@ -277,15 +275,13 @@ const getScValsFromArgs = (args: SorobanInvokeValue["args"]): xdr.ScVal[] => {
         }, []);
 
         const scVal = nativeToScVal(arrayScVals, {
-          type: argValue[0].type.toLowerCase(),
+          type: argValue[0].type,
         });
 
         scVals.push(scVal);
       }
     } else {
-      scVals.push(
-        nativeToScVal(argValue.value, { type: argValue.type.toLowerCase() }),
-      );
+      scVals.push(nativeToScVal(argValue.value, { type: argValue.type }));
     }
   }
 
@@ -312,4 +308,35 @@ const buildSorobanData = ({
     .setReadWrite(readWriteXdrLedgerKey)
     .setResourceFee(resourceFee)
     .build();
+};
+
+export const convertSpecTypeToScValType = (type: string) => {
+  switch (type) {
+    case "Address":
+      return "address";
+    case "U32":
+      return "u32";
+    case "U64":
+      return "u64";
+    case "U128":
+      return "u128";
+    case "U256":
+      return "u256";
+    case "I32":
+      return "i32";
+    case "I64":
+      return "i64";
+    case "I128":
+      return "i128";
+    case "I256":
+      return "i256";
+    case "ScString":
+      return "string";
+    case "ScSymbol":
+      return "symbol";
+    case "DataUrl":
+      return "bytes";
+    default:
+      return type;
+  }
 };


### PR DESCRIPTION
Nando reported that he wasn't able to submit with `ScString` value. The reason is that unlike `integer` and `address` type, `nativeToScVal` takes a `string` as a type instead of `ScString` (see [line 228](https://stellar.github.io/js-stellar-sdk/js-stellar-base_src_scval.js.html) on js sdk). I also added a fix for `ScSymbol` and `DataURL` (`symbol` for spec type `ScSymbol`, `bytes` for `DataURL`)

![CleanShot 2025-05-13 at 09 17 14](https://github.com/user-attachments/assets/40a256c6-fec5-45ad-b01d-24d423fba29d)

I created a function that converts `spec type` to `scVal type`. For `integer` and `address` type, we're lowercasing it since that's what `nativeToScVal` accepts.

I was able to submit Nando's contract: [stellar.expert tx link](https://stellar.expert/explorer/testnet/tx/96def952d80b042523303d1ede4e227c19eac31a34a100548bdf83b782f86f4a)