### PR TITLE
build transaction - read memo by `object.entries`

### DIFF
--- a/src/app/(sidebar)/transaction/build/components/ClassicTransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/ClassicTransactionXdr.tsx
@@ -87,16 +87,20 @@ export const ClassicTransactionXdr = () => {
             }
             break;
           case "memo":
-            // eslint-disable-next-line no-case-declarations
-            const memoId = value?.id;
-
-            if (memoId) {
-              val = { id: BigInt(memoId) };
+            if (typeof value !== "object" || isEmptyObject(value)) {
+              val = "none";
             } else {
+              // Read the memo by its first entry — the same key the form
+              // displays (Params.tsx getMemoPickerValue). Do NOT special-case
+              // `value.id` by key: hydrated state can carry extra params keys,
+              // so an injected key ordered before the real one would let the
+              // encoded memo differ from the one shown in the form.
+              // eslint-disable-next-line no-case-declarations
+              const [memoType, memoVal] = Object.entries(value)[0];
               val =
-                typeof value === "object" && isEmptyObject(value)
-                  ? "none"
-                  : value;
+                memoType === "id"
+                  ? { id: BigInt(memoVal as string) }
+                  : { [memoType]: memoVal };
             }
 
             break;

--- a/src/app/(sidebar)/transaction/build/components/ClassicTransactionXdr.tsx
+++ b/src/app/(sidebar)/transaction/build/components/ClassicTransactionXdr.tsx
@@ -87,7 +87,11 @@ export const ClassicTransactionXdr = () => {
             }
             break;
           case "memo":
-            if (typeof value !== "object" || isEmptyObject(value)) {
+            if (
+              value === null ||
+              typeof value !== "object" ||
+              isEmptyObject(value)
+            ) {
               val = "none";
             } else {
               // Read the memo by its first entry — the same key the form

--- a/src/app/(sidebar)/transaction/build/components/Params.tsx
+++ b/src/app/(sidebar)/transaction/build/components/Params.tsx
@@ -165,12 +165,21 @@ export const Params = () => {
   };
 
   const getMemoPickerValue = () => {
-    return typeof txnParams.memo === "string"
-      ? { type: txnParams.memo, value: "" }
-      : {
-          type: Object.keys(txnParams.memo)[0],
-          value: Object.values(txnParams.memo)[0],
-        };
+    if (typeof txnParams.memo === "string") {
+      return { type: txnParams.memo, value: "" };
+    }
+
+    // Guard against null / non-object memo from hydrated state (e.g. a crafted
+    // `memo:null` querystring). Treat it like the default empty memo.
+    const memo =
+      txnParams.memo && typeof txnParams.memo === "object"
+        ? txnParams.memo
+        : {};
+
+    return {
+      type: Object.keys(memo)[0],
+      value: Object.values(memo)[0],
+    };
   };
 
   const getMemoValue = (memo?: MemoPickerValue) => {
@@ -234,6 +243,7 @@ export const Params = () => {
     const memoValue = txnParams.memo;
 
     if (
+      memoValue &&
       typeof memoValue === "object" &&
       !isEmptyObject(memoValue) &&
       !Object.values(memoValue)[0]

--- a/tests/e2e/buildTransaction.test.ts
+++ b/tests/e2e/buildTransaction.test.ts
@@ -1953,6 +1953,44 @@ test.describe("Build Transaction Page", () => {
       );
     });
   });
+
+  // Security regression: the transaction memo must be encoded as the type the
+  // form displays. A crafted share link can inject an extra memo key (e.g.
+  // { text: "…", id: "…" }); the form shows the first entry (Text) while a
+  // by-key `value.id` read would encode a numeric ID memo instead — signing a
+  // different memo than the one shown, which can misroute custodial deposits.
+  test.describe("Memo — hydrated params", () => {
+    // params.memo { text: "benign note", id: "666" }, "text" ordered first,
+    // serialized via zustand-querystring the same way the store hydrates it.
+    const CRAFTED_QUERYSTRING =
+      "$=transaction$build$classic$operations@$operation_type=account_merge&source_account=&params$destination=GC3N3GAECL3PJOWIKAAKPOB677WHCUNWZRULANQMHEIL4WDX5FICMF3I;;;;&params$source_account=GAGSY6UVUIINHRHSSDO7NMCM7ADWUF5UJ4ZGGJSFSXKWNJDRW6AA4H3Q&fee=100&seq_num=4466559829409793&cond$time$min_time=&max_time=;;&memo$text=benign%20note&id=666;;&isValid$params:true&operations:true;;";
+
+    test("encodes the displayed memo type, not an injected key", async ({
+      page,
+    }) => {
+      await page.goto(`${baseURL}/transaction/build?${CRAFTED_QUERYSTRING}`);
+
+      // The form shows a Text memo "benign note" (the first entry), not "666".
+      await expect(page.locator("#memo_value")).toHaveValue("benign note");
+
+      // The built XDR must carry that Text memo — never a MEMO_ID 666. A by-key
+      // `value.id` read would encode the injected id and diverge from the form.
+      const txnSuccess = page.getByTestId("build-transaction-envelope-xdr");
+      await expect(txnSuccess).toBeVisible();
+      const xdr = await txnSuccess
+        .getByText("XDR")
+        .locator("+ div")
+        .textContent();
+
+      const decoded = TransactionBuilder.fromXDR(
+        xdr ?? "",
+        Networks.TESTNET,
+      ) as any;
+      expect(decoded.memo.type).toBe("text");
+      expect(decoded.memo.value?.toString()).toBe("benign note");
+      expect(decoded.memo.type).not.toBe("id");
+    });
+  });
 });
 
 // =============================================================================

--- a/tests/e2e/buildTransaction.test.ts
+++ b/tests/e2e/buildTransaction.test.ts
@@ -1990,6 +1990,29 @@ test.describe("Build Transaction Page", () => {
       expect(decoded.memo.value?.toString()).toBe("benign note");
       expect(decoded.memo.type).not.toBe("id");
     });
+
+    // A crafted link can hydrate memo as null (lodash merge overrides the
+    // default {} with null). The build page must not crash — the form treats
+    // it as no memo and the built XDR encodes memo "none".
+    const NULL_MEMO_QUERYSTRING =
+      "$=transaction$build$classic$operations@$operation_type=account_merge&source_account=&params$destination=GC3N3GAECL3PJOWIKAAKPOB677WHCUNWZRULANQMHEIL4WDX5FICMF3I;;;;&params$source_account=GAGSY6UVUIINHRHSSDO7NMCM7ADWUF5UJ4ZGGJSFSXKWNJDRW6AA4H3Q&fee=100&seq_num=4466559829409793&cond$time$min_time=&max_time=;;&memo:null;&isValid$params:true&operations:true;;";
+
+    test("builds with no memo when memo hydrates as null", async ({ page }) => {
+      await page.goto(`${baseURL}/transaction/build?${NULL_MEMO_QUERYSTRING}`);
+
+      const txnSuccess = page.getByTestId("build-transaction-envelope-xdr");
+      await expect(txnSuccess).toBeVisible();
+      const xdr = await txnSuccess
+        .getByText("XDR")
+        .locator("+ div")
+        .textContent();
+
+      const decoded = TransactionBuilder.fromXDR(
+        xdr ?? "",
+        Networks.TESTNET,
+      ) as any;
+      expect(decoded.memo.type).toBe("none");
+    });
   });
 });
 


