### PR TITLE
getLedgerEntries: Add new additional setting fields

### DIFF
--- a/src/components/FormElements/ConfigSettingIdPicker.tsx
+++ b/src/components/FormElements/ConfigSettingIdPicker.tsx
@@ -68,12 +68,24 @@ export const ConfigSettingIdPicker = ({
       label: "Config Setting Contract Execution Lanes",
     },
     {
-      id: "bucketlist_size_window",
-      label: "Config Setting Bucketlist Size Window",
+      id: "live_soroban_state_size_window",
+      label: "Config Setting Live Soroban State Size Window",
     },
     {
       id: "eviction_iterator",
       label: "Config Setting Eviction Iterator",
+    },
+    {
+      id: "contract_parallel_compute_v0",
+      label: "Config Setting Contract Parallel Compute v0",
+    },
+    {
+      id: "contract_ledger_cost_ext_v0",
+      label: "Config Setting Contract Ledger Cost Ext v0",
+    },
+    {
+      id: "scp_timing",
+      label: "Config Setting SCP Timing",
     },
   ];
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -358,8 +358,11 @@ export type ConfigSettingIdType =
   | "contract_data_entry_size_bytes"
   | "state_archival"
   | "contract_execution_lanes"
-  | "bucketlist_size_window"
-  | "eviction_iterator";
+  | "live_soroban_state_size_window"
+  | "eviction_iterator"
+  | "contract_parallel_compute_v0"
+  | "contract_ledger_cost_ext_v0"
+  | "scp_timing";
 
 export type XdrFormatType = "json" | "base64";
 


### PR DESCRIPTION
Adding the additional config settings that got added later (https://github.com/stellar/stellar-xdr/blob/curr/Stellar-contract-config-setting.x#L350:L369)

```
CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES = 0,
CONFIG_SETTING_CONTRACT_COMPUTE_V0 = 1,
CONFIG_SETTING_CONTRACT_LEDGER_COST_V0 = 2,
CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0 = 3,
CONFIG_SETTING_CONTRACT_EVENTS_V0 = 4,
CONFIG_SETTING_CONTRACT_BANDWIDTH_V0 = 5,
CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS = 6,
CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES = 7,
CONFIG_SETTING_CONTRACT_DATA_KEY_SIZE_BYTES = 8,
CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES = 9,
CONFIG_SETTING_STATE_ARCHIVAL = 10,
CONFIG_SETTING_CONTRACT_EXECUTION_LANES = 11,
CONFIG_SETTING_LIVE_SOROBAN_STATE_SIZE_WINDOW = 12,
CONFIG_SETTING_EVICTION_ITERATOR = 13,
CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0 = 14,
CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0 = 15,
CONFIG_SETTING_SCP_TIMING = 16
```