### PR TITLE
YouTube link should link to Developer Tutorials not the generic SDF YT Channel

### DIFF
--- a/src/components/Home/Resources.tsx
+++ b/src/components/Home/Resources.tsx
@@ -9,7 +9,7 @@ export const Resources = () => {
       id: "youtube",
       title: "YouTube",
       description: "Watch tutorials, hear from us, and get inspired to build.",
-      link: "https://www.youtube.com/@StellarDevelopmentFoundation",
+      link: "https://www.youtube.com/playlist?list=PLmr3tp_7-7GiyTrRhKjlznmWe7AqFPq6i",
       icon: <Logo.Youtube />,
     },
     {


### PR DESCRIPTION
Link to [Developer Tutorials YT Playlist](https://www.youtube.com/playlist?list=PLmr3tp_7-7GiyTrRhKjlznmWe7AqFPq6i) instead of [the generic channel](https://www.youtube.com/@StellarDevelopmentFoundation/).

Feedback from the community

> the youtube just drops into the main channel and autoplays the old idris ad and has a bunch of brand stuff and last years meridian - can someone put together a better playlist to dump people to that is dev related?

I agree with him because our YT CTA says "Watch tutorials, hear from us, and get inspired to build."