### PR TITLE
add 'app name' to trezor setting

### DIFF
--- a/src/helpers/txHelper.ts
+++ b/src/helpers/txHelper.ts
@@ -214,6 +214,7 @@ const signWithTrezor = async ({
   TrezorConnect.manifest({
     email: "accounts+trezor@stellar.org",
     appUrl: "https://lab.stellar.org/",
+    appName: "Stellar Lab",
   });
 
   try {


### PR DESCRIPTION
I got the following warning while pushing my test changes to a draft PR.

<img width="1264" alt="err-trezor" src="https://github.com/user-attachments/assets/dbe6c62b-3930-4f45-90a7-b140e734f21d" />
