### PR TITLE
Disable 'memo' in build tx for soroban operations for P23

### DIFF
--- a/src/components/FormElements/MemoPicker.tsx
+++ b/src/components/FormElements/MemoPicker.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { MemoType, MemoValue } from "@stellar/stellar-sdk";
 import { Input } from "@stellar/design-system";
 
+import { Box } from "@/components/layout/Box";
 import { SdsLink } from "@/components/SdsLink";
 import { RadioPicker } from "@/components/RadioPicker";
 import { ExpandBox } from "@/components/ExpandBox";
+
 import { EmptyObj } from "@/types/types";
-import { Box } from "@/components/layout/Box";
 
 export type MemoPickerValue = {
   type: MemoType | string | undefined;

--- a/src/components/FormElements/MemoPicker.tsx
+++ b/src/components/FormElements/MemoPicker.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { MemoType, MemoValue } from "@stellar/stellar-sdk";
 import { Input } from "@stellar/design-system";
 
+import { SdsLink } from "@/components/SdsLink";
 import { RadioPicker } from "@/components/RadioPicker";
 import { ExpandBox } from "@/components/ExpandBox";
 import { EmptyObj } from "@/types/types";
+import { Box } from "@/components/layout/Box";
 
 export type MemoPickerValue = {
   type: MemoType | string | undefined;
@@ -93,6 +95,16 @@ export const MemoPicker = ({
           error={error}
         />
       </ExpandBox>
+      <Box gap="xs" addlClassName="FieldNote FieldNote--note FieldNote--md">
+        <div>
+          Note: Starting with Protocol 23,{" "}
+          <SdsLink href="https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md#prohibit-the-transaction-memo-and-muxed-source-accounts-from-being-set-on-soroban-transactions">
+            (CAP 0067)
+          </SdsLink>{" "}
+          Soroban transactions no longer support memos. If you include a memo,
+          it will be ignored. Be sure to update your transactions accordingly.
+        </div>
+      </Box>
     </div>
   );
 };

--- a/src/components/SmartContractJsonSchema/index.tsx
+++ b/src/components/SmartContractJsonSchema/index.tsx
@@ -42,6 +42,7 @@ export const JsonSchemaForm = ({
     isPending: isPrepareTxPending,
     isError: isPrepareTxError,
     error: prepareTxError,
+    isSuccess: isPrepareTxSuccess,
     data: prepareTxData,
     reset: resetPrepareTx,
   } = useRpcPrepareTx();
@@ -180,6 +181,16 @@ export const JsonSchemaForm = ({
             Prepare Transaction
           </Button>
         </Box>
+
+        {isPrepareTxSuccess && txnParams.memo && (
+          <Box
+            gap="md"
+            addlClassName="FieldNote FieldNote--note FieldNote--md"
+            direction="row"
+          >
+            {`Note: Your memo was removed because Soroban transactions no longer support memos as of Protocol 23.`}
+          </Box>
+        )}
 
         {submitTxError && <ErrorText errorMessage={submitTxError} size="sm" />}
       </Box>

--- a/src/components/SmartContractJsonSchema/index.tsx
+++ b/src/components/SmartContractJsonSchema/index.tsx
@@ -113,9 +113,13 @@ export const JsonSchemaForm = ({
     setSubmitTxError("");
     resetPrepareTx();
 
+    const updatedTxnParams = {
+      ...txnParams,
+      memo: {}, // starting with p23, soroban tx no longer support memos
+    };
     const { xdr, error } = getTxnToSimulate(
       value,
-      txnParams,
+      updatedTxnParams,
       sorobanOperation,
       network.passphrase,
     );

--- a/src/components/SmartContractJsonSchema/index.tsx
+++ b/src/components/SmartContractJsonSchema/index.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Button, Card, Text, Textarea } from "@stellar/design-system";
+import {
+  Button,
+  Card,
+  Notification,
+  Text,
+  Textarea,
+} from "@stellar/design-system";
 import type { JSONSchema7 } from "json-schema";
 import { parse, stringify } from "lossless-json";
 import { usePrevious } from "@/hooks/usePrevious";
@@ -188,7 +194,10 @@ export const JsonSchemaForm = ({
             addlClassName="FieldNote FieldNote--note FieldNote--md"
             direction="row"
           >
-            {`Note: Your memo was removed because Soroban transactions no longer support memos as of Protocol 23.`}
+            <Notification
+              variant="warning"
+              title="Note: Your memo was removed because Soroban transactions no longer support memos as of Protocol 23."
+            ></Notification>
           </Box>
         )}
 


### PR DESCRIPTION
- I disable it at `Prepare Transaction` button
- Added a note underneath the memo field

<img width="1151" height="117" alt="Screenshot 2025-07-31 at 5 29 57 PM" src="https://github.com/user-attachments/assets/f8ad7084-03ff-46cc-b942-2163b29744f2" />
