### PR TITLE
sanitizeObject: add description to clarify that 0 is falsy

### DIFF
--- a/src/helpers/sanitizeObject.ts
+++ b/src/helpers/sanitizeObject.ts
@@ -1,6 +1,9 @@
 import { isEmptyObject } from "@/helpers/isEmptyObject";
 import { AnyObject } from "@/types/types";
 
+/**
+ * Sanitize an object by removing falsy values (including 0).
+ */
 export const sanitizeObject = <T extends AnyObject>(
   obj: T,
   noEmptyObj = false,


### PR DESCRIPTION
To make it clear that `0` is expected to be a falsy value when using this method. I tried to exclude the `0`, but too many tests failed to change this behavior. Added a comment for clarity.