### PR TITLE
[New Tx Flow] Skip auth entry if the auth entry account is the same as source account

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/SimulateStepContent.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SimulateStepContent.tsx
@@ -245,10 +245,9 @@ export const SimulateStepContent = ({
           }
 
           // Source account credential entries are authorized by the
-          // transaction envelope signature — pre-populate them so
-          // only address credential entries require user signing.
-          const prePopulated: string[] = [];
-          let needsAuthSigning = false;
+          // transaction envelope signature — pre-populate them as
+          // already signed so only address entries require user action.
+          const preSignedEntries: string[] = [];
 
           for (let i = 0; i < entries.length; i++) {
             const entry = xdr.SorobanAuthorizationEntry.fromXDR(
@@ -256,20 +255,21 @@ export const SimulateStepContent = ({
               "base64",
             );
             if (
-              entry.credentials().switch().name ===
-              "sorobanCredentialsAddress"
+              entry.credentials().switch().name !== "sorobanCredentialsAddress"
             ) {
-              needsAuthSigning = true;
-            } else {
-              prePopulated[i] = entries[i];
+              preSignedEntries[i] = entries[i];
             }
           }
 
-          if (needsAuthSigning) {
-            // Show auth signing card — source account entries are
-            // pre-populated, only address entries need user signing
+          // check if entries include addresses that aren't a source account
+          const hasAddressEntries =
+            entries.length > preSignedEntries.filter(Boolean).length;
+
+          if (hasAddressEntries) {
+            // Show auth signing card for address entries that aren't a source account
             setAuthEntriesXdr(entries);
-            setSignedAuthEntriesXdr(prePopulated);
+            // since source account entries are pre-signed, we can set it in setSignedAuthEntriesXdr
+            setSignedAuthEntriesXdr(preSignedEntries);
           } else {
             // No address credential entries — auto-assemble the
             // transaction with simulation resources (fees, sorobanData)

--- a/src/app/(sidebar)/transaction/build/components/SimulateStepContent.tsx
+++ b/src/app/(sidebar)/transaction/build/components/SimulateStepContent.tsx
@@ -239,14 +239,41 @@ export const SimulateStepContent = ({
           const entries = extractAuthEntries(simBase64Response);
 
           if (entries.length > 0) {
-            setAuthEntriesXdr(entries);
             trackEvent(TrackingEvent.SOROBAN_AUTH_ENTRIES_DETECTED, {
               entryCount: entries.length,
             });
+          }
+
+          // Source account credential entries are authorized by the
+          // transaction envelope signature — pre-populate them so
+          // only address credential entries require user signing.
+          const prePopulated: string[] = [];
+          let needsAuthSigning = false;
+
+          for (let i = 0; i < entries.length; i++) {
+            const entry = xdr.SorobanAuthorizationEntry.fromXDR(
+              entries[i],
+              "base64",
+            );
+            if (
+              entry.credentials().switch().name ===
+              "sorobanCredentialsAddress"
+            ) {
+              needsAuthSigning = true;
+            } else {
+              prePopulated[i] = entries[i];
+            }
+          }
+
+          if (needsAuthSigning) {
+            // Show auth signing card — source account entries are
+            // pre-populated, only address entries need user signing
+            setAuthEntriesXdr(entries);
+            setSignedAuthEntriesXdr(prePopulated);
           } else {
-            // No auth entries — auto-assemble the transaction with
-            // simulation resources (fees, sorobanData) so the Sign step
-            // receives a complete XDR ready for signing.
+            // No address credential entries — auto-assemble the
+            // transaction with simulation resources (fees, sorobanData)
+            // so the Sign step receives a complete XDR ready for signing.
             try {
               const rawTx = TransactionBuilder.fromXDR(
                 builtXdr,

--- a/tests/e2e/simulateStepContent.test.ts
+++ b/tests/e2e/simulateStepContent.test.ts
@@ -12,9 +12,14 @@ import { test, expect, Page } from "@playwright/test";
 const MOCK_BUILT_XDR =
   "AAAAAgAAAABehlCJLiX4z1uDtAEfSWKNdd8o4ToBBlBhd6irPT7lVgAAAMgAFrXYAAAAEwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABfR984Fi8pqygq69PddL9vXaSLgP7qLlpsaqO5YL+IZsAAAAEc3dhcAAAAAgAAAASAAAAAAAAAAAh5dYXbG+vCChQsGMYfg8k2ABTTz0GHlyHZd1Q+bf9dAAAABIAAAAAAAAAAMwJGsOjTzw4CL/dwI16iaHPIxQi4W5zveD3yDEJrwyeAAAAEgAAAAHXkotywnA8z+r365/0701QSlWouXn8m0UOoshCtNHOYQAAABIAAAABUEXNXsBymnaP1a0CUFhS308Cjc6DDlrFIgm6SEg7LwEAAAAKAAAAAAAAAAAAAAAAAAAACgAAAAoAAAAAAAAAAAAAAAAAAAAyAAAACgAAAAAAAAAAAAAAAAAAAGQAAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
-// A mock auth entry XDR
+// A mock auth entry XDR (sorobanCredentialsAddress — requires explicit signing)
 const MOCK_AUTH_ENTRY_XDR =
   "AAAAAQAAAAAAAAAAIeXWF2xvrwgoULBjGH4PJNgAU089Bh5ch2XdUPm3/XRzFw9PTWlqNwAAAAAAAAABAAAAAAAAAAF9H3zgWLymrKCrr0910v29dpIuA/uouWmxqo7lgv4hmwAAAARzd2FwAAAABAAAABIAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAASAAAAAVBFzV7Acpp2j9WtAlBYUt9PAo3Ogw5axSIJukhIOy8BAAAACgAAAAAAAAAAAAAAAAAAAAoAAAAKAAAAAAAAAAAAAAAAAAAAMgAAAAEAAAAAAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAACHl1hdsb68IKFCwYxh+DyTYAFNPPQYeXIdl3VD5t/10AAAAEgAAAAF9H3zgWLymrKCrr0910v29dpIuA/uouWmxqo7lgv4hmwAAAAoAAAAAAAAAAAAAAAAAAAAKAAAAAA==";
+
+// A mock auth entry XDR (sorobanCredentialsSourceAccount — authorized by
+// the transaction envelope signature, no separate signing needed)
+const MOCK_SOURCE_ACCOUNT_AUTH_ENTRY_XDR =
+  "AAAAAAAAAAAAAAABfR984Fi8pqygq69PddL9vXaSLgP7qLlpsaqO5YL+IZsAAAAEc3dhcAAAAAAAAAAA";
 
 // Fake assembled XDR — just needs to be non-empty to represent stale data
 const STALE_ASSEMBLED_XDR = "STALE_ASSEMBLED_XDR_PLACEHOLDER";
@@ -94,9 +99,9 @@ const seedSessionStorageAndNavigate = async (page: Page) => {
 };
 
 /**
- * Mock simulateTransaction to return a response WITH auth entries.
+ * Mock simulateTransaction to return a response with the given auth entries.
  */
-const mockSimulateWithAuthEntries = async (page: Page) => {
+const mockSimulateWithAuth = async (page: Page, authEntries: string[]) => {
   await page.route("https://soroban-testnet.stellar.org", async (route) => {
     const request = route.request();
     const postData = request.postDataJSON();
@@ -114,7 +119,7 @@ const mockSimulateWithAuthEntries = async (page: Page) => {
             latestLedger: 1901916,
             results: [
               {
-                auth: [MOCK_AUTH_ENTRY_XDR],
+                auth: authEntries,
                 xdr: "AAAAAQ==",
               },
             ],
@@ -131,7 +136,7 @@ test.describe("Simulate Step — Re-simulation clears stale state", () => {
   test("Re-simulating clears stale assembledXdr so Next is disabled until auth entries are signed", async ({
     page,
   }) => {
-    await mockSimulateWithAuthEntries(page);
+    await mockSimulateWithAuth(page, [MOCK_AUTH_ENTRY_XDR]);
     await seedSessionStorageAndNavigate(page);
 
     // Precondition: Next button should be enabled because stale
@@ -161,6 +166,87 @@ test.describe("Simulate Step — Re-simulation clears stale state", () => {
     // Next button should now be DISABLED because:
     // 1. assembledXdr was cleared at the start of re-simulation
     // 2. New auth entries need signing before assembly can happen
+    await expect(nextButton).toBeDisabled();
+  });
+});
+
+test.describe("Simulate Step — Source account auth entries skip signing", () => {
+  test("All source account auth entries auto-assemble without showing the auth signing card", async ({
+    page,
+  }) => {
+    await mockSimulateWithAuth(page, [MOCK_SOURCE_ACCOUNT_AUTH_ENTRY_XDR]);
+    await seedSessionStorageAndNavigate(page);
+
+    const simulateButton = page.getByRole("button", {
+      name: "Simulate",
+      exact: true,
+    });
+    await simulateButton.click();
+
+    // Wait for simulation result
+    await expect(page.getByTestId("simulate-step-response")).toBeVisible();
+
+    // Auth signing card should NOT appear — source account entries are
+    // authorized by the transaction envelope signature
+    await expect(
+      page.getByText(
+        "This transaction requires additional authorization signatures",
+      ),
+    ).not.toBeVisible();
+
+    // Next button should be ENABLED — auto-assembly happened
+    const nextButton = page.getByRole("button", {
+      name: /^Next:/,
+    });
+    await expect(nextButton).toBeEnabled();
+  });
+
+  test("Mixed entries: auth signing card shows, but only address entries need signing", async ({
+    page,
+  }) => {
+    await mockSimulateWithAuth(page, [
+      MOCK_SOURCE_ACCOUNT_AUTH_ENTRY_XDR,
+      MOCK_AUTH_ENTRY_XDR,
+    ]);
+    await seedSessionStorageAndNavigate(page);
+
+    const simulateButton = page.getByRole("button", {
+      name: "Simulate",
+      exact: true,
+    });
+    await simulateButton.click();
+
+    // Wait for simulation result
+    await expect(page.getByTestId("simulate-step-response")).toBeVisible();
+
+    // Auth signing card SHOULD appear — there's an address credential entry
+    await expect(
+      page.getByText(
+        "This transaction requires additional authorization signatures",
+      ),
+    ).toBeVisible();
+
+    // Source account entry (#1) should be pre-signed, address entry (#2) unsigned
+    const viewButton = page.getByRole("button", {
+      name: "View auth entries",
+    });
+    await viewButton.click();
+
+    await expect(page.getByText("Entry #1")).toBeVisible();
+    await expect(page.getByText("Entry #2")).toBeVisible();
+
+    // Entry #1 (source account) is pre-populated as Signed
+    const entry1 = page.locator(".SorobanAuthSigning__entry").nth(0);
+    await expect(entry1.getByText("Signed")).toBeVisible();
+
+    // Entry #2 (address) still needs signing
+    const entry2 = page.locator(".SorobanAuthSigning__entry").nth(1);
+    await expect(entry2.getByText("Unsigned")).toBeVisible();
+
+    // Next button should be DISABLED — address entry still needs signing
+    const nextButton = page.getByRole("button", {
+      name: /^Next:/,
+    });
     await expect(nextButton).toBeDisabled();
   });
 });


### PR DESCRIPTION
Fix the [bug](https://stellarfoundation.slack.com/archives/C06KTGUULUF/p1776127591933579?thread_ts=1776111931.130149&cid=C06KTGUULUF) reported by ryan

- only requires explicit auth signing if it's `sorobanCredentialsAddress` type. If it's `sorobanCredentialsSourceAccount`, let users proceeds without auth entry signature since "Sign transaction" step takes care of both.

successful hash:
- [c1803089f4eb81c30bd075eec604a9e5bd2c0ed6860003fc9266d9b63faa019e](https://stellar.expert/explorer/testnet/tx/c1803089f4eb81c30bd075eec604a9e5bd2c0ed6860003fc9266d9b63faa019e)
- [7adb6bb2df7795cf6d57b4f5494e438c979fccf36b57b7c9cb076082b49c3b95](https://stellar.expert/explorer/testnet/tx/8908281863012352)
- [3b01d88e3aa512135b923675def2336139e7313fddf8408cd50ee2638cbda585](https://stellar.expert/explorer/testnet/tx/8908153013997568) 

how to test:
- this bug happens when a source account address is the same as auth entry address. the contract id and operation we used is [here](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAC3gFZiADqJtbRXtDxNmR1jp//oUk2bmGNd+nOl6aFigVQAAk0oADSxdAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABiBqPDN6w3AqtjeChlK9EkpFXvfiHkiIhITjRV4o74c4AAAAGc3VibWl0AAAAAAAEAAAAEgAAAAAAAAAAt4BWYgA6ibW0V7Q8TZkdY6f6FJNm5hjXfpzpemhYoFUAAAASAAAAAAAAAAC3gFZiADqJtbRXtDxNmR1jp//oUk2bmGNd+nOl6aFigVQAAABIAAAAAAAAAALeAVmIAOom1tFe0PE2ZHWOn+hSTZuYY136c6XpoWKBVAAAAEAAAAAEAAAABAAAAEQAAAAEAAAADAAAADwAAAAdhZGRyZXNzAAAAABIAAAAB15KLcsJwPM//q9+uf9O9NUEpVqLl5//JtFDqLIQrTRzmEAAAAPAAAABmFtb3VudAAAAAAACgAAAAAAAAAAAAAAAAAAA+gAAAAPAAAADHJlcXVlc3RfdHlwZQAAAAMAAAACAAAAAQAAAAAAAAAAAAAAAYgajwzesNwKrY3goZSvRJKRV734h5IiISE40VeKO+HOAAAABnN1Ym1pdAAAAAAABAAAABIAAAAAAAAAALeAVmIAOom1tFe0PE2ZHWOn+hSTZuYY136c6XpoWKBVAAAAEgAAAAAAAAAAt4BWYgA6ibW0V7Q8TZkdY6f6FJNm5hjXfpzpemhYoFUAAAASAAAAAAAAAAC3gFZiADqJtbRXtDxNmR1jp//oUk2bmGNd+nOl6aFigVQAAABAAAAABAAAAAQAAABEAAAABAAAAAwAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAdeSi3LCcDzP6vfrn//TvTVBKVai5efybRQ6iyEK00c5hAAAADwAAAAZhbW91bnQAAAAAAAoAAAAAAAAAAAAAAAAAAAPoAAAADwAAAAxyZXF1ZXN0X3R5cGUAAAADAAAAAgAAAAEAAAAAAAAAAdeSi3LCcDzP6vfrn//TvTVBKVai5efybRQ6iyEK00c5hAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAALeAVmIAOom1tFe0PE2ZHWOn+hSTZuYY136c6XpoWKBVAAAAEgAAAAGIGo8M3rDcCq2N4KGUr0SSkVe9+IeSIiEhONFXijvhzgAAAAoAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAEAAAAAAAAABgAAAAYAAAABiBqPDN6w3AqtjeChlK9EkpFXvfiHkiIhITjRV4o74c4AAAAQAAAAAQAAAAIAAAAPAAAAB0F1Y3Rpb24AAAAAEQAAAAEAAAACAAAADwAAAAlhdWN0X3R5cGUAAAAAAAADAAAAAAAAAA8AAAAEdXNlcgAAABIAAAAAAAAAALeAVmIAOom1tFe0PE2ZHWOn+hSTZuYY136c6XpoWKBVAAAAAAAAAAYAAAABiBqPDN6w3AqtjeChlK9EkpFXvfiHkiIhITjRV4o74c4AAAAQAAAAAQAAAAIAAAAPAAAACEVtaXNEYXRhAAAAAwAAAAEAAAABAAAABgAAAAGIGo8M3rDcCq2N4KGUr0SSkVe9+IeSIiEhONFXijvhzgAAABAAAAABAAAAAgAAAA8AAAAJUmVzQ29uZmlnAAAAAAAAEgAAAAHXkotywnA8z+r365//0701QSlWouXn8m0UOoshCtNHOYQAAAAEAAAAGAAAAAYgajwzesNwKrY3goZSvRJKRV734h5IiISE40VeKO+HOAAAAFAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn//TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAAHpB//FPWdTtsBOsVsCHFUFI2akyODiG8cnAPRhJk7BNQ4AAAAEAAAAAAAAAAC3gFZiADqJtbRXtDxNmR1jp//oUk2bmGNd+nOl6aFigVQAAAAYAAAABiBqPDN6w3AqtjeChlK9EkpFXvfiHkiIhITjRV4o74c4AAAAQAAAAAQAAAAIAAAAPAAAACVBvc2l0aW9ucwAAAAAAABIAAAAAAAAAALeAVmIAOom1tFe0PE2ZHWOn+hSTZuYY136c6XpoWKBVAAAAAQAAAAYAAAABiBqPDN6w3AqtjeChlK9EkpFXvfiHkiIhITjRV4o74c4AAAAQAAAAAQAAAAIAAAAPAAAAB1Jlc0RhdGEAAAAAEgAAAAHXkotywnA8z+r365//0701QSlWouXn8m0UOoshCtNHOYQAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn//TvTVBKVai5efybRQ6iyEK00c5hAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAABiBqPDN6w3AqtjeChlK9EkpFXvfiHkiIhITjRV4o74c4AAAABAD2AwgAAAJAAAAQAAAAAAAAAkoIAAAABaFigVQAAAEBR25MC//cQXOhlve5UywmaL1fCe8JmcW0FuuWFycuahSiZLBMxtIWieWpnOHqJB87bFoJLLVhuKDSG5qsNwHCgM;;). But to make it easier:
- Start a transaction
- Add a source account (keep the address handy, we are going to re-use it in soroban operation)
- Select "Invoke contract"
- Contract id "CCEBVDYM32YNYCVNRXQKDFFPISJJCV557CDZEIRBEE4NCV4KHPQ44HGF"
- function name: "submit"
- for the first three addresses, use: `GC3YAVTCAA5ITNNUK62DYTMZDVR2P6QUSNTOMGGXP2OOS6TILCQFLZ2P`
- select `add request`
- add `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` for the first contract id
- `1000` for `amount`
- `2` for `request_type`

Previous version wouldn't recognize the auth entry of the source account once signed.

This version:
- skips it entirely **if all auth entries are the same as source account** since 'sign transaction' handles the auth entry .
- it doesn't skip if one of them is different. make sure to put the `spender` param first account first then `from` when signing auth entries for the contract `CCEBVDYM32YNYCVNRXQKDFFPISJJCV557CDZEIRBEE4NCV4KHPQ44HGF`

<img width="739" height="1159" alt="Screenshot 2026-04-15 at 10 27 54 AM" src="https://github.com/user-attachments/assets/01a75b6f-85bc-43a5-aa36-6e67ff9d0d84" />
