### PR TITLE
[New TX Flow] Add a back button, allow next step in side stepper, & move reset tx to header

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
+++ b/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
@@ -69,50 +69,51 @@ export const BuildStepHeader = ({
     >
       <PageHeader heading={heading} as={headingAs} />
 
-      {showHeaderButtons && (
-        <Box gap="sm" direction="row" justify="center" align="center">
-          <Button
-            size="md"
-            variant="tertiary"
-            onClick={() => setIsClearModalVisible(true)}
-          >
-            <IconButton
-              icon={<Icon.RefreshCcw01 />}
-              customSize="14px"
-              customColor="var(--sds-clr-gray-09)"
-              altText="Clear transaction"
-            />
-          </Button>
+      <Box gap="sm" direction="row" justify="center" align="center">
+        <Button
+          size="md"
+          variant="tertiary"
+          data-testid="clear-all-button"
+          onClick={() => setIsClearModalVisible(true)}
+        >
+          <IconButton
+            icon={<Icon.RefreshCcw01 />}
+            customSize="14px"
+            customColor="var(--sds-clr-gray-09)"
+            altText="Clear transaction"
+          />
+        </Button>
 
-          <Modal
-            visible={isClearModalVisible}
-            onClose={() => setIsClearModalVisible(false)}
-          >
-            <Modal.Heading>Clear everything?</Modal.Heading>
-            <Modal.Body>
-              This will remove all entered data in the form.
-            </Modal.Body>
-            <Modal.Footer>
-              <Button
-                size="md"
-                variant="tertiary"
-                onClick={() => setIsClearModalVisible(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                size="md"
-                variant="error"
-                onClick={() => {
-                  onClearAll();
-                  setIsClearModalVisible(false);
-                }}
-              >
-                Clear all
-              </Button>
-            </Modal.Footer>
-          </Modal>
+        <Modal
+          visible={isClearModalVisible}
+          onClose={() => setIsClearModalVisible(false)}
+        >
+          <Modal.Heading>Clear everything?</Modal.Heading>
+          <Modal.Body>
+            This will remove all entered data in the form.
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              size="md"
+              variant="tertiary"
+              onClick={() => setIsClearModalVisible(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="md"
+              variant="error"
+              onClick={() => {
+                onClearAll();
+                setIsClearModalVisible(false);
+              }}
+            >
+              Clear all
+            </Button>
+          </Modal.Footer>
+        </Modal>
 
+        {showHeaderButtons && (
           <>
             <Button
               size="md"
@@ -146,8 +147,8 @@ export const BuildStepHeader = ({
               }}
             />
           </>
-        </Box>
-      )}
+        )}
+      </Box>
     </Box>
   );
 };

--- a/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
+++ b/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Icon, IconButton, Modal } from "@stellar/design-system";
+import { Button, Icon, Modal } from "@stellar/design-system";
 
 import { TransactionBuildParams } from "@/store/createTransactionFlowStore";
 
@@ -76,12 +76,7 @@ export const BuildStepHeader = ({
           data-testid="clear-all-button"
           onClick={() => setIsClearModalVisible(true)}
         >
-          <IconButton
-            icon={<Icon.RefreshCcw01 />}
-            customSize="14px"
-            customColor="var(--sds-clr-gray-09)"
-            altText="Clear transaction"
-          />
+          <Icon.RefreshCcw01 />
         </Button>
 
         <Modal
@@ -120,12 +115,7 @@ export const BuildStepHeader = ({
               variant="tertiary"
               onClick={() => setIsSaveModalVisible(true)}
             >
-              <IconButton
-                icon={<Icon.Save01 />}
-                customSize="14px"
-                customColor="var(--sds-clr-gray-09)"
-                altText="Save transaction"
-              />
+              <Icon.Save01 />
             </Button>
 
             <SaveToLocalStorageModal

--- a/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
+++ b/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
@@ -1,43 +1,153 @@
-import { Link } from "@stellar/design-system";
+"use client";
 
+import { useState } from "react";
+import { Button, Icon, IconButton, Modal } from "@stellar/design-system";
+
+import { TransactionBuildParams } from "@/store/createTransactionFlowStore";
+
+import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
+
+import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
 import { Box } from "@/components/layout/Box";
 import { PageHeader } from "@/components/layout/PageHeader";
+
+import { TxnOperation } from "@/types/types";
 
 interface BuildStepHeaderProps {
   /** Step title displayed on the left. */
   heading: string;
   /** Semantic heading element for the page header. */
   headingAs?: "h1" | "h2";
+  /** The currently active step */
+  activeStep?: string;
+  /** Built XDR string, used for saving on the build/import step */
+  xdr?: string;
+  /** Transaction build params for saving */
+  params?: TransactionBuildParams;
+  /** Transaction operations for saving */
+  operations?: TxnOperation[];
   /** Callback for resetting the entire transaction build flow. */
   onClearAll: () => void;
-  /** Optional class for the clear-all link to support page-specific styles. */
-  clearAllLinkClassName?: string;
 }
 
 /**
  * Shared header for transaction build steps with a Clear all action.
  *
  * @example
- * <BuildStepHeader heading="Submit transaction" headingAs="h1" onClearAll={resetAll} />
+ * <BuildStepHeader
+ *   heading="Submit transaction"
+ *   headingAs="h1"
+ *   activeStep="build"
+ *   xdr={builtXdr}
+ *   params={build.params}
+ *   operations={build.classic.operations}
+ *   onClearAll={resetAll}
+ *   xdr={builtXdr}
+ *   params={build.params}
+ *   operations={build.classic.operations} />
  */
 export const BuildStepHeader = ({
   heading,
   headingAs,
+  activeStep = "",
+  xdr,
+  params,
+  operations,
   onClearAll,
-  clearAllLinkClassName,
 }: BuildStepHeaderProps) => {
+  const showHeaderButtons = activeStep === "build" || activeStep === "import";
+  const [isSaveModalVisible, setIsSaveModalVisible] = useState(false);
+  const [isClearModalVisible, setIsClearModalVisible] = useState(false);
+
   return (
-    <Box gap="md" direction="row" justify="space-between" align="center">
+    <Box
+      gap="md"
+      direction="row"
+      justify="space-between"
+      align="center"
+      addlClassName="BuildTransaction__header"
+    >
       <PageHeader heading={heading} as={headingAs} />
 
-      <Link
-        variant="primary"
-        addlClassName={clearAllLinkClassName}
-        onClick={onClearAll}
-        size="xs"
-      >
-        Clear all
-      </Link>
+      {showHeaderButtons && (
+        <Box gap="sm" direction="row" justify="center" align="center">
+          <Button
+            size="md"
+            variant="tertiary"
+            onClick={() => setIsClearModalVisible(true)}
+          >
+            <IconButton
+              icon={<Icon.RefreshCcw01 />}
+              customSize="14px"
+              customColor="var(--sds-clr-gray-09)"
+              altText="Clear transaction"
+            />
+          </Button>
+
+          <Modal
+            visible={isClearModalVisible}
+            onClose={() => setIsClearModalVisible(false)}
+          >
+            <Modal.Heading>Clear everything?</Modal.Heading>
+            <Modal.Body>
+              This will remove all entered data in the form.
+            </Modal.Body>
+            <Modal.Footer>
+              <Button
+                size="md"
+                variant="tertiary"
+                onClick={() => setIsClearModalVisible(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="md"
+                variant="error"
+                onClick={() => {
+                  onClearAll();
+                  setIsClearModalVisible(false);
+                }}
+              >
+                Clear all
+              </Button>
+            </Modal.Footer>
+          </Modal>
+
+          <>
+            <Button
+              size="md"
+              variant="tertiary"
+              onClick={() => setIsSaveModalVisible(true)}
+            >
+              <IconButton
+                icon={<Icon.Save01 />}
+                customSize="14px"
+                customColor="var(--sds-clr-gray-09)"
+                altText="Save transaction"
+              />
+            </Button>
+
+            <SaveToLocalStorageModal
+              type="save"
+              itemTitle="Transaction"
+              itemProps={{
+                xdr: xdr || "",
+                page: "build",
+                ...(params ? { params } : {}),
+                ...(operations ? { operations } : {}),
+              }}
+              allSavedItems={localStorageSavedTransactions.get()}
+              isVisible={isSaveModalVisible}
+              onClose={() => {
+                setIsSaveModalVisible(false);
+              }}
+              onUpdate={(updatedItems) => {
+                localStorageSavedTransactions.set(updatedItems);
+              }}
+            />
+          </>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
+++ b/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
@@ -76,7 +76,7 @@ export const BuildStepHeader = ({
           data-testid="clear-all-button"
           onClick={() => setIsClearModalVisible(true)}
         >
-          <Icon.RefreshCcw01 />
+          <Icon.RefreshCw01 />
         </Button>
 
         <Modal

--- a/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
+++ b/src/app/(sidebar)/transaction/build/components/BuildStepHeader.tsx
@@ -113,6 +113,7 @@ export const BuildStepHeader = ({
             <Button
               size="md"
               variant="tertiary"
+              data-testid="save-to-local-storage-button"
               onClick={() => setIsSaveModalVisible(true)}
             >
               <Icon.Save01 />

--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect } from "react";
 import { Alert, Card } from "@stellar/design-system";
 
 import { useBuildFlowStore } from "@/store/createTransactionFlowStore";
@@ -36,6 +37,7 @@ export default function BuildTransaction() {
     highestCompletedStep,
     setActiveStep,
     goToNextStep,
+    markStepCompleted,
     resetAll,
   } = useBuildFlowStore();
 
@@ -92,6 +94,13 @@ export default function BuildTransaction() {
   };
 
   const isNextDisabled = getIsNextDisabled();
+
+  useEffect(() => {
+    if (!isNextDisabled && activeStep !== "submit") {
+      markStepCompleted(activeStep, steps);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isNextDisabled, activeStep]);
 
   const renderError = () => {
     if (paramsError.length > 0 || operationsError.length > 0) {

--- a/src/app/(sidebar)/transaction/build/page.tsx
+++ b/src/app/(sidebar)/transaction/build/page.tsx
@@ -59,7 +59,7 @@ export default function BuildTransaction() {
       : ["build", "simulate", "sign", "submit"]
     : ["build", "sign", "submit"];
 
-  const { handleNext, handleStepClick } = useTransactionFlow({
+  const { handleNext, handleBack, handleStepClick } = useTransactionFlow({
     steps,
     activeStep,
     highestCompletedStep,
@@ -152,7 +152,12 @@ export default function BuildTransaction() {
           resetAll();
           dismissLegacyAlert();
         }}
-        clearAllLinkClassName="resetButton"
+        xdr={currentXdr}
+        params={build.params}
+        activeStep={activeStep}
+        operations={
+          isSoroban ? [build.soroban.operation] : build.classic.operations
+        }
       />
 
       {isLegacyUrl ? (
@@ -207,14 +212,8 @@ export default function BuildTransaction() {
               steps={steps}
               activeStep={activeStep}
               onNext={handleNext}
+              onBack={handleBack}
               isNextDisabled={isNextDisabled}
-              xdr={currentXdr}
-              params={build.params}
-              operations={
-                isSoroban
-                  ? [build.soroban.operation]
-                  : build.classic.operations
-              }
             />
           </Box>
         </div>

--- a/src/app/(sidebar)/transaction/build/styles.scss
+++ b/src/app/(sidebar)/transaction/build/styles.scss
@@ -34,6 +34,12 @@
     .Button {
       width: pxToRem(32px);
       height: pxToRem(32px);
+
+      svg {
+        width: pxToRem(14px);
+        height: pxToRem(14px);
+        color: var(--sds-clr-gray-09);
+      }
     }
 
     .Link {

--- a/src/app/(sidebar)/transaction/build/styles.scss
+++ b/src/app/(sidebar)/transaction/build/styles.scss
@@ -34,6 +34,7 @@
     .Button {
       width: pxToRem(32px);
       height: pxToRem(32px);
+      padding: 0;
 
       svg {
         width: pxToRem(14px);

--- a/src/app/(sidebar)/transaction/build/styles.scss
+++ b/src/app/(sidebar)/transaction/build/styles.scss
@@ -31,10 +31,10 @@
   }
 
   &__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding-bottom: pxToRem(16px);
+    .Button {
+      width: pxToRem(32px);
+      height: pxToRem(32px);
+    }
 
     .Link {
       color: var(--sds-clr-lilac-11);

--- a/src/components/TransactionFlowFooter/index.tsx
+++ b/src/components/TransactionFlowFooter/index.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { useState } from "react";
 import { Button, Icon } from "@stellar/design-system";
 
-import { localStorageSavedTransactions } from "@/helpers/localStorageSavedTransactions";
-
-import { SaveToLocalStorageModal } from "@/components/SaveToLocalStorageModal";
 import {
   TransactionStepName,
   getStepLabel,
 } from "@/components/TransactionStepper";
-
-import { TransactionBuildParams } from "@/store/createTransactionFlowStore";
-import { TxnOperation } from "@/types/types";
 
 import "./styles.scss";
 
@@ -24,9 +17,6 @@ import "./styles.scss";
  * @param activeStep - The currently active step
  * @param onNext - Callback to advance to the next step
  * @param isNextDisabled - Whether the Next button should be disabled
- * @param xdr - Built XDR string, used for saving on the build/import step
- * @param params - Transaction build params for saving
- * @param operations - Transaction operations for saving
  *
  * @example
  * <TransactionFlowFooter
@@ -34,82 +24,54 @@ import "./styles.scss";
  *   activeStep="build"
  *   onNext={handleNext}
  *   isNextDisabled={!isValid}
- *   xdr={builtXdr}
- *   params={build.params}
- *   operations={build.classic.operations}
  * />
  */
 export const TransactionFlowFooter = ({
   steps,
   activeStep,
   onNext,
+  onBack,
   isNextDisabled,
-  xdr,
-  params,
-  operations,
 }: {
   steps: TransactionStepName[];
   activeStep: TransactionStepName;
   onNext?: () => void;
+  onBack?: () => void;
   isNextDisabled: boolean;
-  xdr?: string;
-  params?: TransactionBuildParams;
-  operations?: TxnOperation[];
 }) => {
-  const [isSaveModalVisible, setIsSaveModalVisible] = useState(false);
-
   const currentIndex = steps.indexOf(activeStep);
+  const isFirstStep = currentIndex === 0;
   const isLastStep = currentIndex === steps.length - 1;
-  const showSaveButton = activeStep === "build" || activeStep === "import";
 
+  const prevStep = !isFirstStep ? steps[currentIndex - 1] : null;
   const nextStep = !isLastStep ? steps[currentIndex + 1] : null;
 
   return (
     <div className="TransactionFlowFooter">
-      <div className="TransactionFlowFooter__nav">
-        {nextStep && (
-          <Button
-            size="md"
-            variant="secondary"
-            onClick={onNext}
-            disabled={isNextDisabled}
-          >
-            {`Next: ${getStepLabel(nextStep)}`}
-          </Button>
-        )}
-      </div>
-
-      {showSaveButton && (
-        <>
-          <Button
-            size="md"
-            variant="tertiary"
-            icon={<Icon.Save01 />}
-            iconPosition="right"
-            onClick={() => setIsSaveModalVisible(true)}
-          >
-            Save transaction
-          </Button>
-
-          <SaveToLocalStorageModal
-            type="save"
-            itemTitle="Transaction"
-            itemProps={{
-              xdr: xdr || "",
-              page: "build",
-              ...(params ? { params } : {}),
-              ...(operations ? { operations } : {}),
-            }}
-            allSavedItems={localStorageSavedTransactions.get()}
-            isVisible={isSaveModalVisible}
-            onClose={() => {
-              setIsSaveModalVisible(false);
-            }}
-            onUpdate={(updatedItems) => {
-              localStorageSavedTransactions.set(updatedItems);
-            }}
-          />
-        </>
+      {prevStep && (
+        <Button
+          size="md"
+          variant="tertiary"
+          icon={<Icon.ArrowLeft />}
+          iconPosition="left"
+          onClick={onBack}
+          data-position="left"
+        >
+          {`${getStepLabel(prevStep)}`}
+        </Button>
+      )}
+      {nextStep && (
+        <Button
+          size="md"
+          variant="secondary"
+          icon={<Icon.ArrowRight />}
+          iconPosition="right"
+          onClick={onNext}
+          disabled={isNextDisabled}
+          data-position="right"
+        >
+          {`${getStepLabel(nextStep)}`}
+        </Button>
       )}
     </div>
   );

--- a/src/components/TransactionFlowFooter/styles.scss
+++ b/src/components/TransactionFlowFooter/styles.scss
@@ -2,12 +2,14 @@
 
 .TransactionFlowFooter {
   display: flex;
+  width: 100%;
   align-items: center;
-  justify-content: space-between;
 
-  &__nav {
-    display: flex;
-    align-items: center;
-    gap: pxToRem(8px);
+  [data-position="left"] {
+    margin-right: auto;
+  }
+
+  [data-position="right"] {
+    margin-left: auto;
   }
 }

--- a/src/components/TransactionStepper/index.tsx
+++ b/src/components/TransactionStepper/index.tsx
@@ -77,7 +77,11 @@ export const TransactionStepper = ({
       {steps.map((step, index) => {
         const isActive = step === activeStep;
         const isCompleted = index <= highestCompletedIndex;
-        const isClickable = isCompleted && !isActive;
+        // The step immediately after the highest completed step is accessible
+        // but not yet completed — no checkmark, but clickable.
+        const isAccessible =
+          !isCompleted && index === highestCompletedIndex + 1;
+        const isClickable = (isCompleted || isAccessible) && !isActive;
         const isLast = index === steps.length - 1;
 
         return (
@@ -87,6 +91,7 @@ export const TransactionStepper = ({
             className="TransactionStepper__step"
             data-is-active={isActive || undefined}
             data-is-completed={isCompleted || undefined}
+            data-is-accessible={isAccessible || undefined}
             data-is-clickable={isClickable || undefined}
             data-has-description={!!STEP_DESCRIPTIONS[step] || undefined}
             onClick={isClickable ? () => onStepClick(step) : undefined}

--- a/src/components/TransactionStepper/styles.scss
+++ b/src/components/TransactionStepper/styles.scss
@@ -44,6 +44,10 @@
     [data-is-completed="true"]
       > .TransactionStepper__indicator
       > .TransactionStepper__badgeWrapper
+      > &,
+    [data-is-accessible="true"]
+      > .TransactionStepper__indicator
+      > .TransactionStepper__badgeWrapper
       > & {
       color: var(--sds-clr-gray-12);
     }
@@ -97,7 +101,8 @@
     }
 
     [data-is-active="true"] > &,
-    [data-is-completed="true"] > & {
+    [data-is-completed="true"] > &,
+    [data-is-accessible="true"] > & {
       color: var(--sds-clr-gray-12);
     }
 

--- a/src/hooks/useTransactionFlow.ts
+++ b/src/hooks/useTransactionFlow.ts
@@ -42,6 +42,11 @@ export const useTransactionFlow = ({
     : -1;
 
   const handleNext = () => goToNextStep(steps);
+  const handleBack = () => {
+    if (stepIndex > 0) {
+      setActiveStep(steps[stepIndex - 1]);
+    }
+  };
   const handleStepClick = (step: TransactionStepName) => {
     if (steps.indexOf(step) <= highestCompletedIndex) {
       setActiveStep(step);
@@ -52,6 +57,7 @@ export const useTransactionFlow = ({
     highestCompletedStep,
     stepIndex,
     handleNext,
+    handleBack,
     handleStepClick,
   };
 };

--- a/src/hooks/useTransactionFlow.ts
+++ b/src/hooks/useTransactionFlow.ts
@@ -48,7 +48,7 @@ export const useTransactionFlow = ({
     }
   };
   const handleStepClick = (step: TransactionStepName) => {
-    if (steps.indexOf(step) <= highestCompletedIndex) {
+    if (steps.indexOf(step) <= highestCompletedIndex + 1) {
       setActiveStep(step);
     }
   };

--- a/src/store/createTransactionFlowStore.ts
+++ b/src/store/createTransactionFlowStore.ts
@@ -115,6 +115,16 @@ interface TransactionFlowActions {
    */
   goToNextStep: (steps: TransactionStepName[]) => void;
 
+  /**
+   * Mark a step as completed without changing activeStep. Used to
+   * auto-enable stepper navigation when the current step becomes valid
+   * before the user clicks Next.
+   */
+  markStepCompleted: (
+    step: TransactionStepName,
+    steps: TransactionStepName[],
+  ) => void;
+
   setBuildParams: (params: TransactionBuildParamsObj) => void;
 
   setBuildSorobanOperation: (operation: TxnOperation) => void;
@@ -324,6 +334,17 @@ const createTransactionFlowStore = (
               if (currentIndex > highestIndex) {
                 state.highestCompletedStep = steps[currentIndex];
               }
+            }
+          }),
+
+        markStepCompleted: (step, steps) =>
+          set((state) => {
+            const stepIndex = steps.indexOf(step);
+            const highestIndex = state.highestCompletedStep
+              ? steps.indexOf(state.highestCompletedStep)
+              : -1;
+            if (stepIndex > highestIndex) {
+              state.highestCompletedStep = step;
             }
           }),
 

--- a/tests/e2e/buildTransaction.test.ts
+++ b/tests/e2e/buildTransaction.test.ts
@@ -1374,7 +1374,7 @@ test.describe("Build Transaction Page", () => {
         // In the new flow, extend_footprint_ttl does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
         const nextButton = page.getByRole("button", {
-          name: /Next: Simulate/,
+          name: /Simulate/,
         });
         await expect(nextButton).toBeEnabled();
       });
@@ -1494,7 +1494,7 @@ test.describe("Build Transaction Page", () => {
         // In the new flow, extend_footprint_ttl does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
         const nextButton = page.getByRole("button", {
-          name: /Next: Simulate/,
+          name: /Simulate/,
         });
         await expect(nextButton).toBeEnabled();
       });
@@ -1687,7 +1687,7 @@ test.describe("Build Transaction Page", () => {
         // In the new flow, restore_footprint does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
         const nextButton = page.getByRole("button", {
-          name: /Next: Simulate/,
+          name: /Simulate/,
         });
         await expect(nextButton).toBeEnabled();
       });
@@ -1805,7 +1805,7 @@ test.describe("Build Transaction Page", () => {
         // In the new flow, restore_footprint does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
         const nextButton = page.getByRole("button", {
-          name: /Next: Simulate/,
+          name: /Simulate/,
         });
         await expect(nextButton).toBeEnabled();
       });

--- a/tests/e2e/buildTransaction.test.ts
+++ b/tests/e2e/buildTransaction.test.ts
@@ -41,12 +41,7 @@ test.describe("Build Transaction Page", () => {
     await operation_0.getByLabel("Destination").fill(ACCOUNT_ONE);
     await operation_0.getByLabel("Starting balance").fill("1");
 
-    const saveTxButton = page.getByRole("button", {
-      name: "Save transaction",
-    });
-
-    await expect(saveTxButton).toBeVisible();
-    await saveTxButton.click();
+    await page.getByTestId("save-to-local-storage-button").click();
 
     const modal = page.locator(".Modal");
 

--- a/tests/e2e/buildTransaction.test.ts
+++ b/tests/e2e/buildTransaction.test.ts
@@ -126,7 +126,8 @@ test.describe("Build Transaction Page", () => {
 
       // Clear params
       await expect(paramsErrors).toBeHidden();
-      await page.getByText("Clear all").click();
+      await page.getByTestId("clear-all-button").click();
+      await page.getByRole("button", { name: "Clear all" }).click();
       await expect(paramsErrors).toBeVisible();
     });
 
@@ -1373,9 +1374,7 @@ test.describe("Build Transaction Page", () => {
 
         // In the new flow, extend_footprint_ttl does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
-        const nextButton = page.getByRole("button", {
-          name: /Simulate/,
-        });
+        const nextButton = page.locator('[data-position="right"]');
         await expect(nextButton).toBeEnabled();
       });
 
@@ -1493,9 +1492,7 @@ test.describe("Build Transaction Page", () => {
 
         // In the new flow, extend_footprint_ttl does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
-        const nextButton = page.getByRole("button", {
-          name: /Simulate/,
-        });
+        const nextButton = page.locator('[data-position="right"]');
         await expect(nextButton).toBeEnabled();
       });
 
@@ -1686,9 +1683,7 @@ test.describe("Build Transaction Page", () => {
 
         // In the new flow, restore_footprint does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
-        const nextButton = page.getByRole("button", {
-          name: /Simulate/,
-        });
+        const nextButton = page.locator('[data-position="right"]');
         await expect(nextButton).toBeEnabled();
       });
 
@@ -1804,9 +1799,7 @@ test.describe("Build Transaction Page", () => {
 
         // In the new flow, restore_footprint does not produce XDR on
         // the build step — verify the Next button is enabled (form valid).
-        const nextButton = page.getByRole("button", {
-          name: /Simulate/,
-        });
+        const nextButton = page.locator('[data-position="right"]');
         await expect(nextButton).toBeEnabled();
       });
 

--- a/tests/e2e/signStepContent.test.ts
+++ b/tests/e2e/signStepContent.test.ts
@@ -103,7 +103,7 @@ test.describe("Sign Step in Build Flow", () => {
     await expect(page.locator("h1")).toHaveText("Sign transaction");
 
     const nextButton = page.getByRole("button", {
-      name: "Next: Submit transaction",
+      name: "Submit transaction",
     });
     await expect(nextButton).toBeDisabled();
   });
@@ -144,7 +144,7 @@ test.describe("Sign Step in Build Flow", () => {
 
     // Next button should now be enabled
     const nextButton = page.getByRole("button", {
-      name: "Next: Submit transaction",
+      name: "Submit transaction",
     });
     await expect(nextButton).toBeEnabled();
   });

--- a/tests/e2e/signStepContent.test.ts
+++ b/tests/e2e/signStepContent.test.ts
@@ -102,9 +102,7 @@ test.describe("Sign Step in Build Flow", () => {
     // Wait for the sign step to hydrate from sessionStorage
     await expect(page.locator("h1")).toHaveText("Sign transaction");
 
-    const nextButton = page.getByRole("button", {
-      name: "Submit transaction",
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeDisabled();
   });
 
@@ -143,9 +141,7 @@ test.describe("Sign Step in Build Flow", () => {
     // await expect(page.getByText("Wrap with fee bump")).toBeVisible();
 
     // Next button should now be enabled
-    const nextButton = page.getByRole("button", {
-      name: "Submit transaction",
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeEnabled();
   });
 
@@ -166,8 +162,9 @@ test.describe("Sign Step in Build Flow", () => {
       page.getByText("Transaction signed and ready to submit."),
     ).toBeVisible();
 
-    // Click Clear all
-    await page.getByText("Clear all").click();
+    // Click Clear all (opens confirmation modal, then confirm)
+    await page.getByTestId("clear-all-button").click();
+    await page.getByRole("button", { name: "Clear all" }).click();
 
     // Should reset to build step
     await expect(page.locator("h1")).toHaveText("Build transaction");

--- a/tests/e2e/simulateStepContent.test.ts
+++ b/tests/e2e/simulateStepContent.test.ts
@@ -141,9 +141,7 @@ test.describe("Simulate Step — Re-simulation clears stale state", () => {
 
     // Precondition: Next button should be enabled because stale
     // assembledXdr exists from the previous simulation.
-    const nextButton = page.getByRole("button", {
-      name: /^Next:/,
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeEnabled();
 
     // Re-simulate
@@ -195,9 +193,7 @@ test.describe("Simulate Step — Source account auth entries skip signing", () =
     ).not.toBeVisible();
 
     // Next button should be ENABLED — auto-assembly happened
-    const nextButton = page.getByRole("button", {
-      name: /^Next:/,
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeEnabled();
   });
 
@@ -244,9 +240,7 @@ test.describe("Simulate Step — Source account auth entries skip signing", () =
     await expect(entry2.getByText("Unsigned")).toBeVisible();
 
     // Next button should be DISABLED — address entry still needs signing
-    const nextButton = page.getByRole("button", {
-      name: /^Next:/,
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeDisabled();
   });
 });

--- a/tests/e2e/validateStepContent.test.ts
+++ b/tests/e2e/validateStepContent.test.ts
@@ -162,7 +162,10 @@ test.describe("Validate Step in Build Flow", () => {
   }) => {
     await seedSessionStorageAndNavigate(page);
 
-    const validateButton = page.getByRole("button", { name: "Validate", exact: true });
+    const validateButton = page.getByRole("button", {
+      name: "Validate",
+      exact: true,
+    });
     await expect(validateButton).toBeEnabled();
   });
 
@@ -172,7 +175,10 @@ test.describe("Validate Step in Build Flow", () => {
     await mockEnforceSimulationSuccess(page);
     await seedSessionStorageAndNavigate(page);
 
-    const validateButton = page.getByRole("button", { name: "Validate", exact: true });
+    const validateButton = page.getByRole("button", {
+      name: "Validate",
+      exact: true,
+    });
     await validateButton.click();
 
     // Wait for success alert
@@ -192,7 +198,10 @@ test.describe("Validate Step in Build Flow", () => {
     await mockEnforceSimulationFailure(page);
     await seedSessionStorageAndNavigate(page);
 
-    const validateButton = page.getByRole("button", { name: "Validate", exact: true });
+    const validateButton = page.getByRole("button", {
+      name: "Validate",
+      exact: true,
+    });
     await validateButton.click();
 
     await expect(page.getByText("Validation failed")).toBeVisible();
@@ -204,7 +213,10 @@ test.describe("Validate Step in Build Flow", () => {
     await mockEnforceSimulationSuccess(page);
     await seedSessionStorageAndNavigate(page);
 
-    const validateButton = page.getByRole("button", { name: "Validate", exact: true });
+    const validateButton = page.getByRole("button", {
+      name: "Validate",
+      exact: true,
+    });
     await validateButton.click();
 
     await expect(
@@ -236,7 +248,7 @@ test.describe("Validate Step in Build Flow", () => {
     await seedSessionStorageAndNavigate(page);
 
     const nextButton = page.getByRole("button", {
-      name: "Next: Submit transaction",
+      name: "Submit transaction",
     });
     await expect(nextButton).toBeDisabled();
   });
@@ -247,14 +259,17 @@ test.describe("Validate Step in Build Flow", () => {
     await mockEnforceSimulationSuccess(page);
     await seedSessionStorageAndNavigate(page);
 
-    const validateButton = page.getByRole("button", { name: "Validate", exact: true });
+    const validateButton = page.getByRole("button", {
+      name: "Validate",
+      exact: true,
+    });
     await validateButton.click();
 
     // Wait for success
     await expect(page.getByText("Auth entries validated")).toBeVisible();
 
     const nextButton = page.getByRole("button", {
-      name: "Next: Submit transaction",
+      name: "Submit transaction",
     });
     await expect(nextButton).toBeEnabled();
   });

--- a/tests/e2e/validateStepContent.test.ts
+++ b/tests/e2e/validateStepContent.test.ts
@@ -247,9 +247,7 @@ test.describe("Validate Step in Build Flow", () => {
   test("Next button is disabled before validation", async ({ page }) => {
     await seedSessionStorageAndNavigate(page);
 
-    const nextButton = page.getByRole("button", {
-      name: "Submit transaction",
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeDisabled();
   });
 
@@ -268,9 +266,7 @@ test.describe("Validate Step in Build Flow", () => {
     // Wait for success
     await expect(page.getByText("Auth entries validated")).toBeVisible();
 
-    const nextButton = page.getByRole("button", {
-      name: "Submit transaction",
-    });
+    const nextButton = page.locator('[data-position="right"]');
     await expect(nextButton).toBeEnabled();
   });
 });


### PR DESCRIPTION
- Move `Save transaction` from footer to the top in only icon format
- Change `clear all` text button to a clear icon with a warning modal popup upon click

<img width="1003" height="426" alt="header" src="https://github.com/user-attachments/assets/91b69084-51b6-413c-b189-eecd3c218832" />

<img width="795" height="367" alt="header-modal" src="https://github.com/user-attachments/assets/b1b2c6bc-d9c7-41d8-b631-25269435622e" />

- Removed `Next:` to keep just the next step. 
- Added a Back button

<img width="769" height="407" alt="Screenshot 2026-04-17 at 6 50 59 PM" src="https://github.com/user-attachments/assets/107a533d-5c3d-43d6-a325-7da3db0dee33" />

5. The next step in side stepper gets enabled once the current step's form is filled and returned success message. This logic is based on whether the next step in the footer is enabled or not