### PR TITLE
[New TX Flow] Make stepper horizontal on mobile

### DIFF
--- a/src/app/(sidebar)/transaction/build/styles.scss
+++ b/src/app/(sidebar)/transaction/build/styles.scss
@@ -47,12 +47,17 @@
   }
 
   @media (max-width: 960px) {
+    &__tabs {
+      width: 100%;
+    }
+
     &__layout {
       flex-direction: column;
     }
 
     &__stepper {
-      display: none;
+      width: 100%;
+      order: -1;
     }
   }
 }

--- a/src/components/SorobanAuthSigning/styles.scss
+++ b/src/components/SorobanAuthSigning/styles.scss
@@ -16,6 +16,10 @@
     &--expanded {
       border-bottom: 1px solid var(--sds-clr-gray-06);
     }
+
+    @media (max-width: 960px) {
+      grid-template-columns: 1fr;
+    }
   }
 
   &__header-text {

--- a/src/components/TransactionStepper/index.tsx
+++ b/src/components/TransactionStepper/index.tsx
@@ -21,6 +21,15 @@ const STEP_LABELS: Record<TransactionStepName, string> = {
   submit: "Submit transaction",
 };
 
+const STEP_SHORT_LABELS: Record<TransactionStepName, string> = {
+  build: "Build",
+  import: "Import",
+  simulate: "Simulate",
+  validate: "Validate",
+  sign: "Sign",
+  submit: "Submit",
+};
+
 const STEP_DESCRIPTIONS: Partial<Record<TransactionStepName, string>> = {
   validate:
     "This transaction contains authorization entries that need to be validated before submitting.",
@@ -108,7 +117,12 @@ export const TransactionStepper = ({
               {!isLast && <div className="TransactionStepper__connector" />}
             </div>
             <div className="TransactionStepper__label">
-              {STEP_LABELS[step]}
+              <span className="TransactionStepper__labelFull">
+                {STEP_LABELS[step]}
+              </span>
+              <span className="TransactionStepper__labelShort">
+                {STEP_SHORT_LABELS[step]}
+              </span>
               {STEP_DESCRIPTIONS[step] && (
                 <Text
                   size="xs"

--- a/src/components/TransactionStepper/styles.scss
+++ b/src/components/TransactionStepper/styles.scss
@@ -110,9 +110,62 @@
     }
   }
 
+  &__labelShort {
+    display: none;
+  }
+
   &__description {
     white-space: normal;
     color: var(--sds-clr-gray-09);
     padding-top: pxToRem(2px);
+  }
+
+  @media (max-width: 960px) {
+    flex-direction: row;
+    justify-content: center;
+    gap: pxToRem(22px);
+    padding: pxToRem(8px) 0;
+
+    &__step {
+      flex-direction: column;
+      align-items: center;
+      width: pxToRem(60px);
+      position: relative;
+      gap: 0;
+    }
+
+    &__connector {
+      position: absolute;
+      height: 1px;
+      width: pxToRem(52px);
+      top: pxToRem(14px);
+      left: calc(50% + #{pxToRem(15px)});
+
+      [data-has-description="true"] & {
+        height: 1px;
+      }
+    }
+
+    &__label {
+      text-align: center;
+      white-space: nowrap;
+      padding-top: pxToRem(5px);
+
+      [data-has-description="true"] > & {
+        padding-bottom: 0;
+      }
+    }
+
+    &__labelFull {
+      display: none;
+    }
+
+    &__labelShort {
+      display: block;
+    }
+
+    &__description {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
Move the side stepper above the content on mobile viewports and render it as a horizontal row with short labels, matching [the Figma spec](https://www.figma.com/design/9j3YQ5URseAsn3j0tf2FFq/Laboratory?node-id=7643-80488&m=dev). Also stack the SorobanAuthSigning header in a single column on mobile.

<img width="400" height="743" alt="Screenshot 2026-04-10 at 1 41 10 PM" src="https://github.com/user-attachments/assets/4f67353d-b66d-4f3e-8297-9d3760c4a942" />
