### PR TITLE
Add production deployment instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,25 @@ yarn start --public randomsubdomain.ngrok.io
 yarn build
 ```
 
-To build and run production build locally:
+The app will be built into the `build` directory in Next.js' standalone output
+format.
+
+To run production build locally this command can be used conveniently:
 
 ```sh
 yarn start
+```
+
+To distribute and deploy the production build you need to copy the
+`build/static` directory to the `build/standalone/public/_next/static`
+location, and then the files and directories inside the `build/standalone`
+directory are the only files needed for production and can be distributed to
+the deployment location.
+
+In the deployment location the following command will run the app:
+
+```sh
+node server.js
 ```
 
 ## Tracking


### PR DESCRIPTION
### What
Add deployment instructions to README.

### Why
The readme's "production" instructions don't align with how next.js standalone builds are intended to be deployed. The instructions say to use `yarn start` which is convenient, but isn't actually running the standalone production build that `yarn build` produced.

The `next.config.js` file configures the build to be a standalone build here:
https://github.com/stellar/laboratory/blob/2fe31e3c374d30da726d1e0b83a945c7cd0b50a0/next.config.js#L3

A standalone build doesn't need yarn, or the repo. It only needs the `static` and `standalone` directories from the `build` directory.

For more details see https://nextjs.org/docs/pages/api-reference/config/next-config-js/output#automatically-copying-traced-files.

I took a look at this as part of looking into how quickstart was deploying lab (https://github.com/stellar/quickstart/pull/706). It was including the entire repo because it was using `yarn start` unnecessarily. Next.js' standalone build isn't as well documented as what it could be and based on the number of discussion threads online. Including the instructions here in the readme can serve to knowledge share this.