### PR TITLE
[Invoke Contract] Enable Simulate for Get function and allow 'enabled' on useAcctSeqNumber

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
@@ -50,8 +50,10 @@ export const InvokeContractForm = ({
 }) => {
   const { walletKit } = useStore();
   const [contractSpec, setContractSpec] = useState<contract.Spec | null>();
-  const [signedTxXdr, setSignedTxXdr] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [invokeError, setInvokeError] = useState<{
+    message: string;
+    methodType: string;
+  } | null>(null);
   const [isExtensionLoading, setIsExtensionLoading] = useState(false);
   const [formValue, setFormValue] = useState<SorobanInvokeValue>({
     contract_id: infoData.contract,
@@ -59,8 +61,11 @@ export const InvokeContractForm = ({
     args: {},
   });
   const [formError, setFormError] = useState<AnyObject>({});
+  // const [isGetFunction, checkGetFunction] = useState(false);
+  const [dereferencedSchema, setDereferencedSchema] =
+    useState<DereferencedSchemaType | null>(null);
 
-  const hasNoErrors = isEmptyObject(formError);
+  const hasNoFormErrors = isEmptyObject(formError);
 
   const { wasm: wasmHash } = infoData;
 
@@ -74,10 +79,11 @@ export const InvokeContractForm = ({
     horizonUrl: network.horizonUrl,
     headers: getNetworkHeaders(network, "horizon"),
     uniqueId: funcName,
+    enabled: !!walletKit?.publicKey,
   });
 
   const {
-    mutateAsync: simulateTx,
+    mutate: simulateTx,
     data: simulateTxData,
     isError: isSimulateTxError,
     isPending: isSimulateTxPending,
@@ -85,9 +91,10 @@ export const InvokeContractForm = ({
   } = useSimulateTx();
 
   const {
-    mutateAsync: prepareTx,
+    mutate: prepareTx,
     isPending: isPrepareTxPending,
     data: prepareTxData,
+    // error: prepareTxError,
     reset: resetPrepareTx,
   } = useRpcPrepareTx();
 
@@ -119,7 +126,7 @@ export const InvokeContractForm = ({
 
   const signTx = async (xdr: string) => {
     if (!walletKitInstance?.walletKit || !walletKit?.publicKey) {
-      return;
+      return null;
     }
 
     setIsExtensionLoading(true);
@@ -135,17 +142,17 @@ export const InvokeContractForm = ({
         );
 
         if (result.signedTxXdr && result.signedTxXdr !== "") {
-          setSignedTxXdr(result.signedTxXdr);
+          return result.signedTxXdr;
         }
-        setIsExtensionLoading(false);
       } catch (error: any) {
         if (error?.message) {
-          setError(error?.message);
+          setInvokeError({ message: error?.message, methodType: "sign" });
         }
+      } finally {
         setIsExtensionLoading(false);
-        return;
       }
     }
+    return null;
   };
 
   useEffect(() => {
@@ -185,7 +192,24 @@ export const InvokeContractForm = ({
     getContractData();
   }, [wasmBinary]);
 
+  useEffect(() => {
+    if (contractSpec) {
+      const schema = dereferenceSchema(
+        contractSpec?.jsonSchema(funcName) as JSONSchema7,
+        funcName,
+      );
+
+      setDereferencedSchema(schema);
+
+      // if (schema) {
+      //   const isEmptyProperties = isEmptyObject(schema?.properties);
+      //   // checkGetFunction(isEmptyProperties);
+      // }
+    }
+  }, [contractSpec, funcName]);
+
   const handleChange = (value: SorobanInvokeValue) => {
+    setInvokeError(null);
     setFormValue(value);
   };
 
@@ -209,6 +233,10 @@ export const InvokeContractForm = ({
 
   const handleSubmit = async () => {
     if (!prepareTxData?.transactionXdr) {
+      setInvokeError({
+        message: "No transaction data available to sign",
+        methodType: "sign",
+      });
       return;
     }
 
@@ -219,99 +247,120 @@ export const InvokeContractForm = ({
       funcName: formValue.function_name,
     });
 
-    if (prepareTxData?.transactionXdr) {
-      await signTx(prepareTxData.transactionXdr);
-    }
+    try {
+      const signedTxXdr = await signTx(prepareTxData.transactionXdr);
 
-    if (signedTxXdr) {
+      if (!signedTxXdr) {
+        throw new Error(
+          "Transaction signing failed - no signed transaction received",
+        );
+      }
+
       submitRpc({
         rpcUrl: network.rpcUrl,
         transactionXdr: signedTxXdr,
         networkPassphrase: network.passphrase,
         headers: getNetworkHeaders(network, "rpc"),
       });
+    } catch (error: any) {
+      setInvokeError({
+        message: error?.message || "Failed to sign transaction",
+        methodType: "sign",
+      });
     }
   };
 
-  const handleSimulate = () => {
+  const handleSimulate = async () => {
     // reset
-    setError(null);
+    setInvokeError(null);
     resetSimulateState();
     resetSubmitState();
     resetPrepareTx();
 
-    // fetch sequence number
-    fetchSequenceNumber();
+    try {
+      // fetch sequence number first
+      await fetchSequenceNumber();
 
-    trackEvent(
-      TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE,
-      {
-        funcName: formValue.function_name,
-      },
-    );
-
-    const txnParams: TransactionBuildParams = {
-      source_account: walletKit?.publicKey || "",
-      fee: BASE_FEE,
-      seq_num: sequenceNumberData || "",
-      cond: {
-        time: {
-          min_time: "0",
-          max_time: "0",
-        },
-      },
-      memo: {},
-    };
-
-    const sorobanOperation = {
-      operation_type: "invoke_contract_function",
-      params: {
-        contract_id: formValue.contract_id,
-        function_name: formValue.function_name,
-        args: formValue.args,
-      },
-    };
-
-    const { xdr, error } = getTxnToSimulate(
-      formValue,
-      txnParams,
-      sorobanOperation,
-      network.passphrase,
-    );
-
-    if (xdr) {
-      simulateTx({
-        rpcUrl: network.rpcUrl,
-        transactionXdr: xdr,
-        headers: getNetworkHeaders(network, "rpc"),
-      });
-
-      // using prepareTransaction instead of assembleTransaction because
-      // assembleTransaction requires an auth, but signing for simulation is rare
-      prepareTx({
-        rpcUrl: network.rpcUrl,
-        transactionXdr: xdr,
-        networkPassphrase: network.passphrase,
-        headers: getNetworkHeaders(network, "rpc"),
-      });
+      if (!sequenceNumberData) {
+        throw new Error("Failed to fetch sequence number. Please try again.");
+      }
 
       trackEvent(
-        TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_SUCCESS,
+        TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE,
         {
           funcName: formValue.function_name,
         },
       );
-    }
 
-    if (error) {
-      setError(error);
-
-      trackEvent(
-        TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_ERROR,
-        {
-          funcName: formValue.function_name,
+      const txnParams: TransactionBuildParams = {
+        source_account: walletKit?.publicKey || "",
+        fee: BASE_FEE,
+        seq_num: sequenceNumberData,
+        cond: {
+          time: {
+            min_time: "0",
+            max_time: "0",
+          },
         },
+        memo: {},
+      };
+
+      const sorobanOperation = {
+        operation_type: "invoke_contract_function",
+        params: {
+          contract_id: formValue.contract_id,
+          function_name: formValue.function_name,
+          args: formValue.args,
+        },
+      };
+
+      const { xdr, error: simulateError } = getTxnToSimulate(
+        formValue,
+        txnParams,
+        sorobanOperation,
+        network.passphrase,
       );
+
+      if (xdr) {
+        simulateTx({
+          rpcUrl: network.rpcUrl,
+          transactionXdr: xdr,
+          headers: getNetworkHeaders(network, "rpc"),
+        });
+
+        // using prepareTransaction instead of assembleTransaction because
+        // assembleTransaction requires an auth, but signing for simulation is rare
+        prepareTx({
+          rpcUrl: network.rpcUrl,
+          transactionXdr: xdr,
+          networkPassphrase: network.passphrase,
+          headers: getNetworkHeaders(network, "rpc"),
+        });
+
+        trackEvent(
+          TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_SUCCESS,
+          {
+            funcName: formValue.function_name,
+          },
+        );
+      }
+
+      if (simulateError) {
+        setInvokeError({ message: simulateError, methodType: "simulate" });
+
+        trackEvent(
+          TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_ERROR,
+          {
+            funcName: formValue.function_name,
+          },
+        );
+      }
+    } catch (error: any) {
+      setInvokeError({
+        message:
+          error?.message || "Failed to simulate transaction. Please try again.",
+        methodType: "simulate",
+      });
     }
   };
 
@@ -336,16 +385,7 @@ export const InvokeContractForm = ({
   );
 
   const renderSchema = () => {
-    if (!contractSpec) {
-      return null;
-    }
-
-    const dereferencedSchema: DereferencedSchemaType = dereferenceSchema(
-      contractSpec?.jsonSchema(funcName) as JSONSchema7,
-      funcName,
-    );
-
-    if (!dereferencedSchema) {
+    if (!contractSpec || !dereferencedSchema) {
       return null;
     }
 
@@ -427,15 +467,39 @@ export const InvokeContractForm = ({
       );
     }
 
-    if (error) {
+    if (invokeError?.message) {
       return (
         <div ref={responseErrorEl}>
-          <ErrorText errorMessage={error} size="sm" />
+          <ErrorText errorMessage={invokeError.message} size="sm" />
         </div>
       );
     }
 
     return null;
+  };
+
+  /*
+    isSubmitDisabled is true if:
+    - there is an invoke error from simulation or signing
+    - there is a submit rpc error
+    - the transaction is simulating
+    - the wallet is not connected
+    - there are form validation errors
+    - the transaction data from simulation is not available (needed to submit)
+  */
+  const isSubmitDisabled =
+    !!invokeError?.message ||
+    isSubmitRpcError ||
+    isSimulating ||
+    !walletKit?.publicKey ||
+    !hasNoFormErrors ||
+    !simulateTxData?.result?.transactionData;
+
+  const isSimulationDisabled = () => {
+    // const validForms = !isGetFunction && Object.keys(formValue.args).length;
+
+    // check whether inputs are filled
+    return !walletKit?.publicKey || !hasNoFormErrors;
   };
 
   return (
@@ -454,11 +518,7 @@ export const InvokeContractForm = ({
           <Button
             size="md"
             variant="tertiary"
-            disabled={
-              !Object.keys(formValue.args).length ||
-              !walletKit?.publicKey ||
-              !hasNoErrors
-            }
+            disabled={isSimulationDisabled()}
             isLoading={isSimulating}
             onClick={handleSimulate}
           >
@@ -469,14 +529,7 @@ export const InvokeContractForm = ({
             size="md"
             variant="secondary"
             isLoading={isExtensionLoading || isSubmitRpcPending}
-            disabled={
-              isSimulateTxError ||
-              isSubmitRpcError ||
-              simulateTxData?.result?.error ||
-              isSimulating ||
-              !walletKit?.publicKey ||
-              !hasNoErrors
-            }
+            disabled={isSubmitDisabled}
             onClick={handleSubmit}
           >
             Submit

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
@@ -199,11 +199,6 @@ export const InvokeContractForm = ({
       );
 
       setDereferencedSchema(schema);
-
-      if (schema) {
-        const isSchemaPropertiesEmpty = isEmptyObject(schema?.properties);
-        setIsGetFunction(isSchemaPropertiesEmpty);
-      }
     }
   }, [contractSpec, funcName]);
 

--- a/src/query/useAccountSequenceNumber.ts
+++ b/src/query/useAccountSequenceNumber.ts
@@ -7,11 +7,13 @@ export const useAccountSequenceNumber = ({
   horizonUrl,
   headers,
   uniqueId,
+  enabled = false,
 }: {
   publicKey: string;
   horizonUrl: string;
   headers: NetworkHeaders;
   uniqueId?: string;
+  enabled?: boolean;
 }) => {
   const query = useQuery({
     queryKey: ["accountSequenceNumber", { publicKey, uniqueId }],
@@ -51,7 +53,7 @@ export const useAccountSequenceNumber = ({
         throw `${e}. Check network configuration.`;
       }
     },
-    enabled: false,
+    enabled,
   });
 
   return query;


### PR DESCRIPTION
**Checklist:**

- [x] contract `get` functions to have `simulate` button enabled
-- we can determine functions are a `get` function if it has no required fields
- [x] enable loading while submitting
-- this was already a case; however, there was a race condition with the signed tx being saved from `useState`. ditched `useState` and we just handle everything within `try` `catch`
- [x] fixed the bug that nando reported which is that on initial page load, sequence number is returned as zero because `useAccountSequenceNumber` hook isn't enabled initially since the wallet wasn't connected. we either do initial fetch once the wallet is connected within `useEffect` or enabling `enabled` in `useQuery`. I went with `enabled` in `useQuery` because I didn't want the loading state on `simulate` button right after connecting to the wallet.