### PR TITLE
fix deploy wasm's stellar expert link to use contract one

### DIFF
--- a/src/app/(sidebar)/smart-contracts/deploy-contract/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/deploy-contract/page.tsx
@@ -45,7 +45,7 @@ import { delayedAction } from "@/helpers/delayedAction";
 import { dereferenceSchema } from "@/helpers/dereferenceSchema";
 import { getScValsFromArgs } from "@/helpers/sorobanUtils";
 import { stellarExpertTransactionLink } from "@/helpers/stellarExpertTransactionLink";
-import { stellarExpertAccountLink } from "@/helpers/stellarExpertAccountLink";
+import { stellarExpertContractLink } from "@/helpers/stellarExpertContractLink";
 import { isEmptyObject } from "@/helpers/isEmptyObject";
 
 import { NetworkType } from "@/types/types";
@@ -512,7 +512,7 @@ export default function DeployContract() {
   const renderContractIdExternalLink = () => {
     const contractId = getContractId();
     return contractId ? (
-      <SdsLink href={stellarExpertAccountLink(contractId, network.id)}>
+      <SdsLink href={stellarExpertContractLink(contractId, network.id)}>
         {contractId || ""}
         <Icon.LinkExternal01 />
       </SdsLink>

--- a/src/helpers/stellarExpertContractLink.ts
+++ b/src/helpers/stellarExpertContractLink.ts
@@ -1,0 +1,16 @@
+import { STELLAR_EXPERT } from "@/constants/settings";
+import { NetworkType } from "@/types/types";
+
+export const stellarExpertContractLink = (
+  contractId: string,
+  networkId: NetworkType,
+) => {
+  // Not supported networks
+  if (["futurenet", "custom"].includes(networkId)) {
+    return "";
+  }
+
+  const network = networkId === "mainnet" ? "public" : "testnet";
+
+  return `${STELLAR_EXPERT}/${network}/contract/${contractId}`;
+};


### PR DESCRIPTION
while I was debugging #1676, I noticed that stellar expert link upon the successful deployment was linked to SE's `/account` instead of `/contract`.  

https://stellar.expert/explorer/testnet/account/CDO5PBAI6SHHZI4KJH3DJBJGUJFGNHGH63KU6BYGSI2ZUJP2FHQTKRR5

This fixes it to use `/contract` url instead of `/account`

<img width="500" height="152" alt="contract-wasm" src="https://github.com/user-attachments/assets/bf71ab30-6c39-4387-bac9-83c07435a1b6" />
