### PR TITLE
DataTable: support cell overlfow

### DIFF
--- a/src/app/(sidebar)/transactions-explorer/components/TransactionsTable.tsx
+++ b/src/app/(sidebar)/transactions-explorer/components/TransactionsTable.tsx
@@ -105,6 +105,7 @@ export function TransactionsTable({
               </CopyText>
             </Box>
           ),
+          isOverflow: true,
         },
         { value: <Time timestamp={parseInt(tx.createdAt.toString(), 10)} /> },
         {

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -449,6 +449,7 @@ export const DataTable = <T extends AnyObject>({
               role="cell"
               {...(cell.isBold ? { "data-style": "bold" } : {})}
               {...(cell.isWrap ? { "data-wrap": "true" } : {})}
+              {...(cell.isOverflow ? { "data-overflow": "true" } : {})}
             >
               {cell.value}
             </td>

--- a/src/components/DataTable/styles.scss
+++ b/src/components/DataTable/styles.scss
@@ -23,6 +23,10 @@
     &:has(.DataTable__filter) {
       min-height: pxToRem(400px);
     }
+
+    &:has([data-overflow="true"]) {
+      overflow-x: visible;
+    }
   }
 
   &__table {
@@ -66,6 +70,12 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      &[data-overflow="true"] {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: initial;
+      }
     }
 
     th {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -483,6 +483,7 @@ export type DataTableCell = {
   value: React.ReactNode;
   isBold?: boolean;
   isWrap?: boolean;
+  isOverflow?: boolean;
 };
 
 // =============================================================================


### PR DESCRIPTION
The Transaction Explorer page will not be visible in PR Preview; it can only be tested locally.

https://github.com/user-attachments/assets/4967cfcc-bd38-47d3-9e0e-d71920d87af7

