### PR TITLE
Update stellar-wallets-kit and enable `skipRequestAccess` for `getAccess()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.20.1",
-    "@creit.tech/stellar-wallets-kit": "^1.9.1",
+    "@creit.tech/stellar-wallets-kit": "^1.9.3",
     "@ledgerhq/hw-app-str": "^7.2.4",
     "@ledgerhq/hw-transport-webusb": "^6.29.8",
     "@monaco-editor/react": "^4.7.0",

--- a/src/components/WalletKit/ConnectWallet.tsx
+++ b/src/components/WalletKit/ConnectWallet.tsx
@@ -58,7 +58,6 @@ export const ConnectWallet = () => {
           await handleSetWalletAddress({ skipRequestAccess: true });
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (e) {
-          console.log("error");
           // noop
         }
         clearTimeout(t);

--- a/src/components/WalletKit/WalletKitContextProvider.tsx
+++ b/src/components/WalletKit/WalletKitContextProvider.tsx
@@ -12,7 +12,6 @@ import {
   StellarWalletsKit,
   HotWalletModule,
   xBullModule,
-  XBULL_ID,
 } from "@creit.tech/stellar-wallets-kit";
 import { LedgerModule } from "@creit.tech/stellar-wallets-kit/modules/ledger.module";
 
@@ -114,20 +113,20 @@ export const WalletKitContextProvider = ({
 
     return new StellarWalletsKit({
       network: networkType,
-      selectedWalletId: XBULL_ID,
+      selectedWalletId: savedWallet?.id || "",
       modules: network.id === "mainnet" ? PROD_MODULES : TEST_MODULES,
       ...(theme && {
         buttonTheme: isDarkTheme
           ? {
-            ...commonDarkTheme,
-            buttonPadding: "0.5rem 1.25rem",
-            buttonBorderRadius: "0.5rem",
-          }
+              ...commonDarkTheme,
+              buttonPadding: "0.5rem 1.25rem",
+              buttonBorderRadius: "0.5rem",
+            }
           : {
-            ...commonLightTheme,
-            buttonPadding: "0.5rem 1.25rem",
-            buttonBorderRadius: "0.5rem",
-          },
+              ...commonLightTheme,
+              buttonPadding: "0.5rem 1.25rem",
+              buttonBorderRadius: "0.5rem",
+            },
         modalTheme: isDarkTheme ? modalDarkTheme : modalLightTheme,
       }),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,10 +454,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@creit.tech/stellar-wallets-kit@^1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@creit.tech/stellar-wallets-kit/-/stellar-wallets-kit-1.9.1.tgz#c4daee339070c6dc1c3c9001e405e0dbcb642a93"
-  integrity sha512-bmiwYnrILaC52etdWZ/pHDUDd8Lc8md7ttHldTLUVY5+cpe8V7Jvbm/MyVrfYtl5OsDSbd4YcgOdhP6RqYHl0A==
+"@creit.tech/stellar-wallets-kit@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@creit.tech/stellar-wallets-kit/-/stellar-wallets-kit-1.9.3.tgz#7364143a6ad730f9679a1b0cc4bf9d22788e554f"
+  integrity sha512-uSiPM2ApK3XSDkAHGWMwbtqAGHmwNwDggQIQ9jgA2awzSQfcGldIBEPgNlZz7AB1YXsVyk5ghbkzUsVxIVEk1g==
   dependencies:
     "@albedo-link/intent" "0.12.0"
     "@creit.tech/xbull-wallet-connect" "^0.4.0"
@@ -470,7 +470,7 @@
     "@ngneat/elf-devtools" "1.3.0"
     "@ngneat/elf-entities" "5.0.2"
     "@ngneat/elf-persist-state" "1.2.1"
-    "@stellar/freighter-api" "4.1.0"
+    "@stellar/freighter-api" "5.0.0"
     "@trezor/connect-plugin-stellar" "9.2.1"
     "@trezor/connect-web" "9.6.2"
     "@walletconnect/modal" "2.6.2"
@@ -3055,13 +3055,13 @@
     react-copy-to-clipboard "^5.1.0"
     tslib "^2.8.1"
 
-"@stellar/freighter-api@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@stellar/freighter-api/-/freighter-api-4.1.0.tgz#c7c801d4b6f4af315fe10c7d1d4c43fa1b45ac03"
-  integrity sha512-5iaENUG8AoSlBr771XVou4wjYxfcl+SRyFZydwwGEuHm1XGDu/HLXFifXbRFoU14/5rZYouycnv1uJCuFIeBxg==
+"@stellar/freighter-api@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@stellar/freighter-api/-/freighter-api-5.0.0.tgz#54c4a95db2ddfaf2d95f699fd7b401e782278c70"
+  integrity sha512-MydzLg+WpSzmws24uUs4mVME2LPN8xhUWkwyGEP0N1Hr519swC6I/W7K6cdVBzghBiVv7f/vvGFNT+0p1a33Vg==
   dependencies:
-    buffer "^6.0.3"
-    semver "^7.6.3"
+    buffer "6.0.3"
+    semver "7.7.1"
 
 "@stellar/js-xdr@^3.1.2":
   version "3.1.2"
@@ -8763,12 +8763,17 @@ secp256k1@5.0.1:
     node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
+semver@7.7.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.1, semver@^7.7.2:
+semver@^7.3.5, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.1, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==


### PR DESCRIPTION
How to reproduce this bug:
1. Log into wallet kit using Freighter
2. Log out Freighter
3. Refresh the page
4. Freighter popup appears for log in

`walletKit.getAddress` is the main function that checks whether a user is connected to the extension or not. We also use this + `localStorage` to enable logged in functionality. however, previously, when logged out this prompts users to connect continuously. With Creit-Tech's new release that includes an optional param `skipRequestAccess` for `getAddress`, this issue is now fixed.

https://github.com/Creit-Tech/Stellar-Wallets-Kit/issues/65