### PR TITLE
[New TX Flow] Add backward compatibility for old saved transactions and urls; add submitStepContent test

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/Operations.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Operations.tsx
@@ -287,9 +287,10 @@ export const Operations = () => {
 
       setOperationsError([...errors]);
     }
-    // Re-run when operations are externally reset (e.g. "Clear all")
+    // Re-run when operations are externally reset (e.g. "Clear all") or when
+    // the first operation type changes (e.g. legacy URL migration seeding data).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [txnOperations.length, soroban.operation.operation_type]);
+  }, [txnOperations.length, txnOperations[0]?.operation_type, soroban.operation.operation_type]);
 
   // Update operations error when operations change
   useEffect(() => {

--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -5,6 +5,7 @@ import { Card } from "@stellar/design-system";
 import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
 
 import { useTransactionFlow } from "@/hooks/useTransactionFlow";
+import { useLegacyUrlMigration } from "@/hooks/useLegacyUrlMigration";
 
 import { Box } from "@/components/layout/Box";
 import { ValidationResponseCard } from "@/components/ValidationResponseCard";
@@ -38,6 +39,9 @@ export default function BuildTransaction() {
     goToNextStep,
     resetAll,
   } = useBuildFlowStore();
+
+  // Bridge legacy querystring params into the flow store (one-time migration)
+  useLegacyUrlMigration();
 
   // For Classic
   const { params: paramsError, operations: operationsError } = build.error;

--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -1,6 +1,5 @@
 "use client";
-
-import { Card } from "@stellar/design-system";
+import { Alert, Card } from "@stellar/design-system";
 
 import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
 
@@ -41,7 +40,7 @@ export default function BuildTransaction() {
   } = useBuildFlowStore();
 
   // Bridge legacy querystring params into the flow store (one-time migration)
-  useLegacyUrlMigration();
+  const { isLegacyUrl, dismissLegacyAlert } = useLegacyUrlMigration();
 
   // For Classic
   const { params: paramsError, operations: operationsError } = build.error;
@@ -148,9 +147,20 @@ export default function BuildTransaction() {
     <Box gap="md">
       <BuildStepHeader
         heading="Build transaction"
-        onClearAll={resetAll}
+        onClearAll={() => {
+          resetAll();
+          dismissLegacyAlert();
+        }}
         clearAllLinkClassName="resetButton"
       />
+
+      {isLegacyUrl ? (
+        <Alert variant="warning" placement="inline" title="">
+          This transaction was loaded from a legacy URL format that will be
+          removed in a future update. Please save your transaction to preserve
+          it.
+        </Alert>
+      ) : null}
 
       <Card>
         <Params />

--- a/src/app/(sidebar)/transaction/saved/page.tsx
+++ b/src/app/(sidebar)/transaction/saved/page.tsx
@@ -14,19 +14,17 @@ import { PageCard } from "@/components/layout/PageCard";
 import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
 
 import { useStore } from "@/store/useStore";
+import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
 import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
 import { arrayItem } from "@/helpers/arrayItem";
 import { isSorobanOperationType } from "@/helpers/sorobanUtils";
 
-import {
-  TRANSACTION_OPERATIONS,
-  INITIAL_OPERATION,
-} from "@/constants/transactionOperations";
+import { TRANSACTION_OPERATIONS } from "@/constants/transactionOperations";
 import { SavedTransaction, SavedTransactionPage } from "@/types/types";
 import { trackEvent, TrackingEvent } from "@/metrics/tracking";
 
 export default function SavedTransactions() {
-  const { network, transaction, xdr } = useStore();
+  const { network } = useStore();
   const router = useRouter();
 
   const [savedTxns, setSavedTxns] = useState<SavedTransaction[]>([]);
@@ -55,45 +53,38 @@ export default function SavedTransactions() {
     const found = findLocalStorageTx(timestamp);
 
     if (found) {
-      let isSorobanTx = false;
+      const flowStore = useBuildFlowStore.getState();
 
-      // reset both the classic and soroban related states
-      transaction.updateBuildOperations([INITIAL_OPERATION]);
-      transaction.updateBuildXdr("");
-      transaction.updateSorobanBuildOperation(INITIAL_OPERATION);
-      transaction.updateSorobanBuildXdr("");
+      // Reset the flow store to a clean state before populating
+      flowStore.resetAll();
 
       trackEvent(TrackingEvent.TRANSACTION_SAVED_VIEW_BUILDER);
 
-      router.push(Routes.BUILD_TRANSACTION);
-
       if (found.params) {
-        transaction.setBuildParams(found.params);
+        flowStore.setBuildParams(found.params);
       }
 
       if (found.operations) {
-        isSorobanTx = isSorobanOperationType(
+        const isSorobanTx = isSorobanOperationType(
           found?.operations?.[0]?.operation_type,
         );
 
         if (isSorobanTx) {
-          // reset the classic operation
-          transaction.updateBuildOperations([INITIAL_OPERATION]);
-          transaction.updateSorobanBuildOperation(found.operations[0]);
+          flowStore.setBuildSorobanOperation(found.operations[0]);
         } else {
-          // reset the soroban operation
-          transaction.updateSorobanBuildOperation(INITIAL_OPERATION);
-          transaction.updateBuildOperations(found.operations);
+          flowStore.setBuildClassicOperations(found.operations);
+        }
+
+        if (found.xdr) {
+          if (isSorobanTx) {
+            flowStore.setBuildSorobanXdr(found.xdr);
+          } else {
+            flowStore.setBuildClassicXdr(found.xdr);
+          }
         }
       }
 
-      if (found.xdr) {
-        if (isSorobanTx) {
-          transaction.updateSorobanBuildXdr(found.xdr);
-        } else {
-          transaction.updateBuildXdr(found.xdr);
-        }
-      }
+      router.push(Routes.BUILD_TRANSACTION);
     }
   };
 
@@ -101,13 +92,21 @@ export default function SavedTransactions() {
     const found = findLocalStorageTx(timestamp);
 
     if (found) {
+      const flowStore = useBuildFlowStore.getState();
+
       trackEvent(TrackingEvent.TRANSACTION_SAVED_VIEW_SUBMITTER);
 
-      router.push(Routes.SUBMIT_TRANSACTION);
+      // Reset and seed the flow store at the submit step with the signed XDR
+      flowStore.resetAll();
 
       if (found.xdr) {
-        xdr.updateXdrBlob(found.xdr);
+        flowStore.setSignedXdr(found.xdr);
       }
+
+      flowStore.setActiveStep("submit");
+      useBuildFlowStore.setState({ highestCompletedStep: "sign" });
+
+      router.push(Routes.BUILD_TRANSACTION);
     }
   };
 

--- a/src/hooks/useLegacyUrlMigration.ts
+++ b/src/hooks/useLegacyUrlMigration.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+
+import { useStore } from "@/store/useStore";
+import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
+
+/**
+ * One-time migration hook that bridges legacy querystring-persisted transaction
+ * params into the sessionStorage-based flow store.
+ *
+ * Old bookmarked URLs encode build params in the querystring via
+ * zustand-querystring. The build page now reads from the flow store
+ * (sessionStorage). This hook detects legacy params and seeds the flow store
+ * so old URLs continue to work.
+ *
+ * Should be called once in the build page component.
+ */
+export const useLegacyUrlMigration = () => {
+  const { transaction } = useStore();
+
+  // Use primitive values as dependencies so the effect re-fires when the
+  // main store hydrates from the URL querystring.
+  const legacySourceAccount = transaction.build.params.source_account;
+  const legacySorobanOpType =
+    transaction.build.soroban.operation.operation_type;
+  const legacyClassicOpCount = transaction.build.classic.operations.length;
+  const legacyFirstClassicOpType =
+    transaction.build.classic.operations[0]?.operation_type || "";
+
+  useEffect(() => {
+    const legacyParams = transaction.build.params;
+    const legacyClassicOps = transaction.build.classic.operations;
+    const legacySorobanOp = transaction.build.soroban.operation;
+
+    // Check if the legacy store has non-default params from a URL
+    const hasLegacyParams = Boolean(legacyParams.source_account);
+    const hasLegacyClassicOps =
+      legacyClassicOps.length > 0 &&
+      legacyClassicOps.some((op) => Boolean(op.operation_type));
+    const hasLegacySorobanOp = Boolean(legacySorobanOp.operation_type);
+
+    if (!hasLegacyParams && !hasLegacyClassicOps && !hasLegacySorobanOp) {
+      return;
+    }
+
+    const flowStore = useBuildFlowStore.getState();
+
+    // Seed params if the flow store doesn't have them yet
+    if (hasLegacyParams && !flowStore.build.params.source_account) {
+      flowStore.setBuildParams(legacyParams);
+    }
+
+    // Seed operations if the flow store doesn't have them yet
+    const flowHasOps = flowStore.build.classic.operations.some((op) =>
+      Boolean(op.operation_type),
+    );
+    const flowHasSorobanOp = Boolean(
+      flowStore.build.soroban.operation.operation_type,
+    );
+
+    if (hasLegacySorobanOp && !flowHasSorobanOp) {
+      flowStore.setBuildSorobanOperation(legacySorobanOp);
+
+      if (transaction.build.soroban.xdr) {
+        flowStore.setBuildSorobanXdr(transaction.build.soroban.xdr);
+      }
+    } else if (hasLegacyClassicOps && !flowHasOps) {
+      flowStore.setBuildClassicOperations(legacyClassicOps);
+
+      if (transaction.build.classic.xdr) {
+        flowStore.setBuildClassicXdr(transaction.build.classic.xdr);
+      }
+    }
+  }, [
+    legacySourceAccount,
+    legacySorobanOpType,
+    legacyClassicOpCount,
+    legacyFirstClassicOpType,
+    transaction,
+  ]);
+};

--- a/src/hooks/useLegacyUrlMigration.ts
+++ b/src/hooks/useLegacyUrlMigration.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useStore } from "@/store/useStore";
 import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
@@ -12,19 +12,11 @@ import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
  * (sessionStorage). This hook detects legacy params and seeds the flow store
  * so old URLs continue to work.
  *
- * Should be called once in the build page component.
+ * @returns `isLegacyUrl` — true when data was migrated from a legacy URL.
  */
 export const useLegacyUrlMigration = () => {
+  const [isLegacyUrl, setIsLegacyUrl] = useState(false);
   const { transaction } = useStore();
-
-  // Use primitive values as dependencies so the effect re-fires when the
-  // main store hydrates from the URL querystring.
-  const legacySourceAccount = transaction.build.params.source_account;
-  const legacySorobanOpType =
-    transaction.build.soroban.operation.operation_type;
-  const legacyClassicOpCount = transaction.build.classic.operations.length;
-  const legacyFirstClassicOpType =
-    transaction.build.classic.operations[0]?.operation_type || "";
 
   useEffect(() => {
     const legacyParams = transaction.build.params;
@@ -44,9 +36,12 @@ export const useLegacyUrlMigration = () => {
 
     const flowStore = useBuildFlowStore.getState();
 
+    let didMigrate = false;
+
     // Seed params if the flow store doesn't have them yet
     if (hasLegacyParams && !flowStore.build.params.source_account) {
       flowStore.setBuildParams(legacyParams);
+      didMigrate = true;
     }
 
     // Seed operations if the flow store doesn't have them yet
@@ -63,18 +58,22 @@ export const useLegacyUrlMigration = () => {
       if (transaction.build.soroban.xdr) {
         flowStore.setBuildSorobanXdr(transaction.build.soroban.xdr);
       }
+      didMigrate = true;
     } else if (hasLegacyClassicOps && !flowHasOps) {
       flowStore.setBuildClassicOperations(legacyClassicOps);
 
       if (transaction.build.classic.xdr) {
         flowStore.setBuildClassicXdr(transaction.build.classic.xdr);
       }
+      didMigrate = true;
     }
-  }, [
-    legacySourceAccount,
-    legacySorobanOpType,
-    legacyClassicOpCount,
-    legacyFirstClassicOpType,
-    transaction,
-  ]);
+
+    if (didMigrate) {
+      setIsLegacyUrl(true);
+    }
+  }, [transaction]);
+
+  const dismissLegacyAlert = () => setIsLegacyUrl(false);
+
+  return { isLegacyUrl, dismissLegacyAlert };
 };

--- a/tests/e2e/savedTransactions.test.ts
+++ b/tests/e2e/savedTransactions.test.ts
@@ -46,7 +46,7 @@ test.describe("Saved Transactions Page", () => {
       await expect(txItems).toHaveCount(4);
     });
 
-    test.skip("[Classic] Submit item", async () => {
+    test("[Classic] Submit item", async () => {
       const submitItem = pageContext
         .getByTestId("saved-transactions-item")
         .nth(0);
@@ -72,22 +72,17 @@ test.describe("Saved Transactions Page", () => {
 
       await expect(nameInput).toHaveValue(newName);
 
-      // View in submitter
+      // View in submitter — navigates to build flow at submit step
       await submitItem.getByText("View in submitter").click();
-      await pageContext.waitForURL("**/transaction/submit");
+      await pageContext.waitForURL("**/transaction/build");
 
       await expect(pageContext.locator("h1")).toHaveText("Submit transaction");
-      await expect(
-        pageContext.getByLabel("Input a Base64 encoded TransactionEnvelope:"),
-      ).toHaveValue(
-        "AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq/5HGjapWAXjGSkdAkwAAAGQADQioAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAPhdN05mkM4xHi+T01SNgtsaiwQnrlbvzEup1jqlpjEnAAAAAlQL5AAAAAAAAAAAAUpHQJMAAABA689dl2/R1R1w0BjbrBWdUBSPIZF3zKvEN5Q7apo/1cX1azapoKcCd92gLOnqGTkIfAD8SID5okbCcwzFSOjFDA==",
-      );
       await expect(pageContext.getByLabel("Transaction hash")).toHaveValue(
         "510b76e2cb10e73b05eae02628421d832d340bde5c6c013b11f1a598806b4a3a",
       );
     });
 
-    test.skip("Build item", async () => {
+    test("Build item", async () => {
       const buildItem = pageContext
         .getByTestId("saved-transactions-item")
         .nth(1);
@@ -138,7 +133,7 @@ test.describe("Saved Transactions Page", () => {
       );
     });
 
-    test.skip("[Soroban] Submit item", async () => {
+    test("[Soroban] Submit item", async () => {
       await pageContext.waitForSelector(
         '[data-testid="saved-transactions-item"]',
       );
@@ -169,22 +164,17 @@ test.describe("Saved Transactions Page", () => {
 
       await expect(nameInput).toHaveValue(newName);
 
-      // View in submitter
+      // View in submitter — navigates to build flow at submit step
       await submitItem.getByText("View in submitter").click();
-      await pageContext.waitForURL("**/transaction/submit");
+      await pageContext.waitForURL("**/transaction/build");
 
       await expect(pageContext.locator("h1")).toHaveText("Submit transaction");
-      await expect(
-        pageContext.getByLabel("Input a Base64 encoded TransactionEnvelope:"),
-      ).toHaveValue(
-        "AAAAAgAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAtwUABiLjAAAAGQAAAAAAAAAAAAAAAQAAAAAAAAAZAAAAAAAAdTAAAAABAAAAAAAAAAEAAAAGAAAAASD+7zozM+tVyk2uwVRrzhPzYqyzwMsAT1kzEuqEzbYfAAAAEAAAAAEAAAACAAAADwAAAAdDb3VudGVyAAAAABIAAAAAAAAAAH5MvQcuICNqcxGfJ6rKFvwi77h3WDZ2XVzA+LVRkCKDAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2oQAAAAFRkCKDAAAAQANhue2LOei1g9uW8lDfkOIYSkxNBT2MJgA3FXXxVUZXrMMVKMH6or750Xrno+vigxOnIFW8TXlhKjohPFHkOgQ=",
-      );
       await expect(pageContext.getByLabel("Transaction hash")).toHaveValue(
         "77bba537ae20e1011737604224f70215445c23ee5851b42824711c8bc80f527f",
       );
     });
 
-    test.skip("[Soroban] Build item", async () => {
+    test("[Soroban] Build item", async () => {
       const buildItem = pageContext
         .getByTestId("saved-transactions-item")
         .nth(2);
@@ -232,9 +222,6 @@ test.describe("Saved Transactions Page", () => {
         "AAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAE=",
       );
       await expect(pageContext.getByLabel("Extend To")).toHaveValue("30000");
-      await expect(
-        pageContext.getByLabel("Resource Fee (in stroops)"),
-      ).toHaveValue("46753");
     });
 
     test("Delete transaction", async () => {

--- a/tests/e2e/signStepContent.test.ts
+++ b/tests/e2e/signStepContent.test.ts
@@ -99,6 +99,9 @@ test.describe("Sign Step in Build Flow", () => {
   test("Next button is disabled before signing", async ({ page }) => {
     await seedSessionStorageAndNavigate(page);
 
+    // Wait for the sign step to hydrate from sessionStorage
+    await expect(page.locator("h1")).toHaveText("Sign transaction");
+
     const nextButton = page.getByRole("button", {
       name: "Next: Submit transaction",
     });

--- a/tests/e2e/submitStepContent.test.ts
+++ b/tests/e2e/submitStepContent.test.ts
@@ -244,6 +244,7 @@ test.describe("Submit Step in Build Flow", () => {
 
     const submitButton = page.getByRole("button", {
       name: "Submit transaction",
+      exact: true,
     });
     await expect(submitButton).toBeEnabled();
   });
@@ -260,6 +261,7 @@ test.describe("Submit Step in Build Flow", () => {
 
       const submitButton = page.getByRole("button", {
         name: "Submit transaction",
+        exact: true,
       });
       await submitButton.click();
 
@@ -300,6 +302,7 @@ test.describe("Submit Step in Build Flow", () => {
 
       const submitButton = page.getByRole("button", {
         name: "Submit transaction",
+        exact: true,
       });
       await submitButton.click();
 
@@ -328,6 +331,7 @@ test.describe("Submit Step in Build Flow", () => {
 
       const submitButton = page.getByRole("button", {
         name: "Submit transaction",
+        exact: true,
       });
       await submitButton.click();
 
@@ -405,6 +409,7 @@ test.describe("Submit Step in Build Flow", () => {
 
       const submitButton = page.getByRole("button", {
         name: "Submit transaction",
+        exact: true,
       });
       await submitButton.click();
 

--- a/tests/e2e/submitStepContent.test.ts
+++ b/tests/e2e/submitStepContent.test.ts
@@ -1,0 +1,417 @@
+import { baseURL } from "../../playwright.config";
+import { test, expect, Page } from "@playwright/test";
+
+/**
+ * E2E tests for the Submit step in the single-page transaction build flow.
+ *
+ * Seeds sessionStorage with a signed classic transaction so the flow starts
+ * at the submit step. Mocks both RPC (sendTransaction + getTransaction) and
+ * Horizon (/transactions) endpoints for success and error scenarios.
+ */
+
+// A signed classic path payment transaction XDR (testnet)
+const MOCK_SIGNED_CLASSIC_XDR =
+  "AAAAAgAAAAC3gFZiADqJtbRXtDxNmR1jp/oUk2bmGNd+nOl6aFigVQAAAGQADSxdAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAF6GUIkuJfjPW4O0AR9JYo113yjhOgEGUGF3qKs9PuVWAAAAAAAAAAAF9eEAAAAAAAAAAAFoWKBVAAAAQJ0mGItCNQoAcNg9jjvqI+YhEKLu7LCAqKCVn0mzRxlHTQ1NU/73NBUNqGmpm2FxbtphtNDkJEz8jazDzEWikAE=";
+
+const MOCK_TX_CLASSIC_HASH =
+  "4bb833c2016dce5a8bc6026a4148a9f276fa9cbaaab71bc24dcfc0a06670855d";
+
+const MOCK_SIGNED_SOROBAN_XDR =
+  "AAAAAgAAAABehlCJLiX4z1uDtAEfSWKNdd8o4ToBBlBhd6irPT7lVgAq86oAFrXYAAAAFAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABfR984Fi8pqygq69PddL9vXaSLgP7qLlpsaqO5YL+IZsAAAAEc3dhcAAAAAgAAAASAAAAAAAAAAAh5dYXbG+vCChQsGMYfg8k2ABTTz0GHlyHZd1Q+bf9dAAAABIAAAAAAAAAAMwJGsOjTzw4CL/dwI16iaHPIxQi4W5zveD3yDEJrwyeAAAAEgAAAAHXkotywnA8z+r365/0701QSlWouXn8m0UOoshCtNHOYQAAABIAAAABUEXNXsBymnaP1a0CUFhS308Cjc6DDlrFIgm6SEg7LwEAAAAKAAAAAAAAAAAAAAAAAAAACgAAAAoAAAAAAAAAAAAAAAAAAAAyAAAACgAAAAAAAAAAAAAAAAAAAGQAAAAKAAAAAAAAAAAAAAAAAAAABQAAAAIAAAABAAAAAAAAAAAh5dYXbG+vCChQsGMYfg8k2ABTTz0GHlyHZd1Q+bf9dERU62JfV5LrAB1FoAAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACAh5dYXbG+vCChQsGMYfg8k2ABTTz0GHlyHZd1Q+bf9dAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAECwNgi9iY1+KhjA4oyo6TyZQWK7f2maF560McSgfz3rMJNFbzlPIrfS0mZdFmGY0sh5vKohH82IEeWanAXm4kkBAAAAAAAAAAF9H3zgWLymrKCrr0910v29dpIuA/uouWmxqo7lgv4hmwAAAARzd2FwAAAABAAAABIAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAASAAAAAVBFzV7Acpp2j9WtAlBYUt9PAo3Ogw5axSIJukhIOy8BAAAACgAAAAAAAAAAAAAAAAAAAAoAAAAKAAAAAAAAAAAAAAAAAAAAMgAAAAEAAAAAAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAACHl1hdsb68IKFCwYxh+DyTYAFNPPQYeXIdl3VD5t/10AAAAEgAAAAF9H3zgWLymrKCrr0910v29dpIuA/uouWmxqo7lgv4hmwAAAAoAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAAEAAAAAAAAAAMwJGsOjTzw4CL/dwI16iaHPIxQi4W5zveD3yDEJrwyeHIW3ToTRdfoAHUWgAAAAEAAAAAEAAAABAAAAEQAAAAEAAAACAAAADwAAAApwdWJsaWNfa2V5AAAAAAANAAAAIMwJGsOjTzw4CL/dwI16iaHPIxQi4W5zveD3yDEJrwyeAAAADwAAAAlzaWduYXR1cmUAAAAAAAANAAAAQKTzoJg4aSUds0k9jMpMfL1i2PPBftDooVNdZDoY0S+ftF+ZKwfNm/z+WjmV96jkbw3UBDW0BAeNp4vtSKiLfw0AAAAAAAAAAX0ffOBYvKasoKuvT3XS/b12ki4D+6i5abGqjuWC/iGbAAAABHN3YXAAAAAEAAAAEgAAAAFQRc1ewHKado/VrQJQWFLfTwKNzoMOWsUiCbpISDsvAQAAABIAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAAKAAAAAAAAAAAAAAAAAAAAZAAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAABUEXNXsBymnaP1a0CUFhS308Cjc6DDlrFIgm6SEg7LwEAAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAzAkaw6NPPDgIv93AjXqJoc8jFCLhbnO94PfIMQmvDJ4AAAASAAAAAX0ffOBYvKasoKuvT3XS/b12ki4D+6i5abGqjuWC/iGbAAAACgAAAAAAAAAAAAAAAAAAAGQAAAAAAAAAAQAAAAEAAAABAAAACAAAAAQAAAAAAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAABgAAAAFQRc1ewHKado/VrQJQWFLfTwKNzoMOWsUiCbpISDsvAQAAABQAAAABAAAABgAAAAF9H3zgWLymrKCrr0910v29dpIuA/uouWmxqo7lgv4hmwAAABQAAAABAAAABgAAAAHXkotywnA8z+r365/0701QSlWouXn8m0UOoshCtNHOYQAAABQAAAABAAAACQAAAAAAAAAAIeXWF2xvrwgoULBjGH4PJNgAU089Bh5ch2XdUPm3/XQAAAAAAAAAAMwJGsOjTzw4CL/dwI16iaHPIxQi4W5zveD3yDEJrwyeAAAAAQAAAAAh5dYXbG+vCChQsGMYfg8k2ABTTz0GHlyHZd1Q+bf9dAAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAQAAAADMCRrDo088OAi/3cCNeomhzyMUIuFuc73g98gxCa8MngAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAABgAAAAAAAAAAIeXWF2xvrwgoULBjGH4PJNgAU089Bh5ch2XdUPm3/XQAAAAVRFTrYl9XkusAAAAAAAAABgAAAAAAAAAAzAkaw6NPPDgIv93AjXqJoc8jFCLhbnO94PfIMQmvDJ4AAAAVHIW3ToTRdfoAAAAAAAAABgAAAAFQRc1ewHKado/VrQJQWFLfTwKNzoMOWsUiCbpISDsvAQAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAX0ffOBYvKasoKuvT3XS/b12ki4D+6i5abGqjuWC/iGbAAAAAQAAAAYAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAF9H3zgWLymrKCrr0910v29dpIuA/uouWmxqo7lgv4hmwAAAAEAAAAHSsKnhenNQ9V+QbARYAn8//Wux9dJCqZXzxA72NyVGr4ALR2bAAAKeAAADDQAAAAAACry4gAAAAE9PuVWAAAAQC+jtNd93iP8p91bBeVB2WVgo5W25lfkLsAoDJ0DP1lx5VHV2Bg1QammIolZ6/TEnApsepJlj4xhnrIhwoaHUwE=";
+
+const MOCK_TX_SOROBAN_HASH =
+  "8a3d1009c0a95b5a6eb3304dbc976e0fa803e7e21421fc2a1efbfbc09d57017e";
+
+const buildClassicStoreState = (signedXdr: string) => ({
+  state: {
+    activeStep: "submit",
+    highestCompletedStep: "sign",
+    build: {
+      classic: { operations: [], xdr: signedXdr },
+      soroban: {
+        operation: {
+          operation_type: "",
+          params: {},
+          source_account: "",
+        },
+        xdr: "",
+      },
+      params: {
+        source_account: "",
+        fee: "100",
+        seq_num: "",
+        cond: { time: { min_time: "", max_time: "" } },
+        memo: {},
+      },
+      error: { params: [], operations: [] },
+      isValid: { params: true, operations: true },
+    },
+    simulate: {
+      xdrFormat: "base64",
+      authMode: "record",
+      simulationResultJson: "",
+      isValid: false,
+    },
+    sign: { signedXdr },
+    submit: { submitResultJson: "" },
+    feeBump: { source_account: "", fee: "", xdr: "" },
+  },
+  version: 0,
+});
+
+const buildSorobanStoreState = (signedXdr: string) => ({
+  state: {
+    activeStep: "submit",
+    highestCompletedStep: "validate",
+    build: {
+      classic: { operations: [], xdr: "" },
+      soroban: {
+        operation: {
+          operation_type: "invoke_contract_function",
+          params: {},
+          source_account: "",
+        },
+        xdr: signedXdr,
+      },
+      params: {
+        source_account: "",
+        fee: "100",
+        seq_num: "",
+        cond: { time: { min_time: "", max_time: "" } },
+        memo: {},
+      },
+      error: { params: [], operations: [] },
+      isValid: { params: true, operations: true },
+    },
+    simulate: {
+      xdrFormat: "base64",
+      authMode: "record",
+      simulationResultJson: JSON.stringify({ result: {} }),
+      authEntriesXdr: [],
+      signedAuthEntriesXdr: [],
+      isValid: true,
+    },
+    sign: { signedXdr },
+    submit: { submitResultJson: "" },
+    feeBump: { source_account: "", fee: "", xdr: "" },
+  },
+  version: 0,
+});
+
+const seedSessionStorage = async (page: Page, storeState: object) => {
+  await page.goto(`${baseURL}/transaction/build`);
+
+  await page.evaluate((stateJson) => {
+    sessionStorage.setItem("stellar_lab_tx_flow_build", stateJson);
+  }, JSON.stringify(storeState));
+
+  await page.reload();
+};
+
+/**
+ * Mock RPC sendTransaction returning an error (non-PENDING status).
+ */
+const mockRpcSubmitError = async (page: Page) => {
+  await page.route("**/soroban-testnet.stellar.org/**", async (route) => {
+    const request = route.request();
+    let postData;
+    try {
+      postData = request.postDataJSON();
+    } catch {
+      await route.continue();
+      return;
+    }
+
+    if (postData?.method === "sendTransaction") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: postData.id,
+          result: {
+            status: "ERROR",
+            errorResultXdr: "AAAAAAAAAGT////7AAAAAA==",
+            hash: MOCK_TX_CLASSIC_HASH,
+            latestLedger: 1000,
+            latestLedgerCloseTime: "1700000000",
+          },
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+};
+
+/**
+ * Mock Horizon POST /transactions success.
+ */
+const mockHorizonSubmitSuccess = async (page: Page) => {
+  await page.route(
+    "https://horizon-testnet.stellar.org/transactions",
+    async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            hash: MOCK_TX_CLASSIC_HASH,
+            ledger: 1917984,
+            envelope_xdr: MOCK_SIGNED_CLASSIC_XDR,
+            result_xdr: "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+            fee_charged: "100",
+            operation_count: 1,
+            successful: true,
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    },
+  );
+};
+
+/**
+ * Mock Horizon POST /transactions error (400).
+ */
+const mockHorizonSubmitError = async (page: Page) => {
+  await page.route(
+    "https://horizon-testnet.stellar.org/transactions",
+    async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            type: "https://stellar.org/horizon-errors/transaction_failed",
+            title: "Transaction Failed",
+            status: 400,
+            detail:
+              "The transaction failed when submitted to the stellar network.",
+            extras: {
+              envelope_xdr: MOCK_SIGNED_CLASSIC_XDR,
+              result_xdr: "AAAAAAAAAGT////7AAAAAA==",
+              result_codes: {
+                transaction: "tx_bad_seq",
+              },
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    },
+  );
+};
+
+test.describe("Submit Step in Build Flow", () => {
+  test("Loads the submit step with correct heading", async ({ page }) => {
+    await seedSessionStorage(
+      page,
+      buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+    );
+
+    await expect(page.locator("h1")).toHaveText("Submit transaction");
+  });
+
+  test("Shows signed transaction XDR in read-only picker", async ({ page }) => {
+    await seedSessionStorage(
+      page,
+      buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+    );
+
+    const xdrPicker = page.locator("#submit-tx-xdr");
+    await expect(xdrPicker).toBeVisible();
+  });
+
+  test("Shows transaction hash", async ({ page }) => {
+    await seedSessionStorage(
+      page,
+      buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+    );
+
+    const hashField = page.getByLabel("Transaction hash");
+    await expect(hashField).toBeVisible();
+    await expect(hashField).toHaveValue(MOCK_TX_CLASSIC_HASH);
+  });
+
+  test("Submit button is enabled when signed XDR exists", async ({ page }) => {
+    await seedSessionStorage(
+      page,
+      buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+    );
+
+    const submitButton = page.getByRole("button", {
+      name: "Submit transaction",
+    });
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test.describe("Horizon submission", () => {
+    test("Shows success response on successful Horizon submit", async ({
+      page,
+    }) => {
+      await mockHorizonSubmitSuccess(page);
+      await seedSessionStorage(
+        page,
+        buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+      );
+
+      const submitButton = page.getByRole("button", {
+        name: "Submit transaction",
+      });
+      await submitButton.click();
+
+      await expect(page.getByText("Transaction submitted!")).toBeVisible();
+      await expect(
+        page.getByText(
+          "Transaction successfully submitted with 1 operation(s)",
+        ),
+      ).toBeVisible();
+
+      // Check response details
+      await expect(page.getByText("Hash:")).toBeVisible();
+      await expect(page.getByText("Ledger number:")).toBeVisible();
+      await expect(page.getByText("Fee charged:")).toBeVisible();
+
+      // Block explorer buttons should be visible on testnet
+      await expect(
+        page.getByRole("button", { name: "View on Stellar.Expert" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "View on Stellarchain.io" }),
+      ).toBeVisible();
+
+      // Dashboard link
+      await expect(
+        page.getByRole("button", {
+          name: "View in transaction dashboard",
+        }),
+      ).toBeVisible();
+    });
+
+    test("Shows error response on failed Horizon submit", async ({ page }) => {
+      await mockHorizonSubmitError(page);
+      await seedSessionStorage(
+        page,
+        buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+      );
+
+      const submitButton = page.getByRole("button", {
+        name: "Submit transaction",
+      });
+      await submitButton.click();
+
+      await expect(page.getByText("Transaction Failed")).toBeVisible();
+    });
+  });
+
+  test.describe("RPC submission", () => {
+    const switchToRpc = async (page: Page) => {
+      const methodButton = page.getByRole("button", { name: "via Horizon" });
+      await methodButton.click();
+
+      const rpcOption = page.locator('[data-is-selected="false"]').filter({
+        hasText: "via RPC",
+      });
+      await rpcOption.click();
+    };
+
+    test("Shows error response on failed RPC submit", async ({ page }) => {
+      await mockRpcSubmitError(page);
+      await seedSessionStorage(
+        page,
+        buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+      );
+      await switchToRpc(page);
+
+      const submitButton = page.getByRole("button", {
+        name: "Submit transaction",
+      });
+      await submitButton.click();
+
+      // RPC errors show a "Transaction failed" alert
+      await expect(page.getByText("Transaction failed")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+  });
+
+  test.describe("Submit method selector", () => {
+    test("Defaults to Horizon for classic transactions", async ({ page }) => {
+      await seedSessionStorage(
+        page,
+        buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+      );
+
+      await expect(
+        page.getByRole("button", { name: "via Horizon" }),
+      ).toBeVisible();
+    });
+
+    test("Can switch between Horizon and RPC", async ({ page }) => {
+      await seedSessionStorage(
+        page,
+        buildClassicStoreState(MOCK_SIGNED_CLASSIC_XDR),
+      );
+
+      // Open dropdown
+      const methodButton = page.getByRole("button", { name: "via Horizon" });
+      await methodButton.click();
+
+      // Select RPC
+      const rpcOption = page.locator('[data-is-selected="false"]').filter({
+        hasText: "via RPC",
+      });
+      await rpcOption.click();
+
+      // Button should now say "via RPC"
+      await expect(page.getByRole("button", { name: "via RPC" })).toBeVisible();
+    });
+  });
+
+  test.describe("Soroban transaction submission", () => {
+    test("Defaults to RPC for Soroban transactions", async ({ page }) => {
+      await seedSessionStorage(
+        page,
+        buildSorobanStoreState(MOCK_SIGNED_SOROBAN_XDR),
+      );
+
+      await expect(page.getByRole("button", { name: "via RPC" })).toBeVisible();
+    });
+
+    test("Shows signed Soroban XDR and transaction hash", async ({ page }) => {
+      await seedSessionStorage(
+        page,
+        buildSorobanStoreState(MOCK_SIGNED_SOROBAN_XDR),
+      );
+
+      const xdrPicker = page.locator("#submit-tx-xdr");
+      await expect(xdrPicker).toBeVisible();
+
+      const hashField = page.getByLabel("Transaction hash");
+      await expect(hashField).toHaveValue(MOCK_TX_SOROBAN_HASH);
+    });
+
+    test("Shows error response on failed Soroban RPC submit", async ({
+      page,
+    }) => {
+      await mockRpcSubmitError(page);
+      await seedSessionStorage(
+        page,
+        buildSorobanStoreState(MOCK_SIGNED_SOROBAN_XDR),
+      );
+
+      const submitButton = page.getByRole("button", {
+        name: "Submit transaction",
+      });
+      await submitButton.click();
+
+      await expect(page.getByText("Transaction failed")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+  });
+});

--- a/tests/e2e/urlParams.test.ts
+++ b/tests/e2e/urlParams.test.ts
@@ -37,6 +37,9 @@ test.describe("URL Params", () => {
   });
 
   test.describe("Transactions", () => {
+    // Skipped: Build page now reads from sessionStorage flow store, not URL
+    // querystring. Will be unskipped when URL backward compatibility migration
+    // bridges querystring params into the flow store.
     test.skip("[Classic] Build Transaction", async ({ page }) => {
       await page.goto(
         `${baseURL}/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=create_account&params$destination=GC5TQ7TXKHGE5JQMZPYV5KBSQ67X6PYQVU5QN7JRGWCHRA227UFPZ6LD&starting_balance=3000;&source_account=;&$operation_type=payment&params$destination=GAJAIHPKNTJ362TAUWTU2S56B7PULRTMY456LUELK53USX43537IFMS3&asset$code=USDC&issuer=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&type=credit_alphanum4;&amount=4000;&source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG;;;&params$source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&fee=2000&seq_num=3668692344766465&cond$time$max_time=1733409768;;&memo$text=123;;&isValid$params:true&operations:true;;`,
@@ -130,6 +133,8 @@ test.describe("URL Params", () => {
       );
     });
 
+    // Skipped: /transaction/simulate now redirects to /transaction/build.
+    // Will be unskipped when URL backward compatibility migration is complete.
     test.skip("Simulate Transaction", async ({ page }) => {
       await page.goto(
         `${baseURL}/transaction/simulate?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq//5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79//PxCtOwb9MTWEeINa//Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V//N4s9eMsMt2mWr//kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO//amClp01Lvg//fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+//7BkrIVo//G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==;;`,
@@ -144,6 +149,8 @@ test.describe("URL Params", () => {
       );
     });
 
+    // Skipped: /transaction/submit now redirects to /transaction/build.
+    // Will be unskipped when URL backward compatibility migration is complete.
     test.skip("[Classic] Submit Transaction", async ({ page }) => {
       await page.goto(
         `${baseURL}/transaction/submit?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq//5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79//PxCtOwb9MTWEeINa//Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V//N4s9eMsMt2mWr//kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO//amClp01Lvg//fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+//7BkrIVo//G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==;;`,
@@ -161,6 +168,9 @@ test.describe("URL Params", () => {
       );
     });
 
+    // Skipped: Build page now reads from sessionStorage flow store, not URL
+    // querystring. Will be unskipped when URL backward compatibility migration
+    // bridges querystring params into the flow store.
     test.skip("[Soroban] Build Transaction", async ({ page }) => {
       await page.goto(
         `${baseURL}/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=payment&params$destination=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&asset$code=&issuer=&type=native;&amount=5;&source_account=;;;&soroban$operation$operation_type=extend_footprint_ttl&params$contractDataLedgerKey=AAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAE=&extend_ttl_to=20000&resource_fee=46753;;;&params$source_account=GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG&seq_num=1727208213184538&cond$time$min_time=1733409768;;&memo$text=100;;&isValid$params:true&operations:true;;`,

--- a/tests/e2e/urlParams.test.ts
+++ b/tests/e2e/urlParams.test.ts
@@ -37,10 +37,7 @@ test.describe("URL Params", () => {
   });
 
   test.describe("Transactions", () => {
-    // Skipped: Build page now reads from sessionStorage flow store, not URL
-    // querystring. Will be unskipped when URL backward compatibility migration
-    // bridges querystring params into the flow store.
-    test.skip("[Classic] Build Transaction", async ({ page }) => {
+    test("[Classic] Build Transaction", async ({ page }) => {
       await page.goto(
         `${baseURL}/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=create_account&params$destination=GC5TQ7TXKHGE5JQMZPYV5KBSQ67X6PYQVU5QN7JRGWCHRA227UFPZ6LD&starting_balance=3000;&source_account=;&$operation_type=payment&params$destination=GAJAIHPKNTJ362TAUWTU2S56B7PULRTMY456LUELK53USX43537IFMS3&asset$code=USDC&issuer=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&type=credit_alphanum4;&amount=4000;&source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG;;;&params$source_account=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&fee=2000&seq_num=3668692344766465&cond$time$max_time=1733409768;;&memo$text=123;;&isValid$params:true&operations:true;;`,
       );
@@ -133,45 +130,27 @@ test.describe("URL Params", () => {
       );
     });
 
-    // Skipped: /transaction/simulate now redirects to /transaction/build.
-    // Will be unskipped when URL backward compatibility migration is complete.
-    test.skip("Simulate Transaction", async ({ page }) => {
+    test("Simulate Transaction redirects to build", async ({ page }) => {
       await page.goto(
-        `${baseURL}/transaction/simulate?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq//5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79//PxCtOwb9MTWEeINa//Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V//N4s9eMsMt2mWr//kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO//amClp01Lvg//fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+//7BkrIVo//G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==;;`,
+        `${baseURL}/transaction/simulate?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;`,
       );
 
-      await expect(page.locator("h1")).toHaveText("Simulate transaction");
-
-      await expect(
-        page.getByLabel("Input a Base64 encoded TransactionEnvelope"),
-      ).toHaveValue(
-        "AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq/5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79/PxCtOwb9MTWEeINa/Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V/N4s9eMsMt2mWr/kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO/amClp01Lvg/fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==",
-      );
+      await page.waitForURL("**/transaction/build**");
+      await expect(page.locator("h1")).toHaveText("Build transaction");
     });
 
-    // Skipped: /transaction/submit now redirects to /transaction/build.
-    // Will be unskipped when URL backward compatibility migration is complete.
-    test.skip("[Classic] Submit Transaction", async ({ page }) => {
+    test("[Classic] Submit Transaction redirects to build", async ({
+      page,
+    }) => {
       await page.goto(
-        `${baseURL}/transaction/submit?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq//5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79//PxCtOwb9MTWEeINa//Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V//N4s9eMsMt2mWr//kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO//amClp01Lvg//fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+//7BkrIVo//G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==;;`,
+        `${baseURL}/transaction/submit?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;`,
       );
 
-      await expect(page.locator("h1")).toHaveText("Submit transaction");
-
-      await expect(
-        page.getByLabel("Input a Base64 encoded TransactionEnvelope"),
-      ).toHaveValue(
-        "AAAAAgAAAAA55ZjOXdOOulfzeLPXjLDLdplq/5HGjapWAXjGSkdAkwAAD6AADQioAAAAAQAAAAEAAAAAAAAAAAAAAABnUbvoAAAAAQAAAAMxMjMAAAAAAgAAAAAAAAAAAAAAALs4fndRzE6mDMvxXqgyh79/PxCtOwb9MTWEeINa/Qr8AAAABvwjrAAAAAABAAAAADnlmM5d0466V/N4s9eMsMt2mWr/kcaNqlYBeMZKR0CTAAAAAQAAAAASBB3qbNO/amClp01Lvg/fRcZsxzvl0ItXd0lfm+7+ggAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAACVAvkAAAAAAAAAAAAA==",
-      );
-      await expect(page.getByLabel("Transaction hash")).toHaveValue(
-        "44abaabac11c318d595d392c24166965301b48109899bc8e819723afb89d5e37",
-      );
+      await page.waitForURL("**/transaction/build**");
+      await expect(page.locator("h1")).toHaveText("Build transaction");
     });
 
-    // Skipped: Build page now reads from sessionStorage flow store, not URL
-    // querystring. Will be unskipped when URL backward compatibility migration
-    // bridges querystring params into the flow store.
-    test.skip("[Soroban] Build Transaction", async ({ page }) => {
+    test("[Soroban] Build Transaction", async ({ page }) => {
       await page.goto(
         `${baseURL}/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=payment&params$destination=GA46LGGOLXJY5OSX6N4LHV4MWDFXNGLK76I4NDNKKYAXRRSKI5AJGMXG&asset$code=&issuer=&type=native;&amount=5;&source_account=;;;&soroban$operation$operation_type=extend_footprint_ttl&params$contractDataLedgerKey=AAAABgAAAAEg/u86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAE=&extend_ttl_to=20000&resource_fee=46753;;;&params$source_account=GB7EZPIHFYQCG2TTCGPSPKWKC36CF35YO5MDM5S5LTAPRNKRSARIHWGG&seq_num=1727208213184538&cond$time$min_time=1733409768;;&memo$text=100;;&isValid$params:true&operations:true;;`,
       );
@@ -212,7 +191,6 @@ test.describe("URL Params", () => {
         "AAAABgAAAAEgu86MzPrVcpNrsFUa84T82Kss8DLAE9ZMxLqhM22HwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAB+TL0HLiAjanMRnyeqyhb8Iu+4d1g2dl1cwPi1UZAigwAAAAE=",
       );
       await expect(sorobanOp.getByLabel("Extend To")).toHaveValue("20000");
-      await expect(sorobanOp.getByLabel("Resource Fee")).toHaveValue("46753");
     });
 
     test("Fee Bump", async ({ page }) => {


### PR DESCRIPTION
**How to test:**
- Go to `main` branch in localhost and save bunch of transactions in `Saved Transactions` and urls with params filled
- Switch to this branch, go to `Saved Transactions` and click `View in Builder/Submitter`
- Switch to this branch, directly copy and paste over the urls from `main` branch

**Example urls you can use:**
- http://localhost:3000/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=payment&params$destination=GCLZIY335E7I2QOGSQTRNREQPXTIWUOHLLA6OLVDAN3FFZPU3FEYDA3D&asset$code=&issuer=&type=native;&amount=10;&source_account=;;;&soroban$operation$params@;;;&params$source_account=GBPIMUEJFYS7RT23QO2ACH2JMKGXLXZI4E5ACBSQMF32RKZ5H3SVNL5F&seq_num=6392388805197846;&isValid$params:true&operations:true;;
- http://localhost:3000/transaction/build?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&transaction$build$classic$operations@$operation_type=path_payment_strict_send&params$destination=GD2E7UOAJMTAHJCI6ZNRSAC4Q2FRZ3ZUZZBSLB5DOZNKXQBTHA35H3XC&send_asset$code=&issuer=&type=native;&send_amount=100&dest_asset$code=USDC&issuer=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5&type=credit_alphanum4;&dest_min=1;&source_account=;;;&soroban$operation$params@;;;&params$source_account=GBPIMUEJFYS7RT23QO2ACH2JMKGXLXZI4E5ACBSQMF32RKZ5H3SVNL5F&seq_num=6392388805197846;&isValid$params:true&operations:true;;

**Note:**
- `useLegacyUrlMigration` is for pre-filling based on `zustand-querystring` urls. I added a warning telling users to save this transaction since this won't be supported in the future. Ticket created to remove this in the future #2017 