### PR TITLE
Float notification auto close

### DIFF
--- a/src/components/FloatNotification/index.tsx
+++ b/src/components/FloatNotification/index.tsx
@@ -13,6 +13,7 @@ export type FloatNotificationItem = {
     label: string;
     onAction: () => void;
   }[];
+  closeAt?: number;
 };
 
 type FloatNotificationProps = {

--- a/src/components/layout/LayoutMain.tsx
+++ b/src/components/layout/LayoutMain.tsx
@@ -21,6 +21,34 @@ export const LayoutMain = ({ children }: { children: ReactNode }) => {
     initTracking();
   }, []);
 
+  // Handle auto closing float notifications
+  useEffect(() => {
+    if (floatNotifications.length === 0) {
+      return;
+    }
+
+    // No need to check if there are no auto closing notifications
+    const hasAutoCloseNotifications = floatNotifications.some(
+      (notification) => notification.closeAt,
+    );
+
+    if (!hasAutoCloseNotifications) {
+      return;
+    }
+
+    // Check every 100ms for expired notifications
+    const interval = setInterval(() => {
+      const now = Date.now();
+      floatNotifications.forEach((notification) => {
+        if (notification.closeAt && now >= notification.closeAt) {
+          removeFloatNotification(notification.id);
+        }
+      });
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, [floatNotifications, removeFloatNotification]);
+
   return (
     <div className="LabLayout">
       <div className="LabLayout__header">


### PR DESCRIPTION
Setting a "close at" time on every notification is a performant way to handle auto-closing. It won't cause any extra re-renders, because the store doesn't change when we check notification data.

We set an expiration date on every notification for flexibility. We could have used a flag and set the same duration for all, but this approach will be harder to customize later if we need it.

Usage

```typescript
const { addFloatNotification } = useStore();

addFloatNotification({
  id,
  title,
  description,
  type: "success",
  // Close after 3 seconds
  closeAt: Date.now() + 3000,
});
```