### PR TITLE
Update `skills/component-guide/SKILL.md` and add `skills/react-rerender-mental-models`

### DIFF
--- a/.claude/skills/component-guide/SKILL.md
+++ b/.claude/skills/component-guide/SKILL.md
@@ -102,7 +102,9 @@ export const ComponentName = ({ propName }: ComponentNameProps) => {
 ### Do
 - Use design system components for all standard UI elements
 - Use SCSS with BEM-ish class naming (`ComponentName__element--modifier`)
-- Use `pxToRem()` for spacing values in SCSS
+- Use `pxToRem()` for spacing values in SCSS (skip for trivial values like
+  `1px` or `-1px` — e.g., borders, outlines, offsets — where rem scaling is
+  not meaningful)
 - Use SDS CSS custom properties for colors/fonts/gaps: `var(--sds-clr-gray-06)`,
   `var(--sds-ff-monospace)`, `var(--sds-gap-md)`
 - Use `data-*` attributes for state-driven styling instead of modifier classes:

--- a/.claude/skills/react-rerender-mental-models/SKILL.md
+++ b/.claude/skills/react-rerender-mental-models/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: react-rerender-mental-models
+description: Correct mental models for React re-renders and memoization. Use this skill when writing, reviewing, or optimizing React components to avoid common misconceptions about performance. Debunks the myth that "props cause re-renders" and teaches when memoization actually helps.
+license: MIT
+metadata:
+  author: freighter
+  version: "1.0.0"
+---
+
+# React Re-render Mental Models
+
+A practical guide to understanding how React re-renders actually work, debunking common misconceptions, and knowing when optimization is truly needed.
+
+## Core Philosophy
+
+> "Trust React to be fast. Write simple code. Measure when something actually feels slow. Optimize based on data, not fear."
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new React components
+- Reviewing code for performance issues
+- Deciding whether to add React.memo, useCallback, or useMemo
+- Debugging perceived "slowness" in React apps
+- Refactoring component architecture
+
+## Rule Categories
+
+| Category | Prefix | Description |
+|----------|--------|-------------|
+| Mental Models | `mental-model-` | Correct understanding of how React works |
+| Anti-Patterns | `anti-pattern-` | Common mistakes to avoid |
+| When to Memoize | `when-to-memo-` | Profile-driven optimization guidance |
+| Architecture | `architecture-` | Component structure patterns |
+
+## Quick Reference
+
+### Mental Models (Foundational)
+
+- `mental-model-parent-triggers` - Props don't trigger re-renders; parent re-renders do
+- `mental-model-render-vs-commit` - Render ≠ Commit; renders are cheap, commits touch DOM
+
+### Anti-Patterns (Avoid These)
+
+- `anti-pattern-premature-memo` - Don't memoize without profiling first
+- `anti-pattern-memoization-trap` - Real bottlenecks are often not re-renders
+
+### When to Memoize (Use Sparingly)
+
+- `when-to-memo-context-values` - Stabilize context object references
+- `when-to-usecallback` - Only needed when child is already memoized
+
+### Architecture (Prefer These)
+
+- `architecture-local-state` - Keep state close to where it's used
+- `architecture-composition` - Component structure prevents re-renders naturally
+
+## What Actually Triggers Re-renders
+
+1. **Component's own state changes** (useState, useReducer)
+2. **Parent component re-renders** (cascades to all children)
+3. **Context value changes** (for consumers of that context)
+
+**Props are NOT on this list.** Props are inputs to a render that's already happening—they don't schedule one.
+
+## The Performance Debugging Flow
+
+```
+1. Something feels slow
+2. Open React DevTools Profiler
+3. Record the interaction
+4. Look for components with 50ms+ render times
+5. If found → consider memoization
+6. If not found → the problem is elsewhere:
+   - API calls firing too often
+   - Unoptimized images
+   - Too many DOM nodes
+   - CSS animations triggering layout
+```
+
+## React 19 Compiler
+
+This project runs React 19. The **React Compiler** (formerly React Forget) is
+an opt-in build-time tool that statically analyzes components and automatically
+inserts the equivalent of `useMemo`, `useCallback`, and `React.memo`. It is
+**not enabled by default** — it requires `babel-plugin-react-compiler` (or the
+SWC equivalent) to be installed and configured.
+
+- If the compiler is **enabled in this project**: skip manual memoization. The
+  compiler tracks data flow within each component and caches results at a more
+  granular level than hand-written hooks. If the compiler opts out a specific
+  component (e.g. due to side effects during render), fix the component rather
+  than adding manual memo.
+- If the compiler is **not enabled** (current default): follow the rules below,
+  but prefer architecture fixes (local state, composition) over adding
+  memo/useCallback.
+
+Regardless of compiler status, the mental models and architecture rules in this
+skill still apply — composition and local state are always better than relying
+on memoization (auto or manual). Re-render triggers remain the same either way.
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/mental-model-parent-triggers.md
+rules/anti-pattern-premature-memo.md
+rules/architecture-local-state.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation

--- a/.claude/skills/react-rerender-mental-models/rules/anti-pattern-memoization-trap.md
+++ b/.claude/skills/react-rerender-mental-models/rules/anti-pattern-memoization-trap.md
@@ -1,0 +1,78 @@
+---
+title: The Memoization Trap
+impact: HIGH
+impactDescription: identifies real performance bottlenecks
+tags: anti-pattern, debugging, bottlenecks, profiling
+---
+
+## The Memoization Trap
+
+You see slowness, assume it's re-renders, add memoization, feel productive—meanwhile the real issue is something else entirely.
+
+### Real-World Example
+
+A search input feels laggy. Every keystroke has a noticeable delay.
+
+```tsx
+// The "obvious" fix that doesn't work
+const ProductList = () => {
+  const [search, setSearch] = useState("");
+  const [products, setProducts] = useState([]);
+
+  // ❌ Added useMemo - still laggy
+  const filteredProducts = useMemo(
+    () => products.filter((p) =>
+      p.name.toLowerCase().includes(search.toLowerCase())
+    ),
+    [products, search]
+  );
+
+  // ❌ Added useCallback - still laggy
+  const handleChange = useCallback((value) => {
+    setSearch(value);
+  }, []);
+
+  return (
+    <>
+      <SearchInput value={search} onChange={handleChange} />
+      {filteredProducts.map((product) => (
+        <MemoizedProductCard key={product.id} product={product} />
+      ))}
+    </>
+  );
+};
+```
+
+### The Actual Problem
+
+After profiling:
+- The `.filter()` call: ~0.3ms on 200 products
+- Re-rendering ProductCards: ~8ms total
+- **A useEffect hitting analytics API on every keystroke: 200ms+ blocking**
+
+```tsx
+// ✅ The real fix
+useEffect(() => {
+  // Debounce the analytics call
+  const timer = setTimeout(() => {
+    analytics.track("search", { query: search });
+  }, 300);
+  return () => clearTimeout(timer);
+}, [search]);
+```
+
+### Common Real Bottlenecks (Not Re-renders)
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| Laggy input | API calls on every keystroke | Debounce |
+| Slow initial load | Large unoptimized images | Lazy load, compress |
+| Scroll jank | Too many DOM nodes (1000+) | Virtualization |
+| Animation stutter | CSS triggering layout recalc | Use transform/opacity only |
+| Memory issues | Event listeners not cleaned up | Proper useEffect cleanup |
+
+### Key Takeaway
+
+If the React DevTools Profiler shows render times under 16ms, re-renders aren't
+the problem — look at network calls, DOM node count, and CSS layout thrashing
+instead.

--- a/.claude/skills/react-rerender-mental-models/rules/anti-pattern-premature-memo.md
+++ b/.claude/skills/react-rerender-mental-models/rules/anti-pattern-premature-memo.md
@@ -1,0 +1,78 @@
+---
+title: Don't Memoize Without Profiling
+impact: HIGH
+impactDescription: prevents unnecessary complexity
+tags: anti-pattern, memo, useCallback, useMemo, profiling
+---
+
+## Don't Memoize Without Profiling
+
+Adding `React.memo`, `useCallback`, and `useMemo` without profiling first is premature optimization. For cheap components (most of them), the memo check itself costs more than just re-rendering.
+
+### The Problem
+
+```tsx
+// ❌ Incorrect: Memoizing without knowing if it helps
+const ProductCard = React.memo(({ product, onSelect }) => {
+  return (
+    <div onClick={() => onSelect(product.id)}>
+      <h3>{product.name}</h3>
+      <p>${product.price}</p>
+    </div>
+  );
+});
+
+const ProductList = ({ products }) => {
+  // ❌ useCallback "just in case"
+  const handleSelect = useCallback((id) => {
+    console.log("Selected:", id);
+  }, []);
+
+  return products.map((p) => (
+    <ProductCard key={p.id} product={p} onSelect={handleSelect} />
+  ));
+};
+```
+
+This adds complexity with no proven benefit. The memo check happens every render, comparing props that probably haven't changed.
+
+### The Correct Approach
+
+**Step 1: Write simple code first**
+
+```tsx
+// ✅ Correct: Simple, readable, no premature optimization
+const ProductCard = ({ product, onSelect }) => {
+  return (
+    <div onClick={() => onSelect(product.id)}>
+      <h3>{product.name}</h3>
+      <p>${product.price}</p>
+    </div>
+  );
+};
+
+const ProductList = ({ products }) => {
+  const handleSelect = (id) => {
+    console.log("Selected:", id);
+  };
+
+  return products.map((p) => (
+    <ProductCard key={p.id} product={p} onSelect={handleSelect} />
+  ));
+};
+```
+
+**Step 2: Profile when something feels slow** — only add memoization for
+components with **50ms+ render times** that re-render frequently with unchanged
+props.
+
+### The Real Cost of Premature Memoization
+
+- **Cognitive overhead**: More code to read and maintain
+- **Hidden bugs**: Stale closures from incorrect dependency arrays
+- **False confidence**: "I optimized it" when the real issue is elsewhere
+- **Memo overhead**: The comparison check runs every render
+
+> **Note:** If the React Compiler is enabled, it handles memoization
+> automatically — manual `memo`/`useMemo`/`useCallback` becomes unnecessary for
+> most components.

--- a/.claude/skills/react-rerender-mental-models/rules/architecture-composition.md
+++ b/.claude/skills/react-rerender-mental-models/rules/architecture-composition.md
@@ -1,0 +1,129 @@
+---
+title: Composition Over Optimization
+impact: HIGH
+impactDescription: prevents re-renders through structure
+tags: architecture, composition, children, structure
+---
+
+## Composition Over Optimization
+
+Good component structure prevents re-renders naturally—no `memo`, `useCallback`, or `useMemo` required. Reach for architecture changes before optimization hooks.
+
+### The Pattern: Children Prop
+
+```tsx
+// ❌ Problem: ExpensiveComponent re-renders on every scroll
+const ScrollTracker = () => {
+  const [scrollY, setScrollY] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => setScrollY(window.scrollY);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div>
+      <ScrollIndicator position={scrollY} />
+      <ExpensiveComponent /> {/* Re-renders on every scroll! */}
+    </div>
+  );
+};
+```
+
+### The Fix: Extract State, Pass Children
+
+```tsx
+// ✅ Solution: ExpensiveComponent doesn't re-render
+const ScrollTracker = ({ children }) => {
+  const [scrollY, setScrollY] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => setScrollY(window.scrollY);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div>
+      <ScrollIndicator position={scrollY} />
+      {children}
+    </div>
+  );
+};
+
+// Usage
+const App = () => {
+  return (
+    <ScrollTracker>
+      <ExpensiveComponent /> {/* Created by App, not ScrollTracker */}
+    </ScrollTracker>
+  );
+};
+```
+
+**Why this works:** `ExpensiveComponent` is created by `App`, not `ScrollTracker`. When `ScrollTracker` re-renders due to scroll, `children` is the same React element reference—no re-render needed.
+
+### Another Pattern: Extracting Changing State
+
+```tsx
+// ❌ Problem: Entire form re-renders on mouse move
+const Form = () => {
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+  const [formData, setFormData] = useState({});
+
+  return (
+    <div onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}>
+      <Cursor position={mousePos} />
+      <ExpensiveFormFields data={formData} onChange={setFormData} />
+    </div>
+  );
+};
+```
+
+```tsx
+// ✅ Solution: Extract the changing state into its own component
+const MouseTracker = ({ children }) => {
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+
+  return (
+    <div onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}>
+      <Cursor position={mousePos} />
+      {children}
+    </div>
+  );
+};
+
+const Form = () => {
+  const [formData, setFormData] = useState({});
+
+  return (
+    <MouseTracker>
+      <ExpensiveFormFields data={formData} onChange={setFormData} />
+    </MouseTracker>
+  );
+};
+```
+
+### When to Use This Pattern
+
+- Frequently changing state (scroll, mouse, timers)
+- State that only affects part of the UI
+- Expensive children that don't depend on that state
+
+### The Hierarchy of Solutions
+
+```
+1. First: Can I restructure components to avoid the problem?
+   └─ Move state down, use children prop, split components
+
+2. Second: Is there an architectural issue?
+   └─ State lifted too high, unnecessary context usage
+
+3. Last resort: Add memoization
+   └─ Only after profiling confirms it's needed
+```
+
+### Key Insight
+
+> "Most React apps don't have re-render problems. They have architecture problems. State lifted way too high, components that do ten different things. Fix the architecture first."

--- a/.claude/skills/react-rerender-mental-models/rules/architecture-local-state.md
+++ b/.claude/skills/react-rerender-mental-models/rules/architecture-local-state.md
@@ -1,0 +1,113 @@
+---
+title: Keep State Local
+impact: HIGH
+impactDescription: prevents unnecessary re-renders structurally
+tags: architecture, state, composition, local-state
+---
+
+## Keep State Local
+
+State should live as close as possible to where it's used. When state lives too high in the tree, every state change re-renders everything below—even components that don't use that state.
+
+### The Problem: Lifted State
+
+```tsx
+// ❌ Incorrect: All state at the top
+const Dashboard = () => {
+  const [search, setSearch] = useState("");
+  const [filters, setFilters] = useState({});
+  const [sort, setSort] = useState("name");
+  const [data, setData] = useState([]);
+
+  // Every state change re-renders EVERYTHING below
+  return (
+    <>
+      <SearchBar value={search} onChange={setSearch} />
+      <FilterPanel filters={filters} onChange={setFilters} />
+      <SortDropdown value={sort} onChange={setSort} />
+      <DataTable data={data} />
+      <Summary data={data} />
+      <Charts data={data} />
+    </>
+  );
+};
+```
+
+When the user types in the search box:
+1. `search` state changes
+2. `Dashboard` re-renders
+3. `FilterPanel`, `SortDropdown`, `DataTable`, `Summary`, `Charts` all re-render
+4. None of them needed to!
+
+### The Solution: Local State
+
+```tsx
+// ✅ Correct: State lives where it's used
+const Dashboard = () => {
+  // Only shared state lives here
+  const [data, setData] = useState([]);
+
+  return (
+    <>
+      <SearchSection onSearch={(query) => fetchData(query)} />
+      <FilterSection />
+      <SortSection />
+      <DataTable data={data} />
+      <Summary data={data} />
+      <Charts data={data} />
+    </>
+  );
+};
+
+const SearchSection = ({ onSearch }) => {
+  const [search, setSearch] = useState("");
+  
+  // Search changes only affect THIS component
+  // DataTable, Summary, Charts don't even know it happened
+  const handleChange = (value) => {
+    setSearch(value);
+    onSearch(value);
+  };
+
+  return <SearchBar value={search} onChange={handleChange} />;
+};
+
+const FilterSection = () => {
+  const [filters, setFilters] = useState({});
+  // Filter state is local - other sections don't re-render
+  return <FilterPanel filters={filters} onChange={setFilters} />;
+};
+
+const SortSection = () => {
+  const [sort, setSort] = useState("name");
+  // Sort state is local
+  return <SortDropdown value={sort} onChange={setSort} />;
+};
+```
+
+### The Result
+
+When user types in search:
+1. `search` state changes in `SearchSection`
+2. Only `SearchSection` re-renders
+3. `FilterSection`, `SortSection`, `DataTable`, etc. are untouched
+
+**No memo needed.** This is composition—React's been pushing this pattern forever.
+
+### Rule of Thumb
+
+Ask: "Does this state need to be shared?"
+
+| If... | Then... |
+|-------|---------|
+| Only one component reads the state | Keep it local in that component |
+| Multiple siblings need it | Lift to nearest common parent |
+| Many distant components need it | Consider Context |
+| "It might be needed somewhere" | Keep it local until it actually is |
+
+### Why This Works Better Than Memoization
+
+- **Zero overhead**: No memo checks running every render
+- **Clearer code**: State lives next to the UI it controls
+- **Easier debugging**: State changes are localized
+- **Natural boundaries**: Components are more self-contained

--- a/.claude/skills/react-rerender-mental-models/rules/mental-model-parent-triggers.md
+++ b/.claude/skills/react-rerender-mental-models/rules/mental-model-parent-triggers.md
@@ -1,0 +1,66 @@
+---
+title: Props Don't Trigger Re-renders
+impact: FOUNDATIONAL
+impactDescription: corrects fundamental misconception
+tags: mental-model, re-renders, props, parent
+---
+
+## Props Don't Trigger Re-renders
+
+When a parent component re-renders, React automatically re-renders all its children. Props have nothing to do with the trigger—they're just values that get passed down during a render that's already happening.
+
+### What Actually Triggers Re-renders
+
+1. Component's own state changes
+2. Parent component re-renders
+3. Context value changes
+
+Props are inputs to a render, not triggers of one.
+
+### The Proof
+
+**This child re-renders every time, even though props never change:**
+
+```tsx
+const Child = ({ count }) => {
+  console.log("Child rendered");
+  return <div>Count: {count}</div>;
+};
+
+const Parent = () => {
+  const [parentCount, setParentCount] = useState(0);
+  const childCount = 5; // Never changes
+
+  return (
+    <>
+      <button onClick={() => setParentCount((c) => c + 1)}>
+        Clicked {parentCount} times
+      </button>
+      <Child count={childCount} />
+    </>
+  );
+};
+```
+
+Click the button—Child logs every time. The prop `count` is always `5`, yet Child re-renders because Parent re-renders.
+
+### What's Happening Under the Hood
+
+1. Parent's state changes (`parentCount` updates)
+2. React calls `Parent()` function
+3. Parent returns new JSX
+4. React sees `<Child count={5} />` in the JSX
+5. React calls `Child()` function ← **This is the re-render**
+6. Child returns its JSX
+7. React compares old vs new output, updates DOM if needed
+
+Steps 1-6 happen every time. The component function runs, JSX gets created, new React elements are built.
+
+### Why This Matters
+
+The "props cause re-renders" mental model leads to defensive programming:
+- Wrapping everything in `React.memo` "just in case"
+- Using `useCallback` everywhere because some article said to
+- Code becomes harder to read without actual performance benefit
+
+**Correct mental model:** Trust React to be fast. Optimize based on profiler data, not fear.

--- a/.claude/skills/react-rerender-mental-models/rules/mental-model-render-vs-commit.md
+++ b/.claude/skills/react-rerender-mental-models/rules/mental-model-render-vs-commit.md
@@ -1,0 +1,50 @@
+---
+title: Render vs Commit
+impact: FOUNDATIONAL
+impactDescription: clarifies what "render" actually means
+tags: mental-model, render, commit, DOM, performance
+---
+
+## Render vs Commit
+
+A **render** just means React called your component function. A **commit** is when React actually touches the DOM. Many renders result in zero DOM changes—and those are cheap.
+
+### The Two Phases
+
+| Phase | What Happens | Cost |
+|-------|--------------|------|
+| **Render** | React calls your component function, creates new React elements | Cheap (JavaScript execution) |
+| **Commit** | React updates the actual DOM based on what changed | Expensive (DOM manipulation) |
+
+### Why This Matters
+
+React is incredibly efficient at the render phase. Your 50-component tree probably re-renders in under 10ms. That's not your bottleneck.
+
+```tsx
+// This component "renders" but may not "commit" anything
+const Counter = ({ count }) => {
+  // Render phase: this function runs
+  console.log("Rendered");
+  
+  // React compares this output to previous output
+  // If identical, no DOM commit happens
+  return <div>{count}</div>;
+};
+```
+
+### React.memo and the Render Phase
+
+`React.memo` doesn't prevent re-renders entirely—it bails out early during the render phase:
+
+1. Parent re-renders
+2. React starts to render memoized child
+3. Memo check: "Have props changed?"
+4. If no → skip calling component function, reuse previous output
+5. If yes → call component function normally
+
+You're still in the render phase. The parent already re-rendered. The memo check already happened. Memo just prevents *wasted work* in the child.
+
+### Practical Implication
+
+Quick renders that don't touch the DOM are essentially free. Optimize based on
+render *duration*, not render *count*.

--- a/.claude/skills/react-rerender-mental-models/rules/when-to-memo-context-values.md
+++ b/.claude/skills/react-rerender-mental-models/rules/when-to-memo-context-values.md
@@ -1,0 +1,93 @@
+---
+title: Memoize Context Values
+impact: MEDIUM
+impactDescription: prevents unnecessary context consumer re-renders
+tags: when-to-memo, context, useMemo, reference
+---
+
+## Memoize Context Values
+
+When passing objects to Context providers, use `useMemo` to stabilize the reference. Otherwise, every component using that context re-renders on every provider render—even if the actual values didn't change.
+
+### The Problem
+
+```tsx
+// ❌ Incorrect: Creates new object reference every render
+const ThemeContext = createContext();
+
+const App = () => {
+  const [theme, setTheme] = useState("light");
+  const [user, setUser] = useState(null);
+
+  // New object created on EVERY render
+  const value = { theme, setTheme };
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <ExpensiveTree />
+    </ThemeContext.Provider>
+  );
+};
+```
+
+**What happens:**
+1. `user` state changes (nothing to do with theme)
+2. `App` re-renders
+3. New `value` object is created (different reference)
+4. React sees context value "changed" (reference comparison)
+5. **Every component using `useContext(ThemeContext)` re-renders**
+
+### The Solution
+
+```tsx
+// ✅ Correct: Stable object reference with useMemo
+const App = () => {
+  const [theme, setTheme] = useState("light");
+  const [user, setUser] = useState(null);
+
+  // Only creates new object when theme changes
+  const value = useMemo(() => ({ theme, setTheme }), [theme]);
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <ExpensiveTree />
+    </ThemeContext.Provider>
+  );
+};
+```
+
+Now context consumers only re-render when `theme` actually changes, not on every `App` render.
+
+### Alternative: Split Contexts
+
+For contexts with both state and setters, consider splitting:
+
+```tsx
+// ✅ Even better: Separate contexts for state and dispatch
+const ThemeStateContext = createContext();
+const ThemeDispatchContext = createContext();
+
+const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState("light");
+
+  return (
+    <ThemeStateContext.Provider value={theme}>
+      <ThemeDispatchContext.Provider value={setTheme}>
+        {children}
+      </ThemeDispatchContext.Provider>
+    </ThemeStateContext.Provider>
+  );
+};
+
+// Components that only SET theme don't re-render when theme CHANGES
+const ThemeToggle = () => {
+  const setTheme = useContext(ThemeDispatchContext);
+  // ...
+};
+```
+
+### When to Apply
+
+Apply when a context provider is near the root, passes an object value, and
+re-renders for reasons unrelated to that context. Skip for primitive values or
+providers that rarely re-render.

--- a/.claude/skills/react-rerender-mental-models/rules/when-to-usecallback.md
+++ b/.claude/skills/react-rerender-mental-models/rules/when-to-usecallback.md
@@ -1,0 +1,119 @@
+---
+title: useCallback Only With Memoized Children
+impact: MEDIUM
+impactDescription: prevents breaking memoization
+tags: when-to-memo, useCallback, memo, reference
+---
+
+## useCallback Only With Memoized Children
+
+`useCallback` is only useful when passing callbacks to memoized children. If the child isn't wrapped in `React.memo`, `useCallback` does nothing—you're stabilizing a reference that nobody checks.
+
+### The Chain
+
+```
+React.memo on child → requires stable props → requires useCallback for functions
+```
+
+You don't need one without the other.
+
+### Incorrect: useCallback Without Memo
+
+```tsx
+// ❌ useCallback is pointless here
+const Parent = () => {
+  const [count, setCount] = useState(0);
+
+  // This does nothing useful - Child isn't memoized
+  const handleClick = useCallback(() => {
+    console.log("clicked");
+  }, []);
+
+  return (
+    <>
+      <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
+      <Child onClick={handleClick} />
+    </>
+  );
+};
+
+const Child = ({ onClick }) => {
+  return <button onClick={onClick}>Click me</button>;
+};
+```
+
+`Child` re-renders every time `Parent` re-renders—`useCallback` didn't help.
+
+### Incorrect: Memo Without useCallback
+
+```tsx
+// ❌ Memoization is broken by new function reference
+const MemoizedChild = React.memo(({ onClick }) => {
+  console.log("Child rendered");
+  return <button onClick={onClick}>Click me</button>;
+});
+
+const Parent = () => {
+  const [count, setCount] = useState(0);
+
+  // New function created every render - breaks memo
+  const handleClick = () => {
+    console.log("clicked");
+  };
+
+  return (
+    <>
+      <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
+      <MemoizedChild onClick={handleClick} />
+    </>
+  );
+};
+```
+
+`MemoizedChild` re-renders every time because `onClick` is a new reference.
+
+### Correct: Both Together
+
+```tsx
+// ✅ Correct: memo + useCallback work together
+const MemoizedChild = React.memo(({ onClick }) => {
+  console.log("Child rendered");
+  return <button onClick={onClick}>Click me</button>;
+});
+
+const Parent = () => {
+  const [count, setCount] = useState(0);
+
+  // Stable reference - memo check passes
+  const handleClick = useCallback(() => {
+    console.log("clicked");
+  }, []);
+
+  return (
+    <>
+      <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
+      <MemoizedChild onClick={handleClick} />
+    </>
+  );
+};
+```
+
+Now `MemoizedChild` only renders once. The memo check sees stable props and skips re-rendering.
+
+### Decision Flow
+
+```
+Do I need useCallback?
+│
+├─ Is the child wrapped in React.memo?
+│  ├─ No → Don't use useCallback
+│  └─ Yes → Is the child expensive (50ms+ render)?
+│           ├─ No → Consider removing memo instead
+│           └─ Yes → Use useCallback
+```
+
+`useCallback` without `React.memo` on the receiving child does nothing — you're
+stabilizing a reference that nobody checks.
+
+> **Note:** If the React Compiler is enabled, it auto-memoizes — skip manual
+> `useCallback` entirely.


### PR DESCRIPTION
- update 'component-guide/SKILL.md' to skip `pxToRem` for trivial values
- added 'react-rerender-mental-models/` also used by freighter team