### PR TITLE
[New Tx Flow] Enable 'save transactions' button in TransactionFlowFooter

### DIFF
--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -209,6 +209,12 @@ export default function BuildTransaction() {
               onNext={handleNext}
               isNextDisabled={isNextDisabled}
               xdr={currentXdr}
+              params={build.params}
+              operations={
+                isSoroban
+                  ? [build.soroban.operation]
+                  : build.classic.operations
+              }
             />
           </Box>
         </div>

--- a/src/components/TransactionFlowFooter/index.tsx
+++ b/src/components/TransactionFlowFooter/index.tsx
@@ -11,6 +11,9 @@ import {
   getStepLabel,
 } from "@/components/TransactionStepper";
 
+import { TransactionBuildParams } from "@/store/createTransactionFlowStore";
+import { TxnOperation } from "@/types/types";
+
 import "./styles.scss";
 
 /**
@@ -22,6 +25,8 @@ import "./styles.scss";
  * @param onNext - Callback to advance to the next step
  * @param isNextDisabled - Whether the Next button should be disabled
  * @param xdr - Built XDR string, used for saving on the build/import step
+ * @param params - Transaction build params for saving
+ * @param operations - Transaction operations for saving
  *
  * @example
  * <TransactionFlowFooter
@@ -30,6 +35,8 @@ import "./styles.scss";
  *   onNext={handleNext}
  *   isNextDisabled={!isValid}
  *   xdr={builtXdr}
+ *   params={build.params}
+ *   operations={build.classic.operations}
  * />
  */
 export const TransactionFlowFooter = ({
@@ -38,12 +45,16 @@ export const TransactionFlowFooter = ({
   onNext,
   isNextDisabled,
   xdr,
+  params,
+  operations,
 }: {
   steps: TransactionStepName[];
   activeStep: TransactionStepName;
   onNext?: () => void;
   isNextDisabled: boolean;
   xdr?: string;
+  params?: TransactionBuildParams;
+  operations?: TxnOperation[];
 }) => {
   const [isSaveModalVisible, setIsSaveModalVisible] = useState(false);
 
@@ -86,6 +97,8 @@ export const TransactionFlowFooter = ({
             itemProps={{
               xdr: xdr || "",
               page: "build",
+              ...(params ? { params } : {}),
+              ...(operations ? { operations } : {}),
             }}
             allSavedItems={localStorageSavedTransactions.get()}
             isVisible={isSaveModalVisible}


### PR DESCRIPTION
This wasn't saving its params and operations. This PR updates it to save them

<img width="778" height="133" alt="Screenshot 2026-04-13 at 1 12 03 PM" src="https://github.com/user-attachments/assets/3bb5ea8d-ca21-4b1c-91e7-7496e28fc85d" />