### PR TITLE
Invoke Contract's Simulated Response to use CodeEditor header 

### DIFF
--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
@@ -32,7 +32,6 @@ import { JsonSchemaRenderer } from "@/components/SmartContractJsonSchema/JsonSch
 import { TransactionSuccessCard } from "@/components/TransactionSuccessCard";
 import { WalletKitContext } from "@/components/WalletKit/WalletKitContextProvider";
 import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
-import { TabView } from "@/components/TabView";
 import { CodeEditor, SupportedLanguage } from "@/components/CodeEditor";
 
 import { TransactionBuildParams } from "@/store/createStore";
@@ -636,33 +635,13 @@ export const InvokeContractForm = ({
   const renderResponse = () => {
     if (jsonResponse?.fullResponse || base64Response?.fullResponse) {
       return (
-        <TabView
-          tab1={{
-            id: "json",
-            label: "JSON",
-            content: jsonResponse?.fullResponse && (
-              <SimulatedResponse
-                xdrFormat="json"
-                result={jsonResponse}
-                isFullResponseEnabled={isFullResponseEnabled}
-              />
-            ),
-            isDisabled: !jsonResponse?.fullResponse,
-          }}
-          tab2={{
-            id: "base64",
-            label: "Base64",
-            content: base64Response?.fullResponse && (
-              <SimulatedResponse
-                xdrFormat="xdr"
-                result={base64Response}
-                isFullResponseEnabled={isFullResponseEnabled}
-              />
-            ),
-            isDisabled: !base64Response?.fullResponse,
-          }}
-          activeTabId={xdrFormat}
-          onTabChange={(id) => {
+        <SimulatedResponse
+          xdrFormat={xdrFormat}
+          result={xdrFormat === "json" ? jsonResponse : base64Response}
+          isFullResponseEnabled={isFullResponseEnabled}
+          onFullResponseChange={setIsFullResponseEnabled}
+          funcName={funcName}
+          onLanguageChange={(id) => {
             setXdrFormat(id);
             trackEvent(
               TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SELECTED_XDR_FORMAT,
@@ -671,13 +650,6 @@ export const InvokeContractForm = ({
               },
             );
           }}
-          rightElement={
-            <FullResponseToggle
-              isChecked={isFullResponseEnabled}
-              onChange={setIsFullResponseEnabled}
-              id={funcName}
-            />
-          }
         />
       );
     }
@@ -842,11 +814,17 @@ export const FullResponseToggle = ({
 export const SimulatedResponse = ({
   result,
   isFullResponseEnabled = false,
+  onFullResponseChange,
+  funcName,
   xdrFormat,
+  onLanguageChange,
 }: {
   result: SimulatedResponseType | null;
   isFullResponseEnabled: boolean;
+  onFullResponseChange: (isChecked: boolean) => void;
+  funcName: string;
   xdrFormat: string;
+  onLanguageChange: (format: string) => void;
 }) => {
   if (!result) {
     return null;
@@ -867,10 +845,20 @@ export const SimulatedResponse = ({
     <Box gap="md">
       <div data-testid="invoke-contract-simulate-tx-response">
         <CodeEditor
+          title="Simulated result"
+          languages={["json", "xdr"]}
+          onLanguageChange={onLanguageChange}
+          selectedLanguage={selectedLanguage}
+          customEl={
+            <FullResponseToggle
+              isChecked={isFullResponseEnabled}
+              onChange={onFullResponseChange}
+              id={funcName}
+            />
+          }
           key={`code-editor-${isFullResponseEnabled}`}
           isAutoHeight={!isFullResponseEnabled}
           value={JSON.stringify(json, null, 2)}
-          selectedLanguage={selectedLanguage}
           maxHeightInRem="20"
         />
       </div>

--- a/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
+++ b/src/app/(sidebar)/smart-contracts/contract-explorer/components/InvokeContractForm.tsx
@@ -86,7 +86,7 @@ export const InvokeContractForm = ({
     methodType: string;
   } | null>(null);
   const [isExtensionLoading, setIsExtensionLoading] = useState(false);
-  const [xdrFormat, setXdrFormat] = useState<XdrFormatType | string>("json");
+  const [xdrFormat, setXdrFormat] = useState<XdrFormatType>("json");
   const [formValue, setFormValue] = useState<SorobanInvokeValue>({
     contract_id: contractId,
     function_name: funcName,
@@ -642,11 +642,13 @@ export const InvokeContractForm = ({
           onFullResponseChange={setIsFullResponseEnabled}
           funcName={funcName}
           onLanguageChange={(id) => {
-            setXdrFormat(id);
+            const selectedValue = id === "xdr" ? "base64" : "json";
+
+            setXdrFormat(selectedValue);
             trackEvent(
               TrackingEvent.SMART_CONTRACTS_EXPLORER_INVOKE_CONTRACT_SELECTED_XDR_FORMAT,
               {
-                xdrFormat: id,
+                xdrFormat: selectedValue,
               },
             );
           }}
@@ -823,7 +825,7 @@ export const SimulatedResponse = ({
   isFullResponseEnabled: boolean;
   onFullResponseChange: (isChecked: boolean) => void;
   funcName: string;
-  xdrFormat: string;
+  xdrFormat: XdrFormatType;
   onLanguageChange: (format: string) => void;
 }) => {
   if (!result) {


### PR DESCRIPTION
Bring back the header with a custom component and dropdown for language
<img width="1119" height="439" alt="Screenshot 2026-06-30 at 5 05 07 PM" src="https://github.com/user-attachments/assets/b1ed76b2-1854-4a88-8c22-a42a2d86f017" />

Before:
<img width="1104" height="260" alt="Screenshot 2026-06-30 at 5 06 10 PM" src="https://github.com/user-attachments/assets/5df17c78-f390-4aaf-a68f-08f4e159e0cd" />
