### PR TITLE
Remove fix the invoke contract function bug on build transaction

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SorobanOperation.tsx
@@ -261,7 +261,7 @@ export const SorobanOperation = ({
             <>{renderSourceAccount(sorobanOperation.operation_type, 0)}</>
           </Box>
 
-          {sorobanOperation.operation_type !== "invoke_contract" && (
+          {sorobanOperation.operation_type !== "invoke_contract_function" && (
             <Box gap="sm" align="start">
               <Button
                 disabled={Boolean(!network.rpcUrl)}


### PR DESCRIPTION
"Prepare Soroban Transaction to Sign" should only appear for `extend_ttl` and `restore_footprint`.

`invoke_contract_function` has its own `prepare transaction` button that handles converting native value to smart contract value.