### PR TITLE
Transaction Events: fix failed event crash

### DIFF
--- a/src/app/(sidebar)/transaction-dashboard/components/Events.tsx
+++ b/src/app/(sidebar)/transaction-dashboard/components/Events.tsx
@@ -24,8 +24,8 @@ export const Events = ({
 }: {
   txEvents:
     | {
-        contractEventsJson: RpcTxJsonResponseContractEventsJson;
-        transactionEventsJson: RpcTxJsonResponseTransactionEventsJson;
+        contractEventsJson?: RpcTxJsonResponseContractEventsJson;
+        transactionEventsJson?: RpcTxJsonResponseTransactionEventsJson;
       }
     | undefined;
 }) => {
@@ -33,7 +33,7 @@ export const Events = ({
 
   const events = txEvents
     ? formatTxEvents({
-        contractEvents: txEvents.contractEventsJson[0],
+        contractEvents: txEvents.contractEventsJson?.[0],
         transactionEvents: txEvents.transactionEventsJson,
       })
     : null;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -567,8 +567,8 @@ export type RpcTxJsonResponse = {
   applicationOrder: number;
   createdAt: string;
   events?: {
-    contractEventsJson: RpcTxJsonResponseContractEventsJson;
-    transactionEventsJson: RpcTxJsonResponseTransactionEventsJson;
+    contractEventsJson?: RpcTxJsonResponseContractEventsJson;
+    transactionEventsJson?: RpcTxJsonResponseTransactionEventsJson;
   };
   feeBump: boolean;
   ledger: number;


### PR DESCRIPTION
`contractEventsJson` is not returned in the response for failed transactions.