### PR TITLE
[Invoke Contract] Add a tab view for json and base64

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
@@ -7,13 +7,12 @@ import {
   useState,
 } from "react";
 import {
+  Badge,
   Button,
   Card,
-  Select,
+  Icon,
   Text,
   Textarea,
-  Badge,
-  Icon,
   Tooltip,
 } from "@stellar/design-system";
 import { BASE_FEE, contract } from "@stellar/stellar-sdk";
@@ -24,11 +23,11 @@ import { RpcErrorResponse } from "@/components/TxErrorResponse";
 
 import { Box } from "@/components/layout/Box";
 import { ErrorText } from "@/components/ErrorText";
-import { JsonCodeWrapToggle } from "@/components/JsonCodeWrapToggle";
 import { JsonSchemaRenderer } from "@/components/SmartContractJsonSchema/JsonSchemaRenderer";
-import { PrettyJsonTransaction } from "@/components/PrettyJsonTransaction";
 import { TransactionSuccessCard } from "@/components/TransactionSuccessCard";
 import { WalletKitContext } from "@/components/WalletKit/WalletKitContextProvider";
+import { TabView } from "@/components/TabView";
+import { PrettyJson } from "@/components/PrettyJson";
 
 import { TransactionBuildParams } from "@/store/createStore";
 import { useStore } from "@/store/useStore";
@@ -39,8 +38,6 @@ import { useRpcPrepareTx } from "@/query/useRpcPrepareTx";
 import { useSimulateTx } from "@/query/useSimulateTx";
 import { useSubmitRpcTx } from "@/query/useSubmitRpcTx";
 
-import { useCodeWrappedSetting } from "@/hooks/useCodeWrappedSetting";
-
 import { isEmptyObject } from "@/helpers/isEmptyObject";
 import { dereferenceSchema } from "@/helpers/dereferenceSchema";
 import { getNetworkHeaders } from "@/helpers/getNetworkHeaders";
@@ -49,6 +46,27 @@ import { getTxnToSimulate } from "@/helpers/sorobanUtils";
 import { SorobanInvokeValue, XdrFormatType, AnyObject } from "@/types/types";
 
 import { trackEvent, TrackingEvent } from "@/metrics/tracking";
