### PR TITLE
[Invoke Contract] Enable Stellar Asset Contract

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContract.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContract.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from "react";
 import { Alert, Card, Loader, Text } from "@stellar/design-system";
 import { contract } from "@stellar/stellar-sdk";
 import { useStore } from "@/store/useStore";
 
 import { Box } from "@/components/layout/Box";
-
-import { useSacXdrData } from "@/hooks/useSacXdrData";
 
 import { InvokeContractForm } from "./InvokeContractForm";
 
@@ -14,43 +11,16 @@ export const InvokeContract = ({
   contractId,
   contractSpec,
   contractClientError,
-  isSacType,
 }: {
   isLoading: boolean;
   contractId: string;
-  contractSpec?: contract.Spec;
-  contractClientError: Error | null;
-  isSacType: boolean;
+  contractSpec: contract.Spec;
+  contractClientError: Error | null | undefined;
 }) => {
-  const { walletKit, network } = useStore();
-  const [invokeContractSpec, setInvokeContractSpec] = useState(contractSpec);
-  const [sacError, setSacError] = useState<string | null>(null);
-  const { sacXdrData } = useSacXdrData({
-    isActive: Boolean(network.rpcUrl && isSacType),
-  });
+  const { walletKit } = useStore();
 
-  useEffect(() => {
-    if (sacXdrData) {
-      try {
-        setInvokeContractSpec(new contract.Spec(sacXdrData));
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
-        setSacError("Invalid SAC XDR data");
-      }
-    } else {
-      setInvokeContractSpec(contractSpec);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSacType]);
-
-  const isError = Boolean(
-    (!sacXdrData && contractClientError) ||
-      (isSacType && sacError) ||
-      !(sacXdrData || contractSpec),
-  );
-
-  const renderFunctionCard = (invokeContractSpec: contract.Spec) => {
-    const invokeContractSpecFuncs = invokeContractSpec?.funcs();
+  const renderFunctionCard = () => {
+    const invokeContractSpecFuncs = contractSpec?.funcs();
 
     return invokeContractSpecFuncs
       ?.filter((func) => !func.name().toString().includes("__"))
@@ -59,7 +29,7 @@ export const InvokeContract = ({
 
         return (
           <InvokeContractForm
-            contractSpec={invokeContractSpec}
+            contractSpec={contractSpec}
             key={funcName}
             contractId={contractId}
             funcName={funcName}
@@ -105,8 +75,8 @@ export const InvokeContract = ({
             Invoke Contract
           </Text>
 
-          {invokeContractSpec ? renderFunctionCard(invokeContractSpec) : null}
-          {isError ? renderError() : null}
+          {contractSpec ? renderFunctionCard() : null}
+          {contractClientError ? renderError() : null}
         </Box>
       </Card>
     </Box>

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContract.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContract.tsx
@@ -26,7 +26,7 @@ export const InvokeContract = ({
     isActive: Boolean(network.rpcUrl && isSacType),
   });
   const isError = Boolean(
-    (contractSpec && contractClientError) || !(sacXdrData || contractSpec),
+    (!sacXdrData && contractClientError) || !(sacXdrData || contractSpec),
   );
 
   const invokeContractSpec = sacXdrData

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -26,9 +26,10 @@ import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
 
 import { trackEvent, TrackingEvent } from "@/metrics/tracking";
 
+import { useSacXdrData } from "@/hooks/useSacXdrData";
+
 import { ContractInfo } from "./components/ContractInfo";
 import { InvokeContract } from "./components/InvokeContract";
-import { useSacXdrData } from "@/hooks/useSacXdrData";
 
 export default function ContractExplorer() {
   const { network, smartContracts, savedContractId, clearSavedContractId } =

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/page.tsx
@@ -141,18 +141,18 @@ export default function ContractExplorer() {
 
   const isSacType = contractType
     ? contractType === "contractExecutableStellarAsset"
-    : undefined;
+    : false;
 
   const renderContractInvokeContent = () => {
     const wasmSpec = contractClient?.spec;
 
-    return contractInfoData && wasmSpec ? (
+    return contractInfoData && (wasmSpec || isSacType) ? (
       <InvokeContract
         contractSpec={wasmSpec}
-        infoData={contractInfoData}
-        network={network}
+        contractId={contractInfoData.contract}
         isLoading={isFetchingContractClient}
         contractClientError={contractClientError}
+        isSacType={isSacType}
       />
     ) : null;
   };
@@ -315,7 +315,8 @@ export default function ContractExplorer() {
               label: "Invoke Contract",
               content: renderContractInvokeContent(),
               isDisabled:
-                !isDataLoaded || !(contractInfoData && contractClient?.spec),
+                !isDataLoaded ||
+                (!contractInfoData && !(contractClient?.spec || isSacType)),
             }}
             activeTabId={contractActiveTab}
             onTabChange={(tabId) => {

--- a/src/hooks/useSacXdrData.ts
+++ b/src/hooks/useSacXdrData.ts
@@ -27,14 +27,14 @@ export const useSacXdrData = ({ isActive }: { isActive: boolean }) => {
 
   if (!sacData) {
     return {
-      SacXdrData: "",
+      SacXdrData: [""],
       sacDataError: null,
       isSacDataFetching: false,
       isSacDataLoading: false,
     };
   }
 
-  const SacXdrData = (dataString: string | null | undefined): string[] => {
+  const sacXdrData = (dataString: string | null | undefined): string[] => {
     if (!dataString) {
       return [""];
     }
@@ -48,7 +48,7 @@ export const useSacXdrData = ({ isActive }: { isActive: boolean }) => {
       : [""];
   };
 
-  const sacXdrDataFormatted = SacXdrData(sacData);
+  const sacXdrDataFormatted = sacXdrData(sacData);
 
   return {
     sacXdrData: sacXdrDataFormatted,

--- a/src/hooks/useSacXdrData.ts
+++ b/src/hooks/useSacXdrData.ts
@@ -1,0 +1,59 @@
+import { parse, stringify } from "lossless-json";
+
+import { useGitHubFile } from "@/query/useGitHubFile";
+
+import * as StellarXdr from "@/helpers/StellarXdr";
+
+import { useIsXdrInit } from "@/hooks/useIsXdrInit";
+
+import { STELLAR_ASSET_CONTRACT } from "@/constants/stellarAssetContractData";
+
+import { AnyObject } from "@/types/types";
+
+export const useSacXdrData = ({ isActive }: { isActive: boolean }) => {
+  const {
+    data: sacData,
+    error: sacDataError,
+    isFetching: isSacDataFetching,
+    isLoading: isSacDataLoading,
+  } = useGitHubFile({
+    repo: STELLAR_ASSET_CONTRACT.contractSpecRepo,
+    path: STELLAR_ASSET_CONTRACT.contractSpecPath,
+    file: `${STELLAR_ASSET_CONTRACT.contractSpecFileName}.json`,
+    isActive: Boolean(isActive),
+  });
+
+  const isXdrInit = useIsXdrInit();
+
+  if (!sacData) {
+    return {
+      SacXdrData: "",
+      sacDataError: null,
+      isSacDataFetching: false,
+      isSacDataLoading: false,
+    };
+  }
+
+  const SacXdrData = (dataString: string | null | undefined): string[] => {
+    if (!dataString) {
+      return [""];
+    }
+
+    const jsonData = parse(dataString) as AnyObject[];
+
+    return isXdrInit
+      ? jsonData.map((d) =>
+          StellarXdr.encode("ScSpecEntry", stringify(d) || ""),
+        )
+      : [""];
+  };
+
+  const sacXdrDataFormatted = SacXdrData(sacData);
+
+  return {
+    sacXdrData: sacXdrDataFormatted,
+    sacDataError: sacDataError,
+    isSacDataFetching: isSacDataFetching,
+    isSacDataLoading: isSacDataLoading,
+  };
+};


### PR DESCRIPTION
SAC ID on Testnet: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC

**Summary:**
- created `useSacXdrData` hook so I can re-use it for `Build Tx -> Invoke Contract` later ([#1517](https://github.com/stellar/laboratory/issues/1517))
- simplified the `InvokeContractForm` code by removing the params `infoData`, `network`; passing `contractSpec` so that I don't have to re-call it within that form

Here's [the transfer contract tx](https://stellar.expert/explorer/testnet/tx/3823ddbd3f661d09a03bd1a40fdd6d336bf14f8d76ac93104d245749036aa5b0) that I did while testing this feature

<img width="1136" height="539" alt="Screenshot 2025-07-25 at 12 38 09 PM" src="https://github.com/user-attachments/assets/e56f9f59-cbd8-4003-9093-d1dca365eb0a" />
