### PR TITLE
Use prepare transaction for restoreFootprint and extend ttl

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
@@ -8,15 +8,22 @@ import {
   Notification,
 } from "@stellar/design-system";
 
+import { useStore } from "@/store/useStore";
+
 import { Box } from "@/components/layout/Box";
 import { formComponentTemplateTxnOps } from "@/components/formComponentTemplateTxnOps";
 import { ShareUrlButton } from "@/components/ShareUrlButton";
 import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
+import { ErrorText } from "@/components/ErrorText";
 
 import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
 import { shareableUrl } from "@/helpers/shareableUrl";
+import { getNetworkHeaders } from "@/helpers/getNetworkHeaders";
+import { getTxWithSorobanData } from "@/helpers/sorobanUtils";
+import { sanitizeObject } from "@/helpers/sanitizeObject";
 
-import { useStore } from "@/store/useStore";
+import { useRpcPrepareTx } from "@/query/useRpcPrepareTx";
+
 import {
   EMPTY_OPERATION_ERROR,
   INITIAL_OPERATION,
@@ -25,7 +32,6 @@ import {
 import { trackEvent, TrackingEvent } from "@/metrics/tracking";
 
 import { OperationError, SorobanInvokeValue } from "@/types/types";
-import { sanitizeObject } from "@/helpers/sanitizeObject";
 
 export const SorobanOperation = ({
   operationTypeSelector,
@@ -46,11 +52,45 @@ export const SorobanOperation = ({
   renderSourceAccount: (opType: string, index: number) => React.ReactNode;
 }) => {
   const { transaction, network } = useStore();
-  const { soroban } = transaction.build;
+  const { soroban, params: txnParams } = transaction.build;
   const { operation: sorobanOperation, xdr: sorobanTxnXdr } = soroban;
-  const { updateSorobanBuildOperation } = transaction;
+  const { updateSorobanBuildOperation, updateSorobanBuildXdr } = transaction;
 
   const [isSaveTxnModalVisible, setIsSaveTxnModalVisible] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const {
+    mutateAsync: prepareTx,
+    isPending: isPrepareTxPending,
+    reset: resetPrepareTx,
+  } = useRpcPrepareTx();
+
+  const prepareSorobanTx = async () => {
+    resetPrepareTx();
+    setErrorMessage("");
+
+    try {
+      const sorobanTx = getTxWithSorobanData({
+        operation: sorobanOperation,
+        txnParams,
+        networkPassphrase: network.passphrase,
+      });
+
+      const preparedTx = await prepareTx({
+        rpcUrl: network.rpcUrl,
+        transactionXdr: sorobanTx.xdr,
+        headers: getNetworkHeaders(network, "rpc"),
+        networkPassphrase: network.passphrase,
+      });
+
+      if (preparedTx.transactionXdr) {
+        updateSorobanBuildXdr(preparedTx.transactionXdr);
+      }
+    } catch (e: any) {
+      setErrorMessage(e?.result?.message || "Failed to prepare transaction");
+      updateSorobanBuildXdr("");
+    }
+  };
 
   const resetSorobanOperation = () => {
     updateSorobanBuildOperation(INITIAL_OPERATION);
@@ -220,6 +260,24 @@ export const SorobanOperation = ({
             {/* Optional source account for Soroban operations */}
             <>{renderSourceAccount(sorobanOperation.operation_type, 0)}</>
           </Box>
+
+          {sorobanOperation.operation_type !== "invoke_contract" && (
+            <Box gap="sm" direction="row" align="center">
+              <Button
+                disabled={Boolean(!network.rpcUrl)}
+                isLoading={isPrepareTxPending}
+                size="md"
+                variant="secondary"
+                onClick={prepareSorobanTx}
+              >
+                Prepare Soroban Transaction to Sign
+              </Button>
+
+              {errorMessage && (
+                <ErrorText errorMessage={errorMessage} size="sm" />
+              )}
+            </Box>
+          )}
 
           <Box gap="sm" direction="row" align="center">
             <Notification variant="warning" title="Only One Operation Allowed">

--- a/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
@@ -262,7 +262,7 @@ export const SorobanOperation = ({
           </Box>
 
           {sorobanOperation.operation_type !== "invoke_contract" && (
-            <Box gap="sm" direction="row" align="center">
+            <Box gap="sm" align="start">
               <Button
                 disabled={Boolean(!network.rpcUrl)}
                 isLoading={isPrepareTxPending}

--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -87,20 +87,7 @@ export default function BuildTransaction() {
 
       <>{renderError()}</>
 
-      {IS_SOROBAN_TX ? (
-        renderSorobanTransactionXdr(soroban.operation.operation_type)
-      ) : (
-        <ClassicTransactionXdr />
-      )}
+      {IS_SOROBAN_TX ? <SorobanTransactionXdr /> : <ClassicTransactionXdr />}
     </Box>
   );
 }
-
-const renderSorobanTransactionXdr = (sorobanOperation: string) => {
-  // "invoke_contract_function" operation builds its tx from the component level
-  if (sorobanOperation === "invoke_contract_function") {
-    return <SorobanTransactionXdr hasPreBuiltXdr={true} />;
-  }
-
-  return <SorobanTransactionXdr />;
-};

--- a/src/components/FormElements/ResourceFeePickerWithQuery.tsx
+++ b/src/components/FormElements/ResourceFeePickerWithQuery.tsx
@@ -69,6 +69,12 @@ export const ResourceFeePickerWithQuery = ({
   );
 
   useEffect(() => {
+    if (simulateTxData && (simulateTxData as any)?.result?.error) {
+      setErrorMessage((simulateTxData as any).result.error);
+    }
+  }, [simulateTxData]);
+
+  useEffect(() => {
     // Reset error message when operation params change
     setErrorMessage(undefined);
   }, [soroban.operation]);

--- a/tests/e2e/buildTransaction.test.ts
+++ b/tests/e2e/buildTransaction.test.ts
@@ -1344,11 +1344,17 @@ test.describe("Build Transaction Page", () => {
           .getByLabel("Durability")
           .selectOption({ value: "persistent" });
 
+        const prepareTxButton = page.getByText(
+          "Prepare Soroban Transaction to Sign",
+        );
+        await expect(prepareTxButton).toBeEnabled();
+        await prepareTxButton.click();
+
         await testOpSuccessHashAndXdr({
           isSorobanOp: true,
           page,
-          hash: "f81b348c83b9e59781117a65b01e2332ef5a00523ec7daead11b91bcf56a0755",
-          xdr: "AAAAAgAAAAANLHqVohDTxPKQ3fawTPgHahe0TzJjJkWV1WakcbeADgAAToQAD95QAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAATiAAAAAA",
+          hash: "697f7755242fca0a02dad6c154b0285942da75dc0dc8bc89d13edd4f1a66131c",
+          xdr: "AAAAAgAAAAANLHqVohDTxPKQ3fawTPgHahe0TzJjJkWV1WakcbeADgABBWwAD95QAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALboAAAAAA==",
         });
       });
 
@@ -1465,12 +1471,8 @@ test.describe("Build Transaction Page", () => {
         // Fill in required fields
         await soroban_operation
           .getByLabel("Contract ID")
-          .fill("CAQP53Z2GMZ6WVOKJWXMCVDLZYJ7GYVMWPAMWACPLEZRF2UEZW3B636S");
-        await soroban_operation
-          .getByLabel("Key ScVal in XDR")
-          .fill(
-            "AAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKD",
-          );
+          .fill("CA2WMM5VMUEAZLXBIOHAJTQKXT7AM3D6IKDQVOLGNAWZO5JCJXVIUCJG");
+        await soroban_operation.getByLabel("Key ScVal in XDR").fill("AAAAFA==");
         await soroban_operation
           .getByLabel("Durability")
           .selectOption({ value: "persistent" });
@@ -1478,11 +1480,17 @@ test.describe("Build Transaction Page", () => {
           .getByLabel("Resource Fee (in stroops)")
           .fill("46684");
 
+        const prepareTxButton = page.getByText(
+          "Prepare Soroban Transaction to Sign",
+        );
+        await expect(prepareTxButton).toBeEnabled();
+        await prepareTxButton.click();
+
         await testOpSuccessHashAndXdr({
           isSorobanOp: true,
           page,
-          hash: "232c61d2e07fae61a09ffe12102f13c79c86dadbf0c49f8237fcbe0a2231921c",
-          xdr: "AAAAAgAAAAANLHqVohDTxPKQ3fawTPgHahe0TzJjJkWV1WakcbeADgAAtsAAD95QAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGgAAAAAAAAABAAAAAAAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAC2XAAAAAA=",
+          hash: "111892cc24b7183aba3bbab8bca4103653d982c8ef67e7808e80354928ced640",
+          xdr: "AAAAAgAAAAANLHqVohDTxPKQ3fawTPgHahe0TzJjJkWV1WakcbeADgABbWEAD95QAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGgAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAAA",
         });
       });
 

--- a/tests/e2e/savedTransactions.test.ts
+++ b/tests/e2e/savedTransactions.test.ts
@@ -234,17 +234,6 @@ test.describe("Saved Transactions Page", () => {
       await expect(
         pageContext.getByLabel("Resource Fee (in stroops)"),
       ).toHaveValue("46753");
-
-      const xdrElement = pageContext.getByTestId(
-        "build-soroban-transaction-envelope-xdr",
-      );
-
-      await xdrElement.isVisible();
-
-      // XDR
-      await expect(xdrElement.getByText("XDR").locator("+ div")).toHaveText(
-        "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGQAAAAAAAHUwAAAAAQAAAAAAAAABAAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtqEAAAAA",
-      );
     });
 
     test("Delete transaction", async () => {

--- a/tests/e2e/urlParams.test.ts
+++ b/tests/e2e/urlParams.test.ts
@@ -204,21 +204,6 @@ test.describe("URL Params", () => {
         "persistent",
       );
       await expect(sorobanOp.getByLabel("Resource Fee")).toHaveValue("46753");
-
-      // Validation
-      const txnSuccess = page.getByTestId(
-        "build-soroban-transaction-envelope-xdr",
-      );
-
-      await expect(
-        txnSuccess.getByText("Network Passphrase").locator("+ div"),
-      ).toHaveText("Test SDF Network ; September 2015");
-      await expect(txnSuccess.getByText("Hash").locator("+ div")).toHaveText(
-        "d8c7f3dee39f14373e2f1a1131bcc91a49694b6af6b6d81b7703784b3a51bc94",
-      );
-      await expect(txnSuccess.getByText("XDR").locator("+ div")).toHaveText(
-        "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGgAAAAEAAAAAZ1G76AAAAAAAAAAAAAAAAQAAAAMxMDAAAAAAAQAAAAAAAAAZAAAAAAAATiAAAAABAAAAAAAAAAEAAAAGAAAAASD+7zozM+tVyk2uwVRrzhPzYqyzwMsAT1kzEuqEzbYfAAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKDAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2oQAAAAA=",
-      );
     });
 
     test("Fee Bump", async ({ page }) => {


### PR DESCRIPTION
**Summary:**
- These operations make so much more sense now after working on invoke contract. Previously, `extend_ttl` and `restoreFootprint` weren't using the simulated transaction response so its `readBytes` and `writeBytes` were empty for `restoreFootprint`. I updated to use the `preparedTransaction` (simulated and assembled tx) to restore and extend
- The [doc](https://developers.stellar.org/docs/build/guides/dapps/state-archival#step-2-create-a-helper-function-for-restoration) does a great job at explaining restoring footprint when calling the contract function that returns `restorePreamble`; however, this isn't the flow that the lab follows. I followed [Create a restoration footprint manually to restore archived data using the JavaScript SDK](https://developers.stellar.org/docs/build/guides/archival/create-restoration-footprint-js) and wrongfully implemented this.

**successful restoration on mainnet:**
before:
<img width="1267" height="204" alt="gb5u-expired" src="https://github.com/user-attachments/assets/fd4b949b-9184-4cde-8dfb-420e2fba3b99" />

after:
<img width="1245" height="202" alt="gb5u-restored" src="https://github.com/user-attachments/assets/12464fb9-1845-4f7b-afdf-38e763f2b7f2" />
- [tx on stellar.expert](https://stellar.expert/explorer/public/tx/f7f77d82fc1011c5b1ddbaf96c7da86ddfb8076f13d991743af8cf67591eded0)

**successful extend ttl before & after**
before:
<img width="1254" height="200" alt="CA2WMM5VMUEAZLXBIOHAJTQKXT7AM3D6IKDQVOLGNAWZO5JCJXVIUCJG-before" src="https://github.com/user-attachments/assets/c572b53d-3608-49dc-928b-6777002bf021" />

after:
<img width="1254" height="275" alt="CA2WMM5VMUEAZLXBIOHAJTQKXT7AM3D6IKDQVOLGNAWZO5JCJXVIUCJG-after" src="https://github.com/user-attachments/assets/a2c2e3b4-2324-46de-9048-85b8a7fdfc05" />

