### PR TITLE
remove 'headless' variant from CopyText

### DIFF
--- a/src/components/WalletKit/ConnectedModal.tsx
+++ b/src/components/WalletKit/ConnectedModal.tsx
@@ -43,7 +43,7 @@ export const ConnectedModal = ({
         </Box>
       </Modal.Body>
       <Modal.Footer itemAlignment="stack">
-        <CopyText textToCopy={publicKey} variant="headless">
+        <CopyText textToCopy={publicKey}>
           <Button
             isFullWidth
             size="md"

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -40,6 +40,14 @@
       height: fit-content;
     }
   }
+
+  .ModalFooter {
+    &--stack {
+      .CopyText__content {
+        width: 100%;
+      }
+    }
+  }
 }
 
 .LabLayout {


### PR DESCRIPTION
- removing `variant="headless"` resolved unable to copy text issue
- the error it was receiving was:

> `Invalid prop `onClick` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.`