### PR TITLE
Update <TabView/>

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-list/page.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-list/page.tsx
@@ -60,15 +60,15 @@ export default function ContractList() {
         <Box gap="lg" addlClassName="TabView">
           <div className="TabView__heading">
             <PageHeader heading="Smart contract list" />
-            <div className="TabView__tabContainer">
-              <Tabs
-                tabs={[{ id: "recent", label: "Recent" }]}
-                activeTabId="recent"
-                onChange={() => {
-                  // Single tab - no action needed
-                }}
-              />
-            </div>
+          </div>
+          <div className="TabView__tabContainer">
+            <Tabs
+              tabs={[{ id: "recent", label: "Recent" }]}
+              activeTabId="recent"
+              onChange={() => {
+                // Single tab - no action needed
+              }}
+            />
           </div>
           <div className="TabView__content">
             {/* data-is-active is required for TabView CSS styling */}

--- a/src/components/TabView/index.tsx
+++ b/src/components/TabView/index.tsx
@@ -51,9 +51,9 @@ export const TabView = ({
 
   return (
     <Box gap="lg" addlClassName="TabView">
-      <div className="TabView__heading">
-        {heading ? <TabViewHeading {...heading} /> : null}
+      {heading ? <TabViewHeading {...heading} /> : null}
 
+      <div className="TabView__heading">
         <div className="TabView__tabContainer">
           <Tabs
             tabs={tabItems}


### PR DESCRIPTION
Tabs are now listed below the heading:
<img width="1214" height="808" alt="after" src="https://github.com/user-attachments/assets/9135beb2-4470-4621-b463-944980c838b7" />

before:
<img width="1213" height="810" alt="before" src="https://github.com/user-attachments/assets/c540a55b-fb65-4eda-8acd-eaa03bb50770" />
