### PR TITLE
FetchContractMethodPickerWithQuery - use string instead of array for setState

### DIFF
--- a/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
+++ b/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
@@ -43,7 +43,6 @@ export const FetchContractMethodPickerWithQuery = ({
   const queryClient = useQueryClient();
 
   const [contractIdError, setContractIdError] = useState<string>("");
-  const [contractMethods, setContractMethods] = useState<string[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   const [fetchType, setFetchType] = useState<"sac" | "contract" | null>(null);
@@ -100,6 +99,17 @@ export const FetchContractMethodPickerWithQuery = ({
     return invokeContractSpec?.funcs();
   }, [invokeContractSpec]);
 
+  const contractMethods = useMemo(() => {
+    if ((isSacDataSuccess || isContractClientSuccess) && memoizedMethods) {
+      return (
+        memoizedMethods
+          ?.filter((func) => !func.name().toString().includes("__"))
+          ?.map((func) => func.name().toString()) || []
+      );
+    }
+    return [];
+  }, [isSacDataSuccess, isContractClientSuccess, memoizedMethods]);
+
   // Set the fetch type from the contract type
   useEffect(() => {
     if (contractType) {
@@ -119,39 +129,18 @@ export const FetchContractMethodPickerWithQuery = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchType]);
 
-  // Format contract methods and set the error
+  // Set the error
   useEffect(() => {
-    if ((isSacDataSuccess || isContractClientSuccess) && memoizedMethods) {
-      const methodNames = memoizedMethods
-        ?.filter((func) => !func.name().toString().includes("__"))
-        ?.map((func) => func.name().toString());
-
-      // Only update if the methods have actually changed
-      setContractMethods((prev) => {
-        if (JSON.stringify(prev) === JSON.stringify(methodNames)) {
-          return prev;
-        }
-        return methodNames;
-      });
-    }
-
     const errorMsg = contractClientError?.message || sacDataError?.message;
 
     if (errorMsg) {
       setFetchError(errorMsg);
     }
-  }, [
-    isSacDataSuccess,
-    isContractClientSuccess,
-    contractClientError,
-    sacDataError,
-    memoizedMethods,
-  ]);
+  }, [contractClientError, sacDataError]);
 
   const handleContractIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // reset the error and methods
+    // reset the error
     setFetchError("");
-    setContractMethods([]);
 
     // reset queries
     if (contractType) {

--- a/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
+++ b/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
@@ -116,7 +116,8 @@ export const FetchContractMethodPickerWithQuery = ({
     if (fetchType === "contract") {
       fetchContractClient();
     }
-  }, [fetchContractClient, fetchType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchType]);
 
   // Format contract methods and set the error
   useEffect(() => {
@@ -125,7 +126,13 @@ export const FetchContractMethodPickerWithQuery = ({
         ?.filter((func) => !func.name().toString().includes("__"))
         ?.map((func) => func.name().toString());
 
-      setContractMethods(methodNames);
+      // Only update if the methods have actually changed
+      setContractMethods((prev) => {
+        if (JSON.stringify(prev) === JSON.stringify(methodNames)) {
+          return prev;
+        }
+        return methodNames;
+      });
     }
 
     const errorMsg = contractClientError?.message || sacDataError?.message;


### PR DESCRIPTION
I noticed the endless loop for selecting methods on smart contract's invoke contract function on build transaction. This is caused by `setState` using an array. I think the latest nextjs update may have stricter re-render behavior and made this more noticeable which is good.