### PR TITLE
Contract Explorer: contract spec interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@next/third-parties": "^15.4.4",
     "@sentry/nextjs": "^10",
+    "@stellar-expert/contract-wasm-interface-parser": "^3.2.0",
     "@stellar/design-system": "^3.1.5",
     "@stellar/stellar-sdk": "^14.1.1",
     "@stellar/stellar-xdr-json": "^23.0.0-rc.1",

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
@@ -204,26 +204,25 @@ export const ContractSpec = ({
   return (
     <Box gap="lg">
       {/* Sections */}
-      {/*TODO: put back*/}
-      {/*{contractSections?.contractmetav0*/}
-      {/*  ? renderSectionCodeEditor({*/}
-      {/*      sectionName: "contractmetav0",*/}
-      {/*      title: "Contract Meta",*/}
-      {/*      infoLink:*/}
-      {/*        "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#contract-meta",*/}
-      {/*      height: "22",*/}
-      {/*    })*/}
-      {/*  : null}*/}
+      {contractSections?.contractmetav0
+        ? renderSectionCodeEditor({
+            sectionName: "contractmetav0",
+            title: "Contract Meta",
+            infoLink:
+              "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#contract-meta",
+            height: "22",
+          })
+        : null}
 
-      {/*{contractSections?.contractenvmetav0*/}
-      {/*  ? renderSectionCodeEditor({*/}
-      {/*      sectionName: "contractenvmetav0",*/}
-      {/*      title: "Contract Env Meta",*/}
-      {/*      infoLink:*/}
-      {/*        "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#environment-meta",*/}
-      {/*      height: "15",*/}
-      {/*    })*/}
-      {/*  : null}*/}
+      {contractSections?.contractenvmetav0
+        ? renderSectionCodeEditor({
+            sectionName: "contractenvmetav0",
+            title: "Contract Env Meta",
+            infoLink:
+              "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#environment-meta",
+            height: "15",
+          })
+        : null}
 
       {contractSections?.contractspecv0
         ? renderSectionCodeEditor({

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
@@ -44,7 +44,7 @@ export const ContractSpec = ({
   >({
     contractenvmetav0: "json",
     contractmetav0: "json",
-    contractspecv0: "json",
+    contractspecv0: "interface",
     sac: "json",
   });
   const [contractSections, setContractSections] =
@@ -230,7 +230,7 @@ export const ContractSpec = ({
             title: "Contract Spec",
             infoLink:
               "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#contract-spec",
-            languages: ["json", "xdr", "interface"],
+            languages: ["interface", "json", "xdr"],
           })
         : null}
 

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/ContractSpec.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button, Icon } from "@stellar/design-system";
 import { parse, stringify } from "lossless-json";
+import { parseContractMetadata } from "@stellar-expert/contract-wasm-interface-parser";
 
 import { CodeEditor, SupportedLanguage } from "@/components/CodeEditor";
 import { Box } from "@/components/layout/Box";
@@ -14,6 +15,8 @@ import * as StellarXdr from "@/helpers/StellarXdr";
 import { downloadFile } from "@/helpers/downloadFile";
 import { renderContractSpecViewStatus } from "@/helpers/renderContractSpecViewStatus";
 import { getWasmContractData } from "@/helpers/getWasmContractData";
+import { formatContractInterface } from "@/helpers/formatContractInterface";
+
 import { STELLAR_ASSET_CONTRACT } from "@/constants/stellarAssetContractData";
 import { useIsXdrInit } from "@/hooks/useIsXdrInit";
 
@@ -46,6 +49,8 @@ export const ContractSpec = ({
   });
   const [contractSections, setContractSections] =
     useState<ContractSections | null>();
+  const [contractInterfaceObj, setContractInterfaceObj] =
+    useState<AnyObject | null>(null);
 
   const isXdrInit = useIsXdrInit();
 
@@ -80,7 +85,18 @@ export const ContractSpec = ({
       }
     };
 
+    const parseContractMeta = () => {
+      try {
+        const parsedContractMeta = parseContractMetadata(wasmBinary);
+        setContractInterfaceObj(parsedContractMeta);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (e) {
+        // Do nothing
+      }
+    };
+
     getContractData();
+    parseContractMeta();
   }, [wasmBinary]);
 
   const viewStatus = renderContractSpecViewStatus({
@@ -119,6 +135,19 @@ export const ContractSpec = ({
       : "";
   };
 
+  const formatInterface = (obj: AnyObject | null) => {
+    if (!obj) {
+      return "";
+    }
+
+    try {
+      return formatContractInterface(obj);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (e) {
+      return "";
+    }
+  };
+
   const formatValue = (sectionName: ContractSectionName) => {
     switch (selectedFormat[sectionName]) {
       case "json":
@@ -131,6 +160,11 @@ export const ContractSpec = ({
         return isSacType
           ? formatSacData(sacData, "xdr")
           : `// ${sectionName} \n\n${contractSections?.[sectionName].xdr?.join("\n\n")}`;
+      case "interface":
+        return isSacType
+          ? // We can’t get interface for SAC because there is no Wasm file to parse
+            null
+          : formatInterface(contractInterfaceObj);
       case "text":
       default:
         return "";
@@ -141,11 +175,13 @@ export const ContractSpec = ({
     sectionName,
     title,
     infoLink,
+    languages = ["json", "xdr"],
     height,
   }: {
     sectionName: ContractSectionName;
     title: string;
     infoLink: string;
+    languages?: SupportedLanguage[];
     height?: string;
   }) => (
     <CodeEditor
@@ -153,7 +189,7 @@ export const ContractSpec = ({
       value={formatValue(sectionName) || ""}
       selectedLanguage={selectedFormat[sectionName]}
       fileName={`${wasmHash}-${sectionName}`}
-      languages={["json", "xdr"]}
+      languages={languages}
       onLanguageChange={(newLanguage) => {
         setSelectedFormat({
           ...selectedFormat,
@@ -168,25 +204,26 @@ export const ContractSpec = ({
   return (
     <Box gap="lg">
       {/* Sections */}
-      {contractSections?.contractmetav0
-        ? renderSectionCodeEditor({
-            sectionName: "contractmetav0",
-            title: "Contract Meta",
-            infoLink:
-              "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#contract-meta",
-            height: "22",
-          })
-        : null}
+      {/*TODO: put back*/}
+      {/*{contractSections?.contractmetav0*/}
+      {/*  ? renderSectionCodeEditor({*/}
+      {/*      sectionName: "contractmetav0",*/}
+      {/*      title: "Contract Meta",*/}
+      {/*      infoLink:*/}
+      {/*        "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#contract-meta",*/}
+      {/*      height: "22",*/}
+      {/*    })*/}
+      {/*  : null}*/}
 
-      {contractSections?.contractenvmetav0
-        ? renderSectionCodeEditor({
-            sectionName: "contractenvmetav0",
-            title: "Contract Env Meta",
-            infoLink:
-              "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#environment-meta",
-            height: "15",
-          })
-        : null}
+      {/*{contractSections?.contractenvmetav0*/}
+      {/*  ? renderSectionCodeEditor({*/}
+      {/*      sectionName: "contractenvmetav0",*/}
+      {/*      title: "Contract Env Meta",*/}
+      {/*      infoLink:*/}
+      {/*        "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#environment-meta",*/}
+      {/*      height: "15",*/}
+      {/*    })*/}
+      {/*  : null}*/}
 
       {contractSections?.contractspecv0
         ? renderSectionCodeEditor({
@@ -194,6 +231,7 @@ export const ContractSpec = ({
             title: "Contract Spec",
             infoLink:
               "https://developers.stellar.org/docs/learn/fundamentals/contract-development/overview#contract-spec",
+            languages: ["json", "xdr", "interface"],
           })
         : null}
 

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -59,9 +59,8 @@ export const CodeEditor = ({
   const getFileExtension = () => {
     switch (selectedLanguage) {
       case "xdr":
-        return "txt";
       case "interface":
-        return "spec";
+        return "txt";
       case "json":
       default:
         return selectedLanguage;

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -9,7 +9,7 @@ import { downloadFile } from "@/helpers/downloadFile";
 
 import "./styles.scss";
 
-export type SupportedLanguage = "json" | "xdr" | "text";
+export type SupportedLanguage = "json" | "xdr" | "text" | "interface";
 
 type CodeEditorProps = {
   title: string;
@@ -60,6 +60,8 @@ export const CodeEditor = ({
     switch (selectedLanguage) {
       case "xdr":
         return "txt";
+      case "interface":
+        return "spec";
       case "json":
       default:
         return selectedLanguage;
@@ -170,7 +172,9 @@ export const CodeEditor = ({
         <MonacoEditor
           defaultLanguage="javascript"
           defaultValue=""
-          language={selectedLanguage}
+          language={
+            selectedLanguage === "interface" ? "rust" : selectedLanguage
+          }
           value={value}
           options={{
             minimap: { enabled: false },

--- a/src/helpers/formatContractInterface.ts
+++ b/src/helpers/formatContractInterface.ts
@@ -1,0 +1,179 @@
+import { AnyObject } from "@/types/types";
+
+const TAB = "  ";
+
+export const formatContractInterface = (
+  contractInterface: AnyObject | null,
+): string => {
+  if (!contractInterface || !Object.keys(contractInterface).length) {
+    return "// No interface available";
+  }
+
+  let output = "";
+
+  // Contract-level docs
+  if (contractInterface.doc) {
+    output += `/// ${contractInterface.doc}\n`;
+  }
+
+  // Functions
+  output += functionsOutput(contractInterface.functions);
+
+  // Structs
+  output += structsOutput(contractInterface.structs);
+
+  // Unions
+  output += unionsOutput(contractInterface.unions);
+
+  // Errors
+  output += errorsOutput(contractInterface.errors);
+
+  return output;
+};
+
+const functionsOutput = (functions: any) => {
+  let funcsString = "";
+
+  if (
+    functions &&
+    typeof functions === "object" &&
+    Object.keys(functions).length
+  ) {
+    funcsString += `// ==========================================\n`;
+    funcsString += `// Functions\n`;
+    funcsString += `// ==========================================\n\n`;
+
+    Object.entries(functions).forEach((funcItem) => {
+      const key = funcItem[0];
+      const value = funcItem[1] as any;
+
+      if (value.doc) {
+        value.doc.split("\n").forEach((line: string) => {
+          funcsString += `/// ${line}\n`;
+        });
+      }
+
+      funcsString += `fn ${key}(${formatFnInputs(value.inputs)}) ${formatFnOutputs(value.outputs)}\n\n`;
+    });
+  }
+
+  return funcsString;
+};
+
+const structsOutput = (structs: any) => {
+  let structsString = "";
+
+  if (structs && typeof structs === "object" && Object.keys(structs).length) {
+    structsString += `// ==========================================\n`;
+    structsString += `// Structs\n`;
+    structsString += `// ==========================================\n\n`;
+
+    Object.entries(structs).forEach((structItem) => {
+      const key = structItem[0];
+      const value = structItem[1] as any;
+
+      structsString += `#[contracttype]\n`;
+      structsString += `struct ${key} {\n`;
+
+      if (
+        value.fields &&
+        typeof value.fields === "object" &&
+        Object.keys(value.fields).length
+      ) {
+        Object.entries(value.fields).forEach((fieldItem) => {
+          const fieldKey = fieldItem[0];
+          const fieldValue = fieldItem[1] as any;
+
+          if (fieldValue.doc) {
+            fieldValue.doc.split("\n").forEach((line: string) => {
+              structsString += `${TAB}/// ${line}\n`;
+            });
+          }
+
+          structsString += `${TAB}${fieldKey}: ${fieldValue.type},\n`;
+        });
+      }
+
+      structsString += "}\n\n";
+    });
+  }
+
+  return structsString;
+};
+
+const unionsOutput = (unions: any) => {
+  let unionsString = "";
+
+  if (unions && typeof unions === "object" && Object.keys(unions).length) {
+    unionsString += `// ==========================================\n`;
+    unionsString += `// Unions\n`;
+    unionsString += `// ==========================================\n\n`;
+
+    Object.entries(unions).forEach((unionItem) => {
+      const key = unionItem[0];
+      const value = unionItem[1] as any;
+
+      unionsString += `#[contracttype]\n`;
+      unionsString += `enum ${key} {\n`;
+
+      if (
+        value.cases &&
+        typeof value.cases === "object" &&
+        Object.keys(value.cases).length
+      ) {
+        Object.entries(value.cases).forEach((caseItem) => {
+          const caseKey = caseItem[0];
+          const caseValue = caseItem[1] as any;
+
+          unionsString += `${TAB}${caseKey}(${caseValue?.length ? caseValue.join(",") : ""}),\n`;
+        });
+      }
+
+      unionsString += "}\n\n";
+    });
+  }
+
+  return unionsString;
+};
+
+const errorsOutput = (errors: any) => {
+  let errorsString = "";
+
+  if (errors && typeof errors === "object" && Object.keys(errors).length) {
+    errorsString += `// ==========================================\n`;
+    errorsString += `// Errors\n`;
+    errorsString += `// ==========================================\n\n`;
+
+    errorsString += `#[contracttype]\n`;
+    errorsString += `enum Errors {\n`;
+
+    Object.entries(errors).forEach((errorItem) => {
+      const key = errorItem[0];
+      const value = errorItem[1] as any;
+
+      errorsString += `${TAB}${key} = ${value?.value ?? ""},\n`;
+    });
+
+    errorsString += "}\n\n";
+  }
+
+  return errorsString;
+};
+
+const formatFnInputs = (inputs: any) => {
+  if (!inputs) {
+    return "";
+  }
+
+  return Object.entries(inputs)
+    .map(([key, value]) => {
+      return `${key}: ${(value as any).type}`;
+    })
+    .join(", ");
+};
+
+const formatFnOutputs = (outputs: any) => {
+  const outputType = outputs?.[0];
+
+  return outputType ? `-> ${outputType}` : "";
+};

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,1 @@
+declare module "@stellar-expert/contract-wasm-interface-parser";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,6 +3044,11 @@
     "@stablelib/random" "^1.0.2"
     "@stablelib/wipe" "^1.0.1"
 
+"@stellar-expert/contract-wasm-interface-parser@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@stellar-expert/contract-wasm-interface-parser/-/contract-wasm-interface-parser-3.2.0.tgz#5f60b564f1f8b35560a724f9afe769a9f6065de8"
+  integrity sha512-Y83a6mG0Bj61QJYyzaL0vd5vSL5hTfbilNhDwjRlPZL3KZkWJyypDWPpQyPanUOxVo0RY2Rw59jG1ean2eEMgw==
+
 "@stellar/design-system@^3.1.5":
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@stellar/design-system/-/design-system-3.1.5.tgz#b1b6957b1d1ce384ce3307c0d10ae772ce3c629d"


### PR DESCRIPTION
Display contract spec in a more human-readable format, using StellarExpert as [an example](https://stellar.expert/explorer/public/contract/CA33NXYN7H3EBDSA3U2FPSULGJTTL3FQRHD2ADAAPTKS3FUJOE73735A?filter=interface).

- `CA33NXYN7H3EBDSA3U2FPSULGJTTL3FQRHD2ADAAPTKS3FUJOE73735A` (Mainnet) - with doc comments
- `CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM` (Mainnet) - without doc comments