### PR DESCRIPTION
Test URL (local dev — this branch has the fix):
- to see bug in action: https://lab.stellar.org/transaction/build?$=transaction$build$classic$operations@$operation_type=payment&source_account=&params$destination=GAHMHPWM5JQW3FGXO4YT66L7JYP226LMPDQKEWY5BOB2GHQH5D3DAR7A&asset$type=native&code=&issuer=;&amount=100;;;;&params$source_account=GBQLLGYQCGCJITNGS3NZJKGLN6AXNYU35KHDXWDSXUZ4YED6A47GTW6J&fee=100&seq_num=1&cond$time$min_time=&max_time=;;&memo$text=deposit%20note&id=6011000990139424;;&isValid$params:true&operations:true;;
- use staging link: transaction/build?$=transaction$build$classic$operations@$operation_type=payment&source_account=&params$destination=GAHMHPWM5JQW3FGXO4YT66L7JYP226LMPDQKEWY5BOB2GHQH5D3DAR7A&asset$type=native&code=&issuer=;&amount=100;;;;&params$source_account=GBQLLGYQCGCJITNGS3NZJKGLN6AXNYU35KHDXWDSXUZ4YED6A47GTW6J&fee=100&seq_num=1&cond$time$min_time=&max_time=;;&memo$text=deposit%20note&id=6011000990139424;;&isValid$params:true&operations:true;;

What to expect:
- The memo picker shows Type: Text, value "deposit note" (the benign first key).
- Scroll to the built XDR panel or go to the Submit step's decoded "Transaction envelope" JSON:
  - On the staging link: memo is text: "deposit note" — matches the form. ✅ The fix holds.
  - On prod: memo would be `MEMO_ID 6011000990139424` — the swap. That's the bug