### PR TITLE
Enable fetching a new contract's methods after the first call

### DIFF
--- a/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
+++ b/src/components/FormElements/FetchContractMethodPickerWithQuery.tsx
@@ -150,13 +150,9 @@ export const FetchContractMethodPickerWithQuery = ({
     setFetchType(null);
 
     // reset queries
-    queryClient.resetQueries({
-      queryKey: [
-        "useGetContractTypeFromRpcById",
-        "useClientFromRpc",
-        "useGitHubFile",
-      ],
-    });
+    queryClient.resetQueries({ queryKey: ["useGetContractDataFromRpcById"] });
+    queryClient.resetQueries({ queryKey: ["useClientFromRpc"] });
+    queryClient.resetQueries({ queryKey: ["useGitHubFile"] });
 
     // validate the contract id
     if (e.target.value) {


### PR DESCRIPTION
When you enter a contract id and fetch, then replace the old contract id with a new one, the new one's function methods aren't populating. This fixes this bug.