### PR TITLE
fix(sorobanUtils): decode Bytes struct fields so struct args build

### DIFF
--- a/src/helpers/sorobanUtils.ts
+++ b/src/helpers/sorobanUtils.ts
@@ -428,6 +428,13 @@ const convertPrimitiveField = (field: any) => {
       typeHint: ["symbol"],
     };
   }
+  if (field.type === "bytes") {
+    const encoding = detectBytesEncoding(field.value);
+    return {
+      value: new Uint8Array(Buffer.from(field.value, encoding)),
+      typeHint: ["symbol", "bytes"],
+    };
+  }
   return {
     value: field.value,
     typeHint: ["symbol", field.type],

--- a/tests/unit/getScValsFromArgs.test.ts
+++ b/tests/unit/getScValsFromArgs.test.ts
@@ -596,6 +596,38 @@ describe("convert js arguments to smart contract values using getScValsFromArgs"
     expect(expectedResult).toEqual(scValsResult);
   });
 
+  it("resolves a struct with a bytes field", () => {
+    const args = {
+      s: {
+        data: {
+          value: "deadbeef",
+          type: "bytes",
+        },
+        n: {
+          value: "7",
+          type: "u32",
+        },
+      },
+    };
+
+    const scVals: xdr.ScVal[] = [];
+    const scValsResult = getScValsFromArgs(args, scVals);
+    const expectedResult: xdr.ScVal[] = [
+      xdr.ScVal.scvMap([
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol("data"),
+          val: xdr.ScVal.scvBytes(Buffer.from("deadbeef", "hex")),
+        }),
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol("n"),
+          val: xdr.ScVal.scvU32(7),
+        }),
+      ]),
+    ];
+
+    expect(expectedResult).toEqual(scValsResult);
+  });
+
   // Complex Enum with Struct
   it("resolves a complex enum with a struct", () => {
     const args = {


### PR DESCRIPTION
Resolves #2192

## Problem

Invoking a contract function, or deploying a contract, with a struct argument that contains a `Bytes` field fails to build in the Lab with:

```
TypeError: invalid type ("bytes") specified for string value
```

`convertPrimitiveField` (the struct-encoding path in `src/helpers/sorobanUtils.ts`) special-cases only `bool`; a `bytes` field is passed through as a raw string with typeHint `bytes`, and `nativeToScVal(string, { type: "bytes" })` rejects it. Top-level `bytes` args, and `bytes` inside vecs/tuples, all work because those paths decode the string to a `Uint8Array` first (via `getScValFromPrimitive` and `detectBytesEncoding`); only the struct-field path was missed. This has been the case since `convertPrimitiveField` was introduced.

The operation is hard-blocked with no UI workaround: the value passes `DataUrl` validation, then `getTxnToSimulate` catches the error and surfaces it as an error string. Reachable from the Contract Explorer invoke form, the JSON-schema invoke path, and the deploy-contract constructor args.

## Fix

Add a `bytes` case in `convertPrimitiveField` that decodes with the existing `detectBytesEncoding` helper, mirroring exactly what `getScValFromPrimitive` and the vec/tuple paths already do. This also covers fixed-length `BytesN<N>` struct fields, since the form maps both `Bytes` and `BytesN` to `type: "bytes"`.

## Tests

Adds a `getScValsFromArgs` case: a struct with a `bytes` field (hex) encodes to the expected `scvMap` containing `scvBytes`. It fails on `main` (the `invalid type ("bytes")` throw) and passes with this change; the existing `getScValsFromArgs` suite and the full unit suite stay green.