+
+export const SimulatedResponse = ({
+  result,
+}: {
+  result: Api.SimulateTransactionResponse;
+}) => {
+  const errorClass = Api.isSimulationError(result)
+    ? "PageBody__content--error"
+    : "";
+
+  return (
+    <Box gap="md">
+      <div
+        data-testid="invoke-contract-simulate-tx-response"
+        className={`PageBody__content PageBody__scrollable ${errorClass}`}
+      >
+        <PrettyJson json={result} isCodeWrapped={true} />
+      </div>
+    </Box>
+  );
+};
 
 export const InvokeContractForm = ({
   contractId,
@@ -65,7 +83,7 @@ export const InvokeContractForm = ({
     methodType: string;
   } | null>(null);
   const [isExtensionLoading, setIsExtensionLoading] = useState(false);
-  const [xdrFormat, setXdrFormat] = useState<XdrFormatType>("json");
+  const [xdrFormat, setXdrFormat] = useState<XdrFormatType | string>("json");
   const [formValue, setFormValue] = useState<SorobanInvokeValue>({
     contract_id: contractId,
     function_name: funcName,
@@ -73,6 +91,12 @@ export const InvokeContractForm = ({
   });
   const [formError, setFormError] = useState<AnyObject>({});
   const [isGetFunction, setIsGetFunction] = useState(false);
+
+  const [jsonResult, setJsonResult] =
+    useState<Api.SimulateTransactionResponse>();
+  const [base64Result, setBase64Result] =
+    useState<Api.SimulateTransactionResponse>();
+
   // Based on reads and writes to the contract
   // Can only be determined based on the simulation result
   const [isWriteFn, setIsWriteFn] = useState<boolean | undefined>(undefined);
@@ -146,8 +170,6 @@ export const InvokeContractForm = ({
 
   const IS_BLOCK_EXPLORER_ENABLED =
     network.id === "testnet" || network.id === "mainnet";
-
-  const [isCodeWrapped, setIsCodeWrapped] = useCodeWrappedSetting();
 
   const responseSuccessEl = useRef<HTMLDivElement | null>(null);
   const responseErrorEl = useRef<HTMLDivElement | null>(null);
@@ -362,12 +384,28 @@ export const InvokeContractForm = ({
 
   const handleSimulate = async (xdr: string) => {
     try {
-      await simulateTx({
-        rpcUrl: network.rpcUrl,
-        transactionXdr: xdr,
-        headers: getNetworkHeaders(network, "rpc"),
-        xdrFormat,
-      });
+      const [jsonResult, base64Result] = await Promise.all([
+        simulateTx({
+          rpcUrl: network.rpcUrl,
+          transactionXdr: xdr,
+          headers: getNetworkHeaders(network, "rpc"),
+          xdrFormat: "json",
+        }),
+        simulateTx({
+          rpcUrl: network.rpcUrl,
+          transactionXdr: xdr,
+          headers: getNetworkHeaders(network, "rpc"),
+          xdrFormat: "base64",
+        }),
+      ]);
+
+      if (jsonResult?.result) {
+        setJsonResult(jsonResult?.result);
+      }
+
+      if (base64Result?.result) {
+        setBase64Result(base64Result?.result);
+      }
 
       trackEvent(
         TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_SUCCESS,
@@ -550,40 +588,6 @@ export const InvokeContractForm = ({
     );
   };
 
-  const renderResponse = () => {
-    const { result: simulateResult } = simulateTxData || {};
-    const { result: submitResult } = submitRpcResponse || {};
-
-    const result = simulateResult || submitResult;
-
-    if (result) {
-      return (
-        <Box gap="md">
-          <div
-            data-testid="invoke-contract-simulate-tx-response"
-            className={`PageBody__content PageBody__scrollable ${result?.error ? "PageBody__content--error" : ""}`}
-          >
-            <PrettyJsonTransaction
-              json={result}
-              xdr={result?.xdr}
-              isCodeWrapped={isCodeWrapped}
-            />
-          </div>
-          <Box gap="md" direction="row" align="center">
-            <JsonCodeWrapToggle
-              isChecked={isCodeWrapped}
-              onChange={(isChecked) => {
-                setIsCodeWrapped(isChecked);
-              }}
-            />
-          </Box>
-        </Box>
-      );
-    }
-
-    return null;
-  };
-
   const renderSuccess = () => {
     if (isSubmitRpcSuccess && submitRpcResponse && network.id) {
       return (
@@ -661,50 +665,78 @@ export const InvokeContractForm = ({
         <Box gap="md">
           {renderSchema()}
 
-          <Box gap="sm" direction="row" align="end" justify="end" wrap="wrap">
-            <Box gap="sm" direction="row" align="end" justify="end" wrap="wrap">
-              <Select
-                id="simulate-tx-xdr-format"
-                fieldSize="md"
-                value={xdrFormat}
-                onChange={(e) => {
-                  setXdrFormat(e.target.value as XdrFormatType);
+          <Box
+            gap="sm"
+            direction="row"
+            align="stretch"
+            justify="space-between"
+            wrap="wrap"
+          >
+            <TabView
+              tab1={{
+                id: "json",
+                label: "JSON",
+                content: jsonResult && (
+                  <SimulatedResponse result={jsonResult} />
+                ),
+                isDisabled: !jsonResult,
+              }}
+              tab2={{
+                id: "base64",
+                label: "Base64",
+                content: base64Result && (
+                  <SimulatedResponse result={base64Result} />
+                ),
+                isDisabled: !base64Result,
+              }}
+              activeTabId={xdrFormat}
+              onTabChange={(id) => {
+                setXdrFormat(id);
+                trackEvent(
+                  TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SELECTED_XDR_FORMAT,
+                  {
+                    xdrFormat: id,
+                  },
+                );
+              }}
+            />
+            <Box
+              addlClassName="AbsoluteButtons"
+              gap="sm"
+              direction="row"
+              align="stretch"
+              justify="space-between"
+              wrap="wrap"
+            >
+              <Button
+                size="md"
+                variant="tertiary"
+                disabled={isSimulationDisabled()}
+                isLoading={isSimulating}
+                onClick={async () => {
+                  const xdr = await getXdrToSimulate();
+
+                  if (xdr) {
+                    await handleSimulate(xdr);
+                    await handlePrepareTx(xdr);
+                  }
                 }}
               >
-                <option value="base64">XDR Format: Base64</option>
-                <option value="json">XDR Format: JSON</option>
-              </Select>
+                Simulate
+              </Button>
+
+              <Button
+                size="md"
+                variant="secondary"
+                isLoading={isExtensionLoading || isSubmitRpcPending}
+                disabled={isSubmitDisabled}
+                onClick={handleSimulateAndSubmit}
+              >
+                Simulate & Submit
+              </Button>
             </Box>
-
-            <Button
-              size="md"
-              variant="tertiary"
-              disabled={isSimulationDisabled()}
-              isLoading={isSimulating}
-              onClick={async () => {
-                const xdr = await getXdrToSimulate();
-
-                if (xdr) {
-                  await handleSimulate(xdr);
-                  await handlePrepareTx(xdr);
-                }
-              }}
-            >
-              Simulate
-            </Button>
-
-            <Button
-              size="md"
-              variant="secondary"
-              isLoading={isExtensionLoading || isSubmitRpcPending}
-              disabled={isSubmitDisabled}
-              onClick={handleSimulateAndSubmit}
-            >
-              Simulate & Submit
-            </Button>
           </Box>
 
-          <>{renderResponse()}</>
           <>{renderSuccess()}</>
           <>{renderError()}</>
         </Box>

--- a/src/app/(sidebar)/smart-contracts/styles.scss
+++ b/src/app/(sidebar)/smart-contracts/styles.scss
@@ -33,10 +33,14 @@
 }
 
 .ContractInvoke {
-  .Select {
-    select {
-      font-weight: var(--sds-fw-semi-bold);
-      padding-right: pxToRem(32px);
-    }
+  position: relative;
+
+  .TabView {
+    width: 100%;
+  }
+
+  .AbsoluteButtons {
+    position: absolute;
+    right: 0;
   }
 }

--- a/src/metrics/tracking.ts
+++ b/src/metrics/tracking.ts
@@ -180,6 +180,7 @@ export enum TrackingEvent {
   SMART_CONTRACTS_SAVED_VIEW_IN_EXPLORER = "smart contracts: saved: view in contract explorer",
   SMART_CONTRACTS_EXPLORER_STORAGE_RESTORE = "smart contracts: explorer: storage: restore",
   // Smart Contracts - Invoke Contract
+  SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SELECTED_XDR_FORMAT = "smart contracts: explorer: invoke contract: simulate: xdr format selected",
   SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE = "smart contracts: explorer: invoke contract: simulate",
   SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_SUCCESS = "smart contracts: explorer: invoke contract: simulate: success",
   SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SIMULATE_ERROR = "smart contracts: explorer: invoke contract: simulate: error",


### PR DESCRIPTION
**Summary:**
- calling both xdrFormat `base64` and `json` via `Promise.all` and return responses in two different types using `<Tab />`
- use `<PrettyJson />` instead of `<PrettyJsonTransaction />`
<img width="1100" height="708" alt="json" src="https://github.com/user-attachments/assets/75e888a3-d39b-485a-8589-26c09df1957c" />

<img width="1099" height="605" alt="base64" src="https://github.com/user-attachments/assets/bcc8ca91-969e-486c-a13d-fc5fda88f3ae" />
