### PR TITLE
[New Tx Flow] Properly reset the validate step

### DIFF
--- a/src/store/createTransactionFlowStore.ts
+++ b/src/store/createTransactionFlowStore.ts
@@ -477,10 +477,10 @@ const createTransactionFlowStore = (
             if (fromIndex <= steps.indexOf("sign")) {
               state.sign = initTransactionSignState;
             }
-            // Always clear validate — it's bound to a specific simulation
-            // and becomes stale even when the steps array changes to exclude
-            // the validate step (e.g. new tx has no address auth entries).
-            state.validate = undefined;
+            const validateIndex = steps.indexOf("validate");
+            if (validateIndex === -1 || fromIndex <= validateIndex) {
+              state.validate = undefined;
+            }
             if (fromIndex <= steps.indexOf("submit")) {
               state.submit = initTransactionSubmitState;
             }

--- a/src/store/createTransactionFlowStore.ts
+++ b/src/store/createTransactionFlowStore.ts
@@ -477,9 +477,10 @@ const createTransactionFlowStore = (
             if (fromIndex <= steps.indexOf("sign")) {
               state.sign = initTransactionSignState;
             }
-            if (fromIndex <= steps.indexOf("validate")) {
-              state.validate = undefined;
-            }
+            // Always clear validate — it's bound to a specific simulation
+            // and becomes stale even when the steps array changes to exclude
+            // the validate step (e.g. new tx has no address auth entries).
+            state.validate = undefined;
             if (fromIndex <= steps.indexOf("submit")) {
               state.submit = initTransactionSubmitState;
             }


### PR DESCRIPTION
Added an additional condition `validateIndex === -1` in case, user starts a new transaction without `validate step` after having submitted a transaction with validate